### PR TITLE
Implement GET /jobs/count?<filters>.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           name: zizq-binary-v${{ steps.version.outputs.version }}
           path: target/release/zizq-*-linux-x86_64.tar.gz
+          overwrite: true
 
   # --- Integration tests against client repos ---
 
@@ -142,7 +143,7 @@ jobs:
           name: zizq-binary-v${{ needs.release-binary.outputs.version }}
           path: server
       - name: Unpack server binary
-        run: tar -xzf server/zizq-*-linux-x86_64.tar.gz -C server
+        run: tar -xzf server/zizq-${{ needs.release-binary.outputs.version }}-linux-x86_64.tar.gz -C server
 
       - name: Checkout Node client @ ${{ matrix.ref }}
         uses: actions/checkout@v5
@@ -219,7 +220,7 @@ jobs:
           name: zizq-binary-v${{ needs.release-binary.outputs.version }}
           path: server
       - name: Unpack server binary
-        run: tar -xzf server/zizq-*-linux-x86_64.tar.gz -C server
+        run: tar -xzf server/zizq-${{ needs.release-binary.outputs.version }}-linux-x86_64.tar.gz -C server
 
       - name: Checkout Ruby client @ ${{ matrix.ref }}
         uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.1.2
+## 0.2.0
 
+- Added `GET /jobs/count` (with filter params)
 
 ## 0.1.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -33,10 +33,11 @@ use crate::state::AppState;
 
 use super::types::{
     BulkEnqueueRequest, BulkEnqueueResponse, BulkSuccessNotFoundResponse, BulkSuccessRequest,
-    CommaSet, DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse, FailureRequest,
-    HealthResponse, Job, JobStatus, ListErrorsPages, ListErrorsParams, ListErrorsResponse,
-    ListJobsPages, ListJobsParams, ListJobsResponse, ListQueuesResponse, Order, PatchJobBody,
-    PatchJobsParams, TakeParams, UnsupportedFormatResponse, VersionResponse, parse_unique_while,
+    CommaSet, CountJobsParams, CountJobsResponse, DeleteJobsParams, EnqueueRequest, ErrorRecord,
+    ErrorResponse, FailureRequest, HealthResponse, Job, JobStatus, ListErrorsPages,
+    ListErrorsParams, ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse,
+    ListQueuesResponse, Order, PatchJobBody, PatchJobsParams, TakeParams,
+    UnsupportedFormatResponse, VersionResponse, parse_unique_while,
 };
 
 /// Default priority for jobs that don't specify one.
@@ -389,6 +390,7 @@ pub fn app(state: Arc<AppState>) -> Router {
         )
         .route("/jobs/bulk", post(bulk_enqueue))
         .route("/jobs/success", post(bulk_mark_completed))
