### PR TITLE
Implement PUT /crons/{name}.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -21,7 +21,7 @@ use axum::http::{self, StatusCode};
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::response::sse::{Event, Sse};
-use axum::routing::{get, post};
+use axum::routing::{get, post, put};
 use serde::Serialize;
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::StreamExt;
@@ -33,11 +33,12 @@ use crate::state::AppState;
 
 use super::types::{
     BulkEnqueueRequest, BulkEnqueueResponse, BulkSuccessNotFoundResponse, BulkSuccessRequest,
-    CommaSet, CountJobsParams, CountJobsResponse, DeleteJobsParams, EnqueueRequest, ErrorRecord,
-    ErrorResponse, FailureRequest, HealthResponse, Job, JobStatus, ListErrorsPages,
-    ListErrorsParams, ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse,
-    ListQueuesResponse, Order, PatchJobBody, PatchJobsParams, TakeParams,
-    UnsupportedFormatResponse, VersionResponse, parse_unique_while,
+    CommaSet, CountJobsParams, CountJobsResponse, CronEntryResponse, CronGroupResponse,
+    DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse, FailureRequest, HealthResponse,
+    Job, JobStatus, ListErrorsPages, ListErrorsParams, ListErrorsResponse, ListJobsPages,
+    ListJobsParams, ListJobsResponse, ListQueuesResponse, Order, PatchJobBody, PatchJobsParams,
+    ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse, VersionResponse,
+    parse_unique_while,
 };
 
 /// Default priority for jobs that don't specify one.
@@ -400,6 +401,7 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/jobs/{id}/failure", post(report_failure))
         .route("/jobs/{id}/errors", get(list_errors))
         .route("/jobs/{id}/errors/{attempt}", get(get_error))
