### PR TITLE
Implement a few more `/crons/*` group-levels endpoints.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -35,10 +35,10 @@ use super::types::{
     BulkEnqueueRequest, BulkEnqueueResponse, BulkSuccessNotFoundResponse, BulkSuccessRequest,
     CommaSet, CountJobsParams, CountJobsResponse, CronGroupResponse, DeleteJobsParams,
     EnqueueRequest, ErrorRecord, ErrorResponse, FailureRequest, HealthResponse, Job, JobStatus,
-    ListErrorsPages, ListErrorsParams, ListErrorsResponse, ListJobsPages, ListJobsParams,
-    ListJobsResponse, ListQueuesResponse, Order, PatchJobBody, PatchJobsParams,
-    ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse, VersionResponse,
-    parse_unique_while,
+    ListCronGroupsResponse, ListErrorsPages, ListErrorsParams, ListErrorsResponse, ListJobsPages,
+    ListJobsParams, ListJobsResponse, ListQueuesResponse, Order, PatchCronGroupRequest,
+    PatchJobBody, PatchJobsParams, ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse,
+    VersionResponse, parse_unique_while,
 };
 
 /// Default priority for jobs that don't specify one.
@@ -401,7 +401,14 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/jobs/{id}/failure", post(report_failure))
         .route("/jobs/{id}/errors", get(list_errors))
         .route("/jobs/{id}/errors/{attempt}", get(get_error))