+        .route("/jobs/count", get(count_jobs))
         .route("/jobs/take", get(take_jobs))
         .route(
             "/jobs/{id}",
@@ -1531,6 +1533,83 @@ fn build_errors_page_url(job_id: &str, from: Option<u32>, order: Order, limit: u
     let order = serde_json::to_value(order).unwrap();
     url.push_str(&format!("order={}&limit={limit}", order.as_str().unwrap()));
     url
+}
+
+/// Handle `GET /jobs/count` — count jobs matching the given filters.
+async fn count_jobs(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    params: Result<Query<CountJobsParams>, axum::extract::rejection::QueryRejection>,
+) -> Response {
+    let Query(params) = match params {
+        Ok(q) => q,
+        Err(e) => {
+            return respond(
+                fmt,
+                StatusCode::BAD_REQUEST,
+                &ErrorResponse {
+                    error: format!("invalid query parameters: {e}"),
+                },
+            );
+        }
+    };
+
+    let now = (state.clock)();
+    let mut opts = ListJobsOptions::new().now(now);
+
+    if !params.status.is_empty() {
+        let statuses = params
+            .status
+            .iter()
+            .map(|s| store::JobStatus::from(*s))
+            .collect();
+        opts = opts.statuses(statuses);
+    }
+    if !params.queue.is_empty() {
+        opts = opts.queues(params.queue.0.clone());
+    }
+    if !params.job_type.is_empty() {
+        opts = opts.types(params.job_type.0.clone());
+    }
+    if !params.id.is_empty() {
+        for id in params.id.iter() {
+            if !is_valid_job_id(id) {
+                return respond(
+                    fmt,
+                    StatusCode::BAD_REQUEST,
+                    &ErrorResponse {
+                        error: format!("invalid job ID: {id:?}"),
+                    },
+                );
+            }
+        }
+        opts = opts.ids(params.id.0.clone());
+    }
+    if let Some(ref expr) = params.filter {
+        match PayloadFilter::compile(expr) {
+            Ok(f) => opts.filter = Some(std::sync::Arc::new(f)),
+            Err(e) => {
+                return respond(
+                    fmt,
+                    StatusCode::BAD_REQUEST,
+                    &ErrorResponse {
+                        error: format!("invalid filter: {e}"),
+                    },
+                );
+            }
+        }
+    }
+
+    match state.store.count_jobs(opts).await {
+        Ok(count) => respond(fmt, StatusCode::OK, &CountJobsResponse { count }),
+        Err(e) => respond(
+            fmt,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &ErrorResponse {
+                error: format!("{e}"),
+            },
+        ),
+    }
 }
 
 /// Handle `GET /jobs/{id}/errors` — list error records for a job.
@@ -6049,6 +6128,113 @@ mod tests {
 
         let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
         assert_eq!(body["deleted"], 0);
+    }
+
+    // --- GET /jobs/count ---
+
+    #[tokio::test]
+    async fn count_jobs_returns_zero_for_empty_store() {
+        let req = empty_request("GET", "/jobs/count");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_returns_total_count() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for i in 0..5 {
+            state
+                .store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(i)))
+                .await
+                .unwrap();
+        }
+
+        let req = empty_request("GET", "/jobs/count");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 5);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_filters_by_status() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        // Enqueue 3 ready jobs.
+        for i in 0..3 {
+            state
+                .store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(i)))
+                .await
+                .unwrap();
+        }
+
+        // Take one (moves to in_flight).
+        state
+            .store
+            .take_next_job(now, &std::collections::HashSet::new())
+            .await
+            .unwrap();
+
+        let req = empty_request("GET", "/jobs/count?status=ready");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 2);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_filters_by_queue() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        state
+            .store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "emails", serde_json::json!(1)),
+            )
+            .await
+            .unwrap();
+        state
+            .store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "emails", serde_json::json!(2)),
+            )
+            .await
+            .unwrap();
+        state
+            .store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "reports", serde_json::json!(3)),
+            )
+            .await
+            .unwrap();
+
+        let req = empty_request("GET", "/jobs/count?queue=emails");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 2);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_rejects_unknown_params() {
+        let req = empty_request("GET", "/jobs/count?bogus=true");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 
     // --- PATCH /jobs/{id} ---

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -304,6 +304,13 @@ pub struct VersionResponse {
     pub version: &'static str,
 }
 
+/// Response shape for the count jobs endpoint.
+#[derive(Serialize)]
+pub struct CountJobsResponse {
+    /// Number of matching jobs.
+    pub count: usize,
+}
+
 /// Response shape for the list queues endpoint.
 #[derive(Serialize)]
 pub struct ListQueuesResponse {
@@ -553,6 +560,30 @@ pub struct ListJobsParams {
     pub id: CommaSet<String>,
 
     /// jq expression to filter jobs by payload (e.g. ".user_id == 42").
+    pub filter: Option<String>,
+}
+
+/// Query parameters for `GET /jobs/count`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CountJobsParams {
+    /// ID filter, comma-delimited.
+    #[serde(default)]
+    pub id: CommaSet<String>,
+
+    /// Status filter, comma-delimited.
+    #[serde(default)]
+    pub status: CommaSet<JobStatus>,
+
+    /// Queue filter, comma-delimited.
+    #[serde(default)]
+    pub queue: CommaSet<String>,
+
+    /// Type filter, comma-delimited.
+    #[serde(default, rename = "type")]
+    pub job_type: CommaSet<String>,
+
+    /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
 }
 

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -2822,6 +2822,59 @@ impl Store {
         .await?
     }
 
+    /// Count jobs matching the given filters.
+    ///
+    /// Uses the same index scan and filter machinery as `list_jobs` but
+    /// only counts matching IDs instead of hydrating full job records.
+    /// Payload hydration is skipped unless a payload filter is specified.
+    pub async fn count_jobs(&self, opts: ListJobsOptions) -> Result<usize, StoreError> {
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || -> Result<usize, StoreError> {
+            let snapshot = ks.db.read_tx();
+
+            let id_stream_opt = build_id_stream(
+                &snapshot,
+                &ks,
+                &opts.ids,
+                &opts.statuses,
+                &opts.queues,
+                &opts.types,
+                &None,              // no cursor for count
+                ScanDirection::Asc, // direction doesn't matter for count
+            );
+
+            let needs_payload = opts.filter.is_some();
+
+            let mut job_stream = match id_stream_opt {
+                Some((ids, source, _has_id_filter)) => {
+                    JobStream::by_id(ids, &snapshot, &ks.data, opts.now, needs_payload, source)
+                }
+                None => JobStream::full_scan(
+                    &snapshot,
+                    &ks,
+                    &None,
+                    ScanDirection::Asc,
+                    opts.now,
+                    needs_payload,
+                ),
+            };
+
+            let count = if let Some(filter) = opts.filter.clone() {
+                PayloadFilteredIter {
+                    inner: job_stream,
+                    filter,
+                }
+                .try_fold(0, |acc, r| r.map(|_| acc + 1))?
+            } else {
+                job_stream.try_fold(0, |acc, r| r.map(|_| acc + 1))?
+            };
+
+            Ok(count)
+        })
+        .await?
+    }
+
     /// Return all distinct queue names present in the store.
     ///
     /// Uses a seek-skip algorithm on the on-disk queue index to enumerate