+        .route("/crons/{name}", put(replace_cron_group))
         .fallback(not_found)
         .layer(axum::middleware::from_fn(
             middleware::primary_request_logging,
@@ -2149,6 +2151,135 @@ async fn take_jobs(
 }
 
 /// Fallback handler for unmatched routes.
+// --- Cron scheduling ---
+
+async fn replace_cron_group(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    NegotiatedBody(req): NegotiatedBody<ReplaceCronGroupRequest>,
+) -> Response {
+    // License check.
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    // Validate group name.
+    if let Err(msg) = validate_name("cron group name", &name) {
+        return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+    }
+
+    // Convert request entries to store options.
+    let mut entry_opts = Vec::with_capacity(req.entries.len());
+    for entry in req.entries {
+        // Validate entry name.
+        if let Err(msg) = validate_name("cron entry name", &entry.name) {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+        }
+
+        // Validate job fields.
+        if let Err(msg) = validate_name("type", &entry.job.job_type) {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+        }
+        if let Err(msg) = validate_name("queue", &entry.job.queue) {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+        }
+
+        // ready_at is not supported for cron entries.
+        if entry.job.ready_at.is_some() {
+            return respond(
+                fmt,
+                StatusCode::BAD_REQUEST,
+                &ErrorResponse {
+                    error: "ready_at is not supported for cron entries".into(),
+                },
+            );
+        }
+
+        // Parse unique_while if present.
+        let unique_while = if let Some(ref s) = entry.job.unique_while {
+            match parse_unique_while(s) {
+                Ok(uw) => Some(uw),
+                Err(e) => {
+                    return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: e });
+                }
+            }
+        } else {
+            None
+        };
+
+        let priority = entry.job.priority.unwrap_or(DEFAULT_PRIORITY);
+
+        let mut opts =
+            store::EnqueueOptions::new(entry.job.job_type, entry.job.queue, entry.job.payload)
+                .priority(priority);
+
+        if let Some(retry_limit) = entry.job.retry_limit {
+            opts = opts.retry_limit(retry_limit);
+        }
+        if let Some(backoff) = entry.job.backoff {
+            opts = opts.backoff(backoff.into());
+        }
+        if let Some(retention) = entry.job.retention {
+            opts = opts.retention(retention.into());
+        }
+        if let Some(key) = entry.job.unique_key {
+            opts = opts.unique_key(key);
+        }
+        if let Some(uw) = unique_while {
+            opts = opts.unique_while(uw);
+        }
+
+        entry_opts.push(store::CronEntryOptions {
+            name: entry.name,
+            expression: entry.expression,
+            timezone: entry.timezone,
+            paused: entry.paused,
+            job: opts,
+        });
+    }
+
+    let opts = store::ReplaceCronGroupOptions {
+        paused: req.paused,
+        entries: entry_opts,
+    };
+
+    match state.store.replace_cron_group(&name, opts, now_ms).await {
+        Ok((group, entries)) => {
+            let response = CronGroupResponse {
+                name,
+                paused: group.paused,
+                paused_at: group.paused_at,
+                resumed_at: group.resumed_at,
+                entries: entries
+                    .into_iter()
+                    .map(CronEntryResponse::from_store)
+                    .collect(),
+            };
+            respond(fmt, StatusCode::OK, &response)
+        }
+        Err(StoreError::InvalidOperation(msg)) => {
+            respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg })
+        }
+        Err(e) => {
+            tracing::error!(%e, "replace_cron_group failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
 async fn not_found(AcceptFormat(fmt): AcceptFormat) -> Response {
     respond(
         fmt,
@@ -6578,5 +6709,204 @@ mod tests {
             body,
             serde_json::json!({"queues": ["payments/invoices", "payments/refunds", "webhooks"]})
         );
+    }
+
+    // --- Cron scheduling ---
+
+    fn cron_put(name: &str, body: &serde_json::Value) -> Request {
+        json_request("PUT", &format!("/crons/{name}"), body)
+    }
+
+    #[tokio::test]
+    async fn cron_put_returns_403_on_free_tier() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "test", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cron_put_creates_group_with_entries() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [
+                    {
+                        "name": "e1",
+                        "expression": "* * * * *",
+                        "job": { "type": "test", "queue": "q", "payload": { "x": 1 } }
+                    },
+                    {
+                        "name": "e2",
+                        "expression": "0 9 * * *",
+                        "job": { "type": "report", "queue": "reports", "payload": {} }
+                    }
+                ]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["name"], "default");
+        assert_eq!(body["paused"], false);
+        assert_eq!(body["entries"].as_array().unwrap().len(), 2);
+        assert_eq!(body["entries"][0]["name"], "e1");
+        assert_eq!(body["entries"][0]["expression"], "* * * * *");
+        assert!(body["entries"][0]["next_enqueue_at"].is_number());
+        assert_eq!(body["entries"][0]["job"]["type"], "test");
+        assert_eq!(body["entries"][0]["job"]["queue"], "q");
+        assert_eq!(body["entries"][1]["name"], "e2");
+    }
+
+    #[tokio::test]
+    async fn cron_put_removes_absent_entries() {
+        let app = pro_app();
+
+        // Create two entries.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [
+                    { "name": "e1", "expression": "* * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                    { "name": "e2", "expression": "* * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                ]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Replace with only e1.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [
+                    { "name": "e1", "expression": "* * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                ]
+            }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(body["entries"][0]["name"], "e1");
+    }
+
+    #[tokio::test]
+    async fn cron_put_rejects_invalid_expression() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "bad",
+                    "expression": "not a cron",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn cron_put_rejects_ready_at() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {}, "ready_at": 12345 }
+                }]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(body["error"].as_str().unwrap().contains("ready_at"));
+    }
+
+    #[tokio::test]
+    async fn cron_put_rejects_invalid_entry_name() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn cron_put_accepts_group_level_paused() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "paused": true,
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["paused"], true);
+        assert!(body["paused_at"].is_number());
+    }
+
+    #[tokio::test]
+    async fn cron_put_accepts_timezone() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "timezone": "Australia/Melbourne",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["entries"][0]["timezone"], "Australia/Melbourne");
+    }
+
+    #[tokio::test]
+    async fn cron_put_rejects_invalid_timezone() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "timezone": "Not/Real",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -339,7 +339,7 @@ pub struct UnsupportedFormatResponse {
 /// Jobs are required to specify the queue that they target and a payload to be
 /// provided when dequeued. Priority is optional, defaulting to the center of
 /// the priority range.
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct EnqueueRequest {
     /// The job type, e.g. "send_email" or "generate_report".
     #[serde(rename = "type")]
@@ -349,6 +349,7 @@ pub struct EnqueueRequest {
     pub queue: String,
 
     /// Optional job priority (lower is higher priority).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u16>,
 
     /// Arbitrary job payload provided to the client on dequeue.
@@ -356,26 +357,32 @@ pub struct EnqueueRequest {
 
     /// Optional timestamp (ms since epoch) when the job becomes eligible to
     /// run. If omitted or in the past, the job is immediately ready.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_at: Option<u64>,
 
     /// Per-job maximum retries before the job is killed on failure. When
     /// omitted, the server default applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_limit: Option<u32>,
 
     /// Per-job backoff configuration override. When omitted, the server
     /// default applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub backoff: Option<BackoffConfig>,
 
     /// Per-job retention configuration override. When omitted, the server
     /// default applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub retention: Option<RetentionConfig>,
 
     /// Unique key for deduplication. When present, the store checks for an
     /// existing job with the same key before inserting.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_key: Option<String>,
 
     /// Uniqueness scope: "queued" (default), "active", or "exists".
     /// Only valid when `unique_key` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_while: Option<String>,
 }
 
@@ -835,4 +842,132 @@ pub struct TakeParams {
 
 pub fn default_prefetch() -> usize {
     DEFAULT_PREFETCH
+}
+
+// --- Cron scheduling types ---
+
+/// Request shape for `PUT /crons/{name}`.
+#[derive(Deserialize)]
+pub struct ReplaceCronGroupRequest {
+    /// Whether the group should be paused. Omitted means preserve existing
+    /// state (or default to `false` for new groups).
+    pub paused: Option<bool>,
+
+    pub entries: Vec<CronEntryRequest>,
+}
+
+/// A single cron entry in a replace request.
+#[derive(Deserialize)]
+pub struct CronEntryRequest {
+    /// Entry name (unique within the group).
+    pub name: String,
+
+    /// Cron expression (e.g. `*/15 * * * *`).
+    pub expression: String,
+
+    /// IANA timezone name (e.g. `Australia/Melbourne`). When omitted,
+    /// the server's local timezone is used.
+    pub timezone: Option<String>,
+
+    /// Whether this entry should be paused. Omitted means preserve
+    /// existing state (or default to `false` for new entries).
+    pub paused: Option<bool>,
+
+    /// Job template — same fields as the enqueue request. `ready_at` is
+    /// accepted for compatibility but must not be set (validated in the
+    /// handler).
+    pub job: EnqueueRequest,
+}
+
+/// Response shape for `PUT /crons/{name}` and `GET /crons/{name}`.
+#[derive(Serialize)]
+pub struct CronGroupResponse {
+    /// Group name.
+    pub name: String,
+
+    /// Whether the group is paused.
+    pub paused: bool,
+
+    /// When the group was last paused (ms since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paused_at: Option<u64>,
+
+    /// When the group was last resumed (ms since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resumed_at: Option<u64>,
+
+    /// Entries in the group.
+    pub entries: Vec<CronEntryResponse>,
+}
+
+/// Response shape for a single cron entry.
+#[derive(Serialize)]
+pub struct CronEntryResponse {
+    /// Entry name.
+    pub name: String,
+
+    /// Cron expression.
+    pub expression: String,
+
+    /// IANA timezone name. `None` means system local timezone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+
+    /// Whether this entry is paused.
+    pub paused: bool,
+
+    /// When this entry was last paused (ms since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paused_at: Option<u64>,
+
+    /// When this entry was last resumed (ms since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resumed_at: Option<u64>,
+
+    /// Job template (same shape as an enqueue request).
+    pub job: EnqueueRequest,
+
+    /// Next scheduled enqueue time (ms since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_enqueue_at: Option<u64>,
+
+    /// Last time a job was enqueued from this entry (ms since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_enqueue_at: Option<u64>,
+}
+
+impl CronEntryResponse {
+    pub fn from_store(entry: store::CronEntry) -> Self {
+        let unique_while = entry.job.unique_while.map(|uw| {
+            match uw {
+                store::UniqueWhile::Queued => "queued",
+                store::UniqueWhile::Active => "active",
+                store::UniqueWhile::Exists => "exists",
+            }
+            .to_string()
+        });
+
+        CronEntryResponse {
+            name: entry.name,
+            expression: entry.expression,
+            timezone: entry.timezone,
+            paused: entry.paused,
+            paused_at: entry.paused_at,
+            resumed_at: entry.resumed_at,
+            job: EnqueueRequest {
+                job_type: entry.job.job_type,
+                queue: entry.job.queue,
+                payload: entry.job.payload,
+                priority: Some(entry.job.priority),
+                ready_at: entry.job.ready_at,
+                retry_limit: entry.job.retry_limit,
+                backoff: entry.job.backoff.map(Into::into),
+                retention: entry.job.retention.map(Into::into),
+                unique_key: entry.job.unique_key,
+                unique_while,
+            },
+            next_enqueue_at: entry.next_enqueue_at,
+            last_enqueue_at: entry.last_enqueue_at,
+        }
+    }
 }

--- a/src/commands/serve/cron_scheduler.rs
+++ b/src/commands/serve/cron_scheduler.rs
@@ -148,7 +148,10 @@ mod tests {
     use super::*;
     use crate::license::{License, Tier};
     use crate::state::{AppState, DEFAULT_GLOBAL_IN_FLIGHT_LIMIT, DEFAULT_HEARTBEAT_INTERVAL_MS};
-    use crate::store::{CronEntryOptions, EnqueueOptions, ListJobsOptions, Store, StoreEvent};
+    use crate::store::{
+        CronEntryOptions, EnqueueOptions, ListJobsOptions, ReplaceCronGroupOptions, Store,
+        StoreEvent,
+    };
     use std::sync::RwLock;
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -199,6 +202,7 @@ mod tests {
         CronEntryOptions {
             name: name.to_string(),
             expression: expression.to_string(),
+            timezone: None,
             paused: None,
             job: EnqueueOptions::new("test_job", "cron-q", serde_json::json!({})),
         }
@@ -246,7 +250,14 @@ mod tests {
         let t = clock.load(Ordering::Relaxed);
 
         store
-            .replace_cron_group("default", vec![cron_entry("e1", "* * * * *")], t)
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry("e1", "* * * * *")],
+                },
+                t,
+            )
             .await
             .unwrap();
 
@@ -291,7 +302,14 @@ mod tests {
         let t = clock.load(Ordering::Relaxed);
 
         store
-            .replace_cron_group("default", vec![cron_entry("e1", "* * * * *")], t)
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry("e1", "* * * * *")],
+                },
+                t,
+            )
             .await
             .unwrap();
 
@@ -327,7 +345,14 @@ mod tests {
 
         // Add a cron entry — this emits CronScheduleChanged.
         store
-            .replace_cron_group("default", vec![cron_entry("e1", "* * * * *")], t)
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry("e1", "* * * * *")],
+                },
+                t,
+            )
             .await
             .unwrap();
 
