### PR TITLE
Fix Code Example in README (Worker Loop).

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ http --stream GET http://localhost:7890/jobs/take | while IFS= read -r job; do
   echo "$job" | jq
 
   echo "Acknowledging completion..."
-  http --quiet POST "http://localhost:7890/jobs/${id}/success" --raw ''
+  http --quiet POST "http://localhost:7890/jobs/${id}/success" </dev/null
 
   echo "Done."
 done


### PR DESCRIPTION
The `--raw ''` coupled with `--quiet` was hiding an error because `http` is still reading from stdin (which actually blocks). We need to just redirect `/dev/null` into stdin so nothing is actually sent in the body.