-        .route("/crons/{name}", get(get_cron_group).put(replace_cron_group))
+        .route("/crons", get(list_cron_groups))
+        .route(
+            "/crons/{name}",
+            get(get_cron_group)
+                .put(replace_cron_group)
+                .patch(patch_cron_group)
+                .delete(delete_cron_group),
+        )
         .fallback(not_found)
         .layer(axum::middleware::from_fn(
             middleware::primary_request_logging,
@@ -2152,6 +2159,36 @@ async fn take_jobs(
 
 // --- Cron scheduling ---
 
+/// Handle `GET /crons` — list all cron group names.
+async fn list_cron_groups(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state.store.list_cron_groups().await {
+        Ok(crons) => respond(fmt, StatusCode::OK, &ListCronGroupsResponse { crons }),
+        Err(e) => {
+            tracing::error!(%e, "list_cron_groups failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
 /// Handle `GET /crons/{name}` — fetch a cron group and its entries.
 async fn get_cron_group(
     AcceptFormat(fmt): AcceptFormat,
@@ -2215,6 +2252,22 @@ async fn replace_cron_group(
     // Validate group name.
     if let Err(msg) = validate_name("cron group name", &name) {
         return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+    }
+
+    // Check for duplicate entry names.
+    {
+        let mut seen = HashSet::with_capacity(req.entries.len());
+        for entry in &req.entries {
+            if !seen.insert(&entry.name) {
+                return respond(
+                    fmt,
+                    StatusCode::BAD_REQUEST,
+                    &ErrorResponse {
+                        error: format!("duplicate cron entry name: {:?}", entry.name),
+                    },
+                );
+            }
+        }
     }
 
     // Convert request entries to store options.
@@ -2303,6 +2356,113 @@ async fn replace_cron_group(
         }
         Err(e) => {
             tracing::error!(%e, "replace_cron_group failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `PATCH /crons/{name}` — update group-level fields (pause/unpause).
+async fn patch_cron_group(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    NegotiatedBody(req): NegotiatedBody<PatchCronGroupRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state
+        .store
+        .patch_cron_group(&name, req.paused, now_ms)
+        .await
+    {
+        Ok(Some(group)) => {
+            // Re-fetch the full group with entries for the response.
+            match state.store.get_cron_group(&name).await {
+                Ok(Some((_, entries))) => respond(
+                    fmt,
+                    StatusCode::OK,
+                    &CronGroupResponse::from_store(name, group, entries),
+                ),
+                Ok(None) => respond(
+                    fmt,
+                    StatusCode::NOT_FOUND,
+                    &ErrorResponse {
+                        error: format!("cron group '{name}' not found"),
+                    },
+                ),
+                Err(e) => {
+                    tracing::error!(%e, "patch_cron_group: failed to re-fetch group");
+                    respond(
+                        fmt,
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &ErrorResponse {
+                            error: "internal error".into(),
+                        },
+                    )
+                }
+            }
+        }
+        Ok(None) => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("cron group '{name}' not found"),
+            },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "patch_cron_group failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `DELETE /crons/{name}` — delete a cron group and all its entries.
+async fn delete_cron_group(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state.store.delete_cron_group(&name).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("cron group '{name}' not found"),
+            },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "delete_cron_group failed");
             respond(
                 fmt,
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -6888,6 +7048,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cron_put_rejects_duplicate_entry_names() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [
+                    { "name": "e1", "expression": "* * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                    { "name": "e1", "expression": "*/5 * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                ]
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(body["error"].as_str().unwrap().contains("duplicate"));
+    }
+
+    #[tokio::test]
     async fn cron_put_accepts_group_level_paused() {
         let req = cron_put(
             "default",
@@ -6984,6 +7162,174 @@ mod tests {
     #[tokio::test]
     async fn cron_get_returns_403_on_free_tier() {
         let req = empty_request("GET", "/crons/default");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cron_delete_removes_group() {
+        let app = pro_app();
+
+        // Create a group.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Delete it.
+        let req = empty_request("DELETE", "/crons/default");
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        // Verify it's gone.
+        let req = empty_request("GET", "/crons/default");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cron_delete_returns_404_for_missing_group() {
+        let req = empty_request("DELETE", "/crons/nonexistent");
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cron_delete_returns_403_on_free_tier() {
+        let req = empty_request("DELETE", "/crons/default");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    fn cron_patch(name: &str, body: &serde_json::Value) -> Request {
+        json_request("PATCH", &format!("/crons/{name}"), body)
+    }
+
+    #[tokio::test]
+    async fn cron_patch_pauses_group() {
+        let app = pro_app();
+
+        // Create a group.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Pause it.
+        let req = cron_patch("default", &serde_json::json!({ "paused": true }));
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["paused"], true);
+        assert!(body["paused_at"].is_number());
+        // Entries should still be returned.
+        assert_eq!(body["entries"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cron_patch_unpauses_group() {
+        let app = pro_app();
+
+        // Create a paused group.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "paused": true,
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Unpause it.
+        let req = cron_patch("default", &serde_json::json!({ "paused": false }));
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["paused"], false);
+        assert!(body["resumed_at"].is_number());
+    }
+
+    #[tokio::test]
+    async fn cron_patch_returns_404_for_missing_group() {
+        let req = cron_patch("nonexistent", &serde_json::json!({ "paused": true }));
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cron_patch_returns_403_on_free_tier() {
+        let req = cron_patch("default", &serde_json::json!({ "paused": true }));
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cron_list_returns_group_names() {
+        let app = pro_app();
+
+        // Create two groups.
+        for name in &["alpha", "beta"] {
+            let req = cron_put(
+                name,
+                &serde_json::json!({
+                    "entries": [{
+                        "name": "e1",
+                        "expression": "* * * * *",
+                        "job": { "type": "t", "queue": "q", "payload": {} }
+                    }]
+                }),
+            );
+            let res = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+        }
+
+        let req = empty_request("GET", "/crons");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let crons = body["crons"].as_array().unwrap();
+        assert_eq!(crons.len(), 2);
+        assert!(crons.contains(&serde_json::json!("alpha")));
+        assert!(crons.contains(&serde_json::json!("beta")));
+    }
+
+    #[tokio::test]
+    async fn cron_list_returns_empty_when_no_groups() {
+        let req = empty_request("GET", "/crons");
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["crons"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn cron_list_returns_403_on_free_tier() {
+        let req = empty_request("GET", "/crons");
         let res = test_app().oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -846,6 +846,19 @@ pub fn default_prefetch() -> usize {
 
 // --- Cron scheduling types ---
 
+/// Response shape for `GET /crons`.
+#[derive(Serialize)]
+pub struct ListCronGroupsResponse {
+    pub crons: Vec<String>,
+}
+
+/// Request shape for `PATCH /crons/{name}`.
+#[derive(Deserialize)]
+pub struct PatchCronGroupRequest {
+    /// Whether the group should be paused.
+    pub paused: bool,
+}
+
 /// Request shape for `PUT /crons/{name}`.
 #[derive(Deserialize)]
 pub struct ReplaceCronGroupRequest {

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -4123,6 +4123,58 @@ impl Store {
         .await?
     }
 
+    /// List all cron group names.
+    ///
+    /// Uses a prefix-stepping range scan over `C` tag keys, extracting
+    /// distinct group names. Same O(n) approach as `list_queues`.
+    pub async fn list_cron_groups(&self) -> Result<Vec<String>, StoreError> {
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let snapshot = ks.db.read_tx();
+
+            let end: Vec<u8> = vec![RecordKind::Cron as u8 + 1];
+            let mut start: Vec<u8> = vec![RecordKind::Cron as u8];
+            let mut groups = Vec::new();
+
+            loop {
+                let mut range = snapshot.range::<Vec<u8>, _>(
+                    ks.data.as_ref(),
+                    (Bound::Included(start.clone()), Bound::Excluded(end.clone())),
+                );
+
+                let entry = match range.next() {
+                    Some(entry) => entry,
+                    None => break,
+                };
+
+                let (key, _) = entry.into_inner()?;
+
+                // Key layout: C{group_name}\0... — extract group_name.
+                let name_start = 1; // skip C tag
+                let name_end = key[name_start..]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .map(|p| name_start + p)
+                    .unwrap_or(key.len());
+                let group_name = std::str::from_utf8(&key[name_start..name_end])
+                    .map_err(|e| {
+                        StoreError::Corruption(format!("cron group name is not valid UTF-8: {e}"))
+                    })?
+                    .to_string();
+                groups.push(group_name.clone());
+
+                // Advance past all keys for this group: C{group_name}\x01
+                start.truncate(1); // keep C tag
+                start.extend_from_slice(group_name.as_bytes());
+                start.push(1); // one byte past \0 separator
+            }
+
+            Ok(groups)
+        })
+        .await?
+    }
+
     /// Load a cron group and all its entries.
     ///
     /// Returns `None` if the group does not exist.
@@ -4164,6 +4216,107 @@ impl Store {
                 Ok(Some((group_meta, entries)))
             },
         )
+        .await?
+    }
+
+    /// Update group-level metadata (currently just pause state).
+    ///
+    /// Returns the updated group, or `None` if the group does not exist.
+    pub async fn patch_cron_group(
+        &self,
+        group: &str,
+        paused: bool,
+        now: u64,
+    ) -> Result<Option<CronGroup>, StoreError> {
+        let ks = self.ks.clone();
+        let event_tx = self.event_tx.clone();
+        let group = group.to_string();
+
+        task::spawn_blocking(move || -> Result<Option<CronGroup>, StoreError> {
+            let group_key = make_cron_group_key(&group);
+
+            let mut tx = ks.write_tx();
+
+            let mut group_meta: CronGroup = match ks.data.get(&group_key)? {
+                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                None => return Ok(None),
+            };
+
+            if paused != group_meta.paused {
+                match (group_meta.paused, paused) {
+                    (false, true) => group_meta.paused_at = Some(now),
+                    (true, false) => group_meta.resumed_at = Some(now),
+                    _ => {}
+                }
+                group_meta.paused = paused;
+                tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
+                ks.commit(tx, ks.default_commit_mode)?;
+                let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+            }
+
+            Ok(Some(group_meta))
+        })
+        .await?
+    }
+
+    /// Delete a cron group and all its entries.
+    ///
+    /// Returns `true` if the group existed and was deleted, `false` if it
+    /// did not exist.
+    pub async fn delete_cron_group(&self, group: &str) -> Result<bool, StoreError> {
+        let ks = self.ks.clone();
+        let cron_index = self.cron_index.clone();
+        let event_tx = self.event_tx.clone();
+        let group = group.to_string();
+
+        task::spawn_blocking(move || -> Result<bool, StoreError> {
+            let group_key = make_cron_group_key(&group);
+            let prefix = make_cron_group_prefix(&group);
+
+            let mut tx = ks.write_tx();
+
+            // Check if the group exists.
+            if ks.data.get(&group_key)?.is_none() {
+                return Ok(false);
+            }
+
+            // Collect all entry keys and their next_enqueue_at for index cleanup.
+            let mut range_end = prefix.clone();
+            *range_end.last_mut().unwrap() = 1;
+
+            let data: &fjall::Keyspace = ks.data.as_ref();
+            let mut entries_to_remove: Vec<(String, Option<u64>)> = Vec::new();
+
+            for guard in data
+                .range::<Vec<u8>, _>((Bound::Included(prefix.clone()), Bound::Excluded(range_end)))
+            {
+                let (key, value) = guard.into_inner()?;
+                // Remove everything — group metadata and all entries.
+                tx.remove(&ks.data, key.as_ref());
+
+                // Track entry next_enqueue_at for index cleanup (skip group key).
+                if key.len() > prefix.len() {
+                    let entry: CronEntry = rmp_serde::from_slice(&value)?;
+                    entries_to_remove.push((entry.name, entry.next_enqueue_at));
+                }
+            }
+
+            // Remove the group metadata key itself.
+            tx.remove(&ks.data, &group_key);
+
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            // ---- outside tx: update in-memory cron index ----
+            for (entry_name, next) in &entries_to_remove {
+                if let Some(next) = next {
+                    cron_index.remove(*next, &group, entry_name);
+                }
+            }
+
+            let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+
+            Ok(true)
+        })
         .await?
     }
 
@@ -12467,5 +12620,224 @@ mod tests {
         let next = entries[0].next_enqueue_at.unwrap();
         assert!(next > now);
         assert!(next <= now + 30_000);
+    }
+
+    #[tokio::test]
+    async fn list_cron_groups_returns_names() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        assert!(store.list_cron_groups().await.unwrap().is_empty());
+
+        for name in &["alpha", "beta", "gamma"] {
+            store
+                .replace_cron_group(
+                    name,
+                    ReplaceCronGroupOptions {
+                        paused: None,
+                        entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                    },
+                    now,
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut groups = store.list_cron_groups().await.unwrap();
+        groups.sort();
+        assert_eq!(groups, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[tokio::test]
+    async fn list_cron_groups_handles_common_prefixes() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        // Groups with shared prefixes that could confuse prefix scanning.
+        for name in &["billing", "billing-events", "billing-payments"] {
+            store
+                .replace_cron_group(
+                    name,
+                    ReplaceCronGroupOptions {
+                        paused: None,
+                        entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                    },
+                    now,
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut groups = store.list_cron_groups().await.unwrap();
+        groups.sort();
+        assert_eq!(
+            groups,
+            vec!["billing", "billing-events", "billing-payments"]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_cron_group_removes_group_and_entries() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![
+                        cron_entry_opts("e1", "* * * * *", "q", "test"),
+                        cron_entry_opts("e2", "* * * * *", "q", "test"),
+                    ],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert!(store.delete_cron_group("default").await.unwrap());
+
+        // Group should be gone.
+        assert!(store.get_cron_group("default").await.unwrap().is_none());
+
+        // Entries should be gone.
+        assert!(
+            store
+                .get_cron_entry("default", "e1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .get_cron_entry("default", "e2")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Should not appear in listing.
+        assert!(store.list_cron_groups().await.unwrap().is_empty());
+
+        // Index should be empty.
+        assert!(store.cron_next_due_at().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_cron_group_returns_false_for_missing() {
+        let store = test_store();
+        assert!(!store.delete_cron_group("nonexistent").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_cron_group_does_not_affect_other_groups() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        for name in &["keep", "delete"] {
+            store
+                .replace_cron_group(
+                    name,
+                    ReplaceCronGroupOptions {
+                        paused: None,
+                        entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                    },
+                    now,
+                )
+                .await
+                .unwrap();
+        }
+
+        store.delete_cron_group("delete").await.unwrap();
+
+        let groups = store.list_cron_groups().await.unwrap();
+        assert_eq!(groups, vec!["keep"]);
+
+        // The kept group should still have its entry.
+        assert!(store.get_cron_entry("keep", "e1").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn get_cron_group_returns_group_and_entries() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![
+                        cron_entry_opts("e1", "* * * * *", "q", "test"),
+                        cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
+                    ],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        let (group, entries) = store.get_cron_group("default").await.unwrap().unwrap();
+        assert!(!group.paused);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "e1");
+        assert_eq!(entries[1].name, "e2");
+    }
+
+    #[tokio::test]
+    async fn get_cron_group_returns_none_for_missing() {
+        let store = test_store();
+        assert!(store.get_cron_group("missing").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn patch_cron_group_pauses_and_unpauses() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        // Pause.
+        let group = store
+            .patch_cron_group("default", true, now + 1000)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(group.paused);
+        assert_eq!(group.paused_at, Some(now + 1000));
+        assert!(group.resumed_at.is_none());
+
+        // Unpause.
+        let group = store
+            .patch_cron_group("default", false, now + 2000)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!group.paused);
+        assert_eq!(group.paused_at, Some(now + 1000));
+        assert_eq!(group.resumed_at, Some(now + 2000));
+    }
+
+    #[tokio::test]
+    async fn patch_cron_group_returns_none_for_missing() {
+        let store = test_store();
+        assert!(
+            store
+                .patch_cron_group("missing", true, CRON_NOW)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
Implements:

* `DELETE /crons/{name}` - 204 No Content
* `PATCH /crons/{name}` - 200 OK - Only used for pause/unpause right now
* `GET /crons` - 200 OK - Names of all cron groups

We still have all the entry-level endpoints to implement.