@@ -379,7 +404,14 @@ mod tests {
         let t = clock.load(Ordering::Relaxed);
 
         store
-            .replace_cron_group("default", vec![cron_entry("e1", "* * * * *")], t)
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry("e1", "* * * * *")],
+                },
+                t,
+            )
             .await
             .unwrap();
 

--- a/src/store/cron.rs
+++ b/src/store/cron.rs
@@ -44,6 +44,13 @@ pub struct CronEntry {
     #[serde(rename = "E")]
     pub expression: String,
 
+    /// IANA timezone name (e.g. `Australia/Melbourne`). When `None`, the
+    /// system's local timezone is used.
+    #[serde(rename = "Z")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+
     /// Whether this entry is paused.
     #[serde(rename = "z")]
     #[serde(default)]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -12,7 +12,8 @@ mod types;
 
 pub use options::{
     BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
-    ListErrorsOptions, ListJobsOptions, PatchJobOptions, RetentionConfigPatch,
+    ListErrorsOptions, ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
+    RetentionConfigPatch,
 };
 
 pub use results::{BulkCompleteResult, EnqueueResult, ListErrorsPage, ListJobsPage};

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -437,6 +437,16 @@ impl EnqueueOptions {
     }
 }
 
+/// Options for replacing an entire cron group via `Store::replace_cron_group`.
+pub struct ReplaceCronGroupOptions {
+    /// Whether the group should be paused. `None` means preserve existing
+    /// state (or default to `false` for new groups).
+    pub paused: Option<bool>,
+
+    /// The entries that should exist in the group after the replace.
+    pub entries: Vec<CronEntryOptions>,
+}
+
 /// A single entry in a `replace_cron_group` request.
 ///
 /// The caller provides the entry definition; the Store computes