@@ -8624,6 +8677,229 @@ mod tests {
 
         let jobs = store.list_scheduled_jobs(0, 10).await.unwrap();
         assert_eq!(jobs.len(), 1);
+    }
+
+    // --- count_jobs tests ---
+
+    #[tokio::test]
+    async fn count_jobs_empty_store() {
+        let store = test_store();
+        let count = store.count_jobs(ListJobsOptions::new()).await.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_returns_total() {
+        let store = test_store();
+        let now = now_millis();
+        for i in 0..7 {
+            store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(i)))
+                .await
+                .unwrap();
+        }
+        let count = store
+            .count_jobs(ListJobsOptions::new().now(now))
+            .await
+            .unwrap();
+        assert_eq!(count, 7);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_filters_by_status() {
+        let store = test_store();
+        let now = now_millis();
+
+        // Enqueue 3 ready jobs.
+        for i in 0..3 {
+            store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(i)))
+                .await
+                .unwrap();
+        }
+
+        // Take one (moves to in_flight).
+        store
+            .take_next_job(now, &std::collections::HashSet::new())
+            .await
+            .unwrap();
+
+        let ready_count = store
+            .count_jobs(
+                ListJobsOptions::new()
+                    .now(now)
+                    .statuses([JobStatus::Ready].into()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ready_count, 2);
+
+        let in_flight_count = store
+            .count_jobs(
+                ListJobsOptions::new()
+                    .now(now)
+                    .statuses([JobStatus::InFlight].into()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(in_flight_count, 1);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_filters_by_queue() {
+        let store = test_store();
+        let now = now_millis();
+
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "emails", serde_json::json!(1)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "emails", serde_json::json!(2)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "reports", serde_json::json!(3)),
+            )
+            .await
+            .unwrap();
+
+        let count = store
+            .count_jobs(
+                ListJobsOptions::new()
+                    .now(now)
+                    .queues(["emails".to_string()].into()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_filters_by_type() {
+        let store = test_store();
+        let now = now_millis();
+
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("send_email", "q", serde_json::json!(1)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("send_email", "q", serde_json::json!(2)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("generate_report", "q", serde_json::json!(3)),
+            )
+            .await
+            .unwrap();
+
+        let count = store
+            .count_jobs(
+                ListJobsOptions::new()
+                    .now(now)
+                    .types(["send_email".to_string()].into()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_with_payload_filter() {
+        let store = test_store();
+        let now = now_millis();
+
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "q", serde_json::json!({"score": 10})),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "q", serde_json::json!({"score": 50})),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "q", serde_json::json!({"score": 90})),
+            )
+            .await
+            .unwrap();
+
+        let filter = crate::filter::PayloadFilter::compile(".score > 20").unwrap();
+        let count = store
+            .count_jobs(ListJobsOptions::new().now(now).filter(Arc::new(filter)))
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_combined_filters() {
+        let store = test_store();
+        let now = now_millis();
+
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("send_email", "emails", serde_json::json!(1)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("send_email", "emails", serde_json::json!(2)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("send_email", "reports", serde_json::json!(3)),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("generate_report", "emails", serde_json::json!(4)),
+            )
+            .await
+            .unwrap();
+
+        let count = store
+            .count_jobs(
+                ListJobsOptions::new()
+                    .now(now)
+                    .queues(["emails".to_string()].into())
+                    .types(["send_email".to_string()].into()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
     }
 
     // --- ready_count / scheduled_count tests ---


### PR DESCRIPTION
Clients can now more efficiently count the number of jobs matching some filter. Instead of iterating all pages of jobs matching the filter and counting manually, the single endpoint does it all inside a single read snapshot which is much more efficient and is still non-blocking.