@@ -447,6 +457,10 @@ pub struct CronEntryOptions {
 
     /// Cron expression (e.g. `*/15 * * * *`).
     pub expression: String,
+
+    /// IANA timezone name (e.g. `Australia/Melbourne`). `None` means use
+    /// the system's local timezone.
+    pub timezone: Option<String>,
 
     /// Whether this entry should be paused. `None` means preserve existing
     /// state (or default to `false` for new entries).

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -41,8 +41,8 @@ use super::scheduled_index::ScheduledIndex;
 use super::cron::{CronEntry, CronGroup};
 use super::group_committer::GroupCommitter;
 use super::options::{
-    BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
-    ListErrorsOptions, ListJobsOptions, PatchJobOptions,
+    BulkDeleteOptions, BulkPatchOptions, EnqueueOptions, FailureOptions, ListErrorsOptions,
+    ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
 };
 use super::results::{BulkCompleteResult, EnqueueResult, ListErrorsPage, ListJobsPage};
 use super::types::{
@@ -3949,13 +3949,15 @@ impl Store {
     pub async fn replace_cron_group(
         &self,
         group: &str,
-        entries: Vec<CronEntryOptions>,
+        opts: ReplaceCronGroupOptions,
         now: u64,
     ) -> Result<(CronGroup, Vec<CronEntry>), StoreError> {
         let ks = self.ks.clone();
         let cron_index = self.cron_index.clone();
         let event_tx = self.event_tx.clone();
         let group = group.to_string();
+        let group_paused = opts.paused;
+        let entries = opts.entries;
 
         task::spawn_blocking(move || -> Result<(CronGroup, Vec<CronEntry>), StoreError> {
             let group_key = make_cron_group_key(&group);
@@ -3965,7 +3967,7 @@ impl Store {
             let mut computed_next: Vec<Option<u64>> = Vec::with_capacity(entries.len());
             for input in &entries {
                 // Validates the expression; None means no future occurrences.
-                let next = cron_next_after(&input.expression, now)?;
+                let next = cron_next_after(&input.expression, now, input.timezone.as_deref())?;
                 computed_next.push(next);
             }
 
@@ -3973,13 +3975,35 @@ impl Store {
             // are consistent — no other writer can modify data.
             let mut tx = ks.write_tx();
 
-            // Load or create group metadata.
+            // Load or create group metadata, applying pause state if requested.
             let existing_group: CronGroup = match ks.data.get(&group_key)? {
-                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                Some(bytes) => {
+                    let mut g: CronGroup = rmp_serde::from_slice(&bytes)?;
+                    if let Some(paused) = group_paused {
+                        if paused != g.paused {
+                            match (g.paused, paused) {
+                                (false, true) => g.paused_at = Some(now),
+                                (true, false) => g.resumed_at = Some(now),
+                                _ => {}
+                            }
+                            g.paused = paused;
+                        }
+                        tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&g)?);
+                    }
+                    g
+                }
                 None => {
-                    let group = CronGroup::default();
-                    tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group)?);
-                    group
+                    let g = CronGroup {
+                        paused: group_paused.unwrap_or(false),
+                        paused_at: if group_paused == Some(true) {
+                            Some(now)
+                        } else {
+                            None
+                        },
+                        ..CronGroup::default()
+                    };
+                    tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&g)?);
+                    g
                 }
             };
 
@@ -4030,6 +4054,7 @@ impl Store {
                     CronEntry {
                         name: input.name,
                         expression: input.expression,
+                        timezone: input.timezone,
                         paused,
                         paused_at,
                         resumed_at,
@@ -4041,6 +4066,7 @@ impl Store {
                     CronEntry {
                         name: input.name,
                         expression: input.expression,
+                        timezone: input.timezone,
                         paused: input.paused.unwrap_or(false),
                         paused_at: None,
                         resumed_at: None,
@@ -4178,7 +4204,7 @@ impl Store {
                 let is_paused = group_paused || entry.paused;
 
                 // Compute next occurrence (None if no future occurrences).
-                let next = cron_next_after(&entry.expression, now)?;
+                let next = cron_next_after(&entry.expression, now, entry.timezone.as_deref())?;
 
                 // Prepare the job enqueue (unless paused).
                 let prepared = if !is_paused {
@@ -4341,8 +4367,20 @@ fn make_cron_group_prefix(group: &str) -> Vec<u8> {
 /// Compute the next occurrence of a cron expression after `now_ms`.
 ///
 /// Returns `None` if the expression has no future occurrences.
-fn cron_next_after(expression: &str, now_ms: u64) -> Result<Option<u64>, StoreError> {
+/// Compute the next occurrence of a cron expression after `now_ms`.
+///
+/// When `timezone` is `Some`, the expression is evaluated in that IANA
+/// timezone (e.g. "Australia/Melbourne"). When `None`, the system's
+/// local timezone is used.
+///
+/// Returns `None` if the expression has no future occurrences.
+fn cron_next_after(
+    expression: &str,
+    now_ms: u64,
+    timezone: Option<&str>,
+) -> Result<Option<u64>, StoreError> {
     let cron = croner::Cron::new(expression)
+        .with_seconds_optional()
         .parse()
         .map_err(|e| StoreError::InvalidOperation(format!("invalid cron expression: {e}")))?;
 
@@ -4350,9 +4388,21 @@ fn cron_next_after(expression: &str, now_ms: u64) -> Result<Option<u64>, StoreEr
     let dt = chrono::DateTime::from_timestamp(now_secs, 0)
         .ok_or_else(|| StoreError::InvalidOperation("invalid timestamp".to_string()))?;
 
-    match cron.find_next_occurrence(&dt, false) {
-        Ok(next) => Ok(Some(next.timestamp() as u64 * 1000)),
-        Err(_) => Ok(None),
+    if let Some(tz_name) = timezone {
+        let tz: chrono_tz::Tz = tz_name
+            .parse()
+            .map_err(|_| StoreError::InvalidOperation(format!("invalid timezone: {tz_name:?}")))?;
+        let dt_tz = dt.with_timezone(&tz);
+        match cron.find_next_occurrence(&dt_tz, false) {
+            Ok(next) => Ok(Some(next.timestamp() as u64 * 1000)),
+            Err(_) => Ok(None),
+        }
+    } else {
+        let local = dt.with_timezone(&chrono::Local);
+        match cron.find_next_occurrence(&local, false) {
+            Ok(next) => Ok(Some(next.timestamp() as u64 * 1000)),
+            Err(_) => Ok(None),
+        }
     }
 }
 
@@ -4632,7 +4682,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::SystemTime;
 
-    use crate::store::options::RetentionConfigPatch;
+    use crate::store::options::{CronEntryOptions, RetentionConfigPatch};
     use crate::store::types::RetentionConfig;
     use crate::time::now_millis;
 
@@ -11749,6 +11799,7 @@ mod tests {
         CronEntryOptions {
             name: name.to_string(),
             expression: expression.to_string(),
+            timezone: None,
             paused: None,
             job: EnqueueOptions::new(job_type, queue, serde_json::json!({})),
         }
@@ -11762,7 +11813,10 @@ mod tests {
         let (group, entries) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("every-minute", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("every-minute", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -11786,7 +11840,10 @@ mod tests {
         let (_, entries1) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "*/5 * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "*/5 * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -11798,7 +11855,10 @@ mod tests {
         let (_, entries2) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "*/5 * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "*/5 * * * *", "q", "test")],
+                },
                 now + 1000,
             )
             .await
@@ -11815,7 +11875,10 @@ mod tests {
         let (_, entries1) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -11827,7 +11890,10 @@ mod tests {
         let (_, entries2) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "0 0 * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "0 0 * * *", "q", "test")],
+                },
                 now + 1000,
             )
             .await
@@ -11844,10 +11910,13 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![
-                    cron_entry_opts("e1", "* * * * *", "q", "test"),
-                    cron_entry_opts("e2", "* * * * *", "q", "test"),
-                ],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![
+                        cron_entry_opts("e1", "* * * * *", "q", "test"),
+                        cron_entry_opts("e2", "* * * * *", "q", "test"),
+                    ],
+                },
                 now,
             )
             .await
@@ -11857,7 +11926,10 @@ mod tests {
         let (_, entries) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -11879,7 +11951,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -11887,7 +11962,14 @@ mod tests {
 
         // Replace with empty entries — group should be cleaned up.
         let (_, entries) = store
-            .replace_cron_group("default", vec![], now)
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![],
+                },
+                now,
+            )
             .await
             .unwrap();
 
@@ -11906,7 +11988,10 @@ mod tests {
         let result = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("bad", "not a cron expr", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("bad", "not a cron expr", "q", "test")],
+                },
                 now,
             )
             .await;
@@ -11923,10 +12008,13 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![CronEntryOptions {
-                    paused: Some(true),
-                    ..cron_entry_opts("e1", "* * * * *", "q", "test")
-                }],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![CronEntryOptions {
+                        paused: Some(true),
+                        ..cron_entry_opts("e1", "* * * * *", "q", "test")
+                    }],
+                },
                 now,
             )
             .await
@@ -11936,7 +12024,10 @@ mod tests {
         let (_, entries) = store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now + 1000,
             )
             .await
@@ -11953,7 +12044,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -11963,10 +12057,13 @@ mod tests {
         let (_, entries) = store
             .replace_cron_group(
                 "default",
-                vec![CronEntryOptions {
-                    paused: Some(true),
-                    ..cron_entry_opts("e1", "* * * * *", "q", "test")
-                }],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![CronEntryOptions {
+                        paused: Some(true),
+                        ..cron_entry_opts("e1", "* * * * *", "q", "test")
+                    }],
+                },
                 now + 1000,
             )
             .await
@@ -11984,7 +12081,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -12011,7 +12111,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -12052,7 +12155,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -12082,10 +12188,13 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![CronEntryOptions {
-                    paused: Some(true),
-                    ..cron_entry_opts("e1", "* * * * *", "q", "test")
-                }],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![CronEntryOptions {
+                        paused: Some(true),
+                        ..cron_entry_opts("e1", "* * * * *", "q", "test")
+                    }],
+                },
                 now,
             )
             .await
@@ -12135,10 +12244,13 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![
-                    cron_entry_opts("e1", "* * * * *", "q", "test"),
-                    cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
-                ],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![
+                        cron_entry_opts("e1", "* * * * *", "q", "test"),
+                        cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
+                    ],
+                },
                 now,
             )
             .await
@@ -12165,7 +12277,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -12184,7 +12299,10 @@ mod tests {
         store
             .replace_cron_group(
                 "default",
-                vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
                 now,
             )
             .await
@@ -12206,5 +12324,104 @@ mod tests {
         assert_eq!(due.len(), 1);
         assert_eq!(due[0].1, "default");
         assert_eq!(due[0].2, "e1");
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_respects_timezone() {
+        let store = test_store();
+        let now = CRON_NOW; // 2023-11-14 22:13:20 UTC
+
+        // Create two entries with the same expression but different timezones.
+        // "0 9 * * *" = 9:00 AM daily.
+        // In UTC, next 9:00 AM is 2023-11-15 09:00 UTC.
+        // In Australia/Melbourne (UTC+11 in Nov), next 9:00 AM local is
+        // 2023-11-14 22:00 UTC (already passed) → 2023-11-15 22:00 UTC.
+        let utc_entry = CronEntryOptions {
+            timezone: Some("UTC".to_string()),
+            ..cron_entry_opts("utc-9am", "0 9 * * *", "q", "test")
+        };
+        let melb_entry = CronEntryOptions {
+            timezone: Some("Australia/Melbourne".to_string()),
+            ..cron_entry_opts("melb-9am", "0 9 * * *", "q", "test")
+        };
+
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![utc_entry, melb_entry],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        let utc_next = entries
+            .iter()
+            .find(|e| e.name == "utc-9am")
+            .unwrap()
+            .next_enqueue_at
+            .unwrap();
+        let melb_next = entries
+            .iter()
+            .find(|e| e.name == "melb-9am")
+            .unwrap()
+            .next_enqueue_at
+            .unwrap();
+
+        // They should be different — Melbourne 9 AM is a different UTC time than UTC 9 AM.
+        assert_ne!(utc_next, melb_next);
+
+        // UTC 9 AM should be earlier (it's ~11 hours before Melbourne 9 AM in UTC).
+        assert!(utc_next < melb_next);
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_invalid_timezone_returns_error() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        let entry = CronEntryOptions {
+            timezone: Some("Not/A/Timezone".to_string()),
+            ..cron_entry_opts("bad-tz", "* * * * *", "q", "test")
+        };
+
+        let result = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![entry],
+                },
+                now,
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_accepts_6_field_expression() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        // 6-field: second minute hour dom month dow
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("every-30s", "*/30 * * * * *", "q", "test")],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        // With seconds, next occurrence should be within 30 seconds.
+        let next = entries[0].next_enqueue_at.unwrap();
+        assert!(next > now);
+        assert!(next <= now + 30_000);
     }
 }


### PR DESCRIPTION
Wires up `Store::replace_cron_group()` with the API and closes a couple of gaps:

1. Missing time zone support (this adds ~2MB to the binary!)
2. Support for 6-field cron syntax (i.e. seconds)

API calls looks like:

```
PUT /crons/{name}
{
  "entries": [
    "name": "example_cron",
    "expression": "*/10 22 * * *",
    "timezone": "Australia/Melbourne",
    "job": { ... }
  ]
}
```

This is a full replacement of the schedule. Any existing entries not present are removed.

All the usual Job inputs *except* `ready_at` are accepted. There is no server-generated ID for the cron, or for the job. It is purely a template. Jobs get IDs once the scheduler enqueues them.

It is also possible to pause a whole group, or an entry, by passing `"paused": true` at the group-level or at the entry-level.