### PR TITLE
Implement Cron entry-specific APIs.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -33,12 +33,13 @@ use crate::state::AppState;
 
 use super::types::{
     BulkEnqueueRequest, BulkEnqueueResponse, BulkSuccessNotFoundResponse, BulkSuccessRequest,
-    CommaSet, CountJobsParams, CountJobsResponse, CronGroupResponse, DeleteJobsParams,
-    EnqueueRequest, ErrorRecord, ErrorResponse, FailureRequest, HealthResponse, Job, JobStatus,
-    ListCronGroupsResponse, ListErrorsPages, ListErrorsParams, ListErrorsResponse, ListJobsPages,
-    ListJobsParams, ListJobsResponse, ListQueuesResponse, Order, PatchCronGroupRequest,
-    PatchJobBody, PatchJobsParams, ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse,
-    VersionResponse, parse_unique_while,
+    CommaSet, CountJobsParams, CountJobsResponse, CronEntryRequest, CronEntryResponse,
+    CronGroupResponse, DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse,
+    FailureRequest, HealthResponse, Job, JobStatus, ListCronGroupsResponse, ListErrorsPages,
+    ListErrorsParams, ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse,
+    ListQueuesResponse, Order, PatchCronGroupRequest, PatchJobBody, PatchJobsParams,
+    ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse, VersionResponse,
+    parse_unique_while,
 };
 
 /// Default priority for jobs that don't specify one.
@@ -408,6 +409,14 @@ pub fn app(state: Arc<AppState>) -> Router {
                 .put(replace_cron_group)
                 .patch(patch_cron_group)
                 .delete(delete_cron_group),
+        )
+        .route("/crons/{name}/entries", post(add_cron_entry))
+        .route(
+            "/crons/{name}/entries/{entry}",
+            get(get_cron_entry)
+                .put(put_cron_entry)
+                .patch(patch_cron_entry)
+                .delete(delete_cron_entry),
         )
         .fallback(not_found)
         .layer(axum::middleware::from_fn(
@@ -2159,6 +2168,53 @@ async fn take_jobs(
 
 // --- Cron scheduling ---
 
+/// Validate a cron entry request and convert it to store options.
+fn validate_cron_entry(entry: CronEntryRequest) -> Result<store::CronEntryOptions, String> {
+    validate_name("cron entry name", &entry.name)?;
+    validate_name("type", &entry.job.job_type)?;
+    validate_name("queue", &entry.job.queue)?;
+
+    if entry.job.ready_at.is_some() {
+        return Err("ready_at is not supported for cron entries".into());
+    }
+
+    let unique_while = if let Some(ref s) = entry.job.unique_while {
+        Some(parse_unique_while(s)?)
+    } else {
+        None
+    };
+
+    let priority = entry.job.priority.unwrap_or(DEFAULT_PRIORITY);
+
+    let mut opts =
+        store::EnqueueOptions::new(entry.job.job_type, entry.job.queue, entry.job.payload)
+            .priority(priority);
+
+    if let Some(retry_limit) = entry.job.retry_limit {
+        opts = opts.retry_limit(retry_limit);
+    }
+    if let Some(backoff) = entry.job.backoff {
+        opts = opts.backoff(backoff.into());
+    }
+    if let Some(retention) = entry.job.retention {
+        opts = opts.retention(retention.into());
+    }
+    if let Some(key) = entry.job.unique_key {
+        opts = opts.unique_key(key);
+    }
+    if let Some(uw) = unique_while {
+        opts = opts.unique_while(uw);
+    }
+
+    Ok(store::CronEntryOptions {
+        name: entry.name,
+        expression: entry.expression,
+        timezone: entry.timezone,
+        paused: entry.paused,
+        job: opts,
+    })
+}
+
 /// Handle `GET /crons` — list all cron group names.
 async fn list_cron_groups(
     AcceptFormat(fmt): AcceptFormat,
@@ -2270,74 +2326,13 @@ async fn replace_cron_group(
         }
     }
 
-    // Convert request entries to store options.
+    // Validate and convert entries.
     let mut entry_opts = Vec::with_capacity(req.entries.len());
     for entry in req.entries {
-        // Validate entry name.
-        if let Err(msg) = validate_name("cron entry name", &entry.name) {
-            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+        match validate_cron_entry(entry) {
+            Ok(opts) => entry_opts.push(opts),
+            Err(e) => return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: e }),
         }
-
-        // Validate job fields.
-        if let Err(msg) = validate_name("type", &entry.job.job_type) {
-            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
-        }
-        if let Err(msg) = validate_name("queue", &entry.job.queue) {
-            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
-        }
-
-        // ready_at is not supported for cron entries.
-        if entry.job.ready_at.is_some() {
-            return respond(
-                fmt,
-                StatusCode::BAD_REQUEST,
-                &ErrorResponse {
-                    error: "ready_at is not supported for cron entries".into(),
-                },
-            );
-        }
-
-        // Parse unique_while if present.
-        let unique_while = if let Some(ref s) = entry.job.unique_while {
-            match parse_unique_while(s) {
-                Ok(uw) => Some(uw),
-                Err(e) => {
-                    return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: e });
-                }
-            }
-        } else {
-            None
-        };
-
-        let priority = entry.job.priority.unwrap_or(DEFAULT_PRIORITY);
-
-        let mut opts =
-            store::EnqueueOptions::new(entry.job.job_type, entry.job.queue, entry.job.payload)
-                .priority(priority);
-
-        if let Some(retry_limit) = entry.job.retry_limit {
-            opts = opts.retry_limit(retry_limit);
-        }
-        if let Some(backoff) = entry.job.backoff {
-            opts = opts.backoff(backoff.into());
-        }
-        if let Some(retention) = entry.job.retention {
-            opts = opts.retention(retention.into());
-        }
-        if let Some(key) = entry.job.unique_key {
-            opts = opts.unique_key(key);
-        }
-        if let Some(uw) = unique_while {
-            opts = opts.unique_while(uw);
-        }
-
-        entry_opts.push(store::CronEntryOptions {
-            name: entry.name,
-            expression: entry.expression,
-            timezone: entry.timezone,
-            paused: entry.paused,
-            job: opts,
-        });
     }
 
     let opts = store::ReplaceCronGroupOptions {
@@ -2356,6 +2351,171 @@ async fn replace_cron_group(
         }
         Err(e) => {
             tracing::error!(%e, "replace_cron_group failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `PUT /crons/{name}/entries/{entry}` — create or replace a single cron entry.
+async fn put_cron_entry(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((name, entry_name)): Path<(String, String)>,
+    NegotiatedBody(req): NegotiatedBody<CronEntryRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    if let Err(msg) = validate_name("cron group name", &name) {
+        return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+    }
+
+    // The entry name in the URL takes precedence.
+    let mut opts = match validate_cron_entry(req) {
+        Ok(opts) => opts,
+        Err(e) => return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: e }),
+    };
+    opts.name = entry_name;
+
+    match state.store.put_cron_entry(&name, opts, now_ms).await {
+        Ok(entry) => respond(fmt, StatusCode::OK, &CronEntryResponse::from_store(entry)),
+        Err(StoreError::InvalidOperation(msg)) => {
+            respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg })
+        }
+        Err(e) => {
+            tracing::error!(%e, "put_cron_entry failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `GET /crons/{name}/entries/{entry}` — fetch a single cron entry.
+async fn get_cron_entry(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((name, entry)): Path<(String, String)>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state.store.get_cron_entry(&name, &entry).await {
+        Ok(Some(entry)) => respond(fmt, StatusCode::OK, &CronEntryResponse::from_store(entry)),
+        Ok(None) => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("cron entry '{entry}' not found in group '{name}'"),
+            },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "get_cron_entry failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `PATCH /crons/{name}/entries/{entry}` — update entry-level fields (pause/unpause).
+async fn patch_cron_entry(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((name, entry)): Path<(String, String)>,
+    NegotiatedBody(req): NegotiatedBody<PatchCronGroupRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state
+        .store
+        .patch_cron_entry(&name, &entry, req.paused, now_ms)
+        .await
+    {
+        Ok(Some(entry)) => respond(fmt, StatusCode::OK, &CronEntryResponse::from_store(entry)),
+        Ok(None) => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("cron entry '{entry}' not found in group '{name}'"),
+            },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "patch_cron_entry failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `DELETE /crons/{name}/entries/{entry}` — delete a single cron entry.
+async fn delete_cron_entry(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((name, entry)): Path<(String, String)>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state.store.delete_cron_entry(&name, &entry).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("cron entry '{entry}' not found in group '{name}'"),
+            },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "delete_cron_entry failed");
             respond(
                 fmt,
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2425,6 +2585,57 @@ async fn patch_cron_group(
         ),
         Err(e) => {
             tracing::error!(%e, "patch_cron_group failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `POST /crons/{name}/entries` — add a single entry to a cron group.
+async fn add_cron_entry(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    NegotiatedBody(req): NegotiatedBody<CronEntryRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    if let Err(msg) = validate_name("cron group name", &name) {
+        return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg });
+    }
+
+    let opts = match validate_cron_entry(req) {
+        Ok(opts) => opts,
+        Err(e) => return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: e }),
+    };
+
+    match state.store.add_cron_entry(&name, opts, now_ms).await {
+        Ok(entry) => respond(
+            fmt,
+            StatusCode::CREATED,
+            &CronEntryResponse::from_store(entry),
+        ),
+        Err(StoreError::Conflict(msg)) => {
+            respond(fmt, StatusCode::CONFLICT, &ErrorResponse { error: msg })
+        }
+        Err(StoreError::InvalidOperation(msg)) => {
+            respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg })
+        }
+        Err(e) => {
+            tracing::error!(%e, "add_cron_entry failed");
             respond(
                 fmt,
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -7330,6 +7541,361 @@ mod tests {
     #[tokio::test]
     async fn cron_list_returns_403_on_free_tier() {
         let req = empty_request("GET", "/crons");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    fn cron_post_entry(group: &str, body: &serde_json::Value) -> Request {
+        json_request("POST", &format!("/crons/{group}/entries"), body)
+    }
+
+    #[tokio::test]
+    async fn cron_post_entry_creates_entry() {
+        let req = cron_post_entry(
+            "default",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "test", "queue": "q", "payload": { "x": 1 } }
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["name"], "e1");
+        assert_eq!(body["expression"], "* * * * *");
+        assert!(body["next_enqueue_at"].is_number());
+        assert_eq!(body["job"]["type"], "test");
+    }
+
+    #[tokio::test]
+    async fn cron_post_entry_auto_creates_group() {
+        let app = pro_app();
+
+        // POST an entry to a group that doesn't exist.
+        let req = cron_post_entry(
+            "new-group",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "t", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        // The group should now be GETable.
+        let req = empty_request("GET", "/crons/new-group");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["entries"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cron_post_entry_returns_409_on_duplicate() {
+        let app = pro_app();
+
+        let entry = serde_json::json!({
+            "name": "e1",
+            "expression": "* * * * *",
+            "job": { "type": "t", "queue": "q", "payload": {} }
+        });
+
+        // First POST — should succeed.
+        let req = cron_post_entry("default", &entry);
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        // Second POST — should conflict.
+        let req = cron_post_entry("default", &entry);
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(body["error"].as_str().unwrap().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn cron_post_entry_returns_403_on_free_tier() {
+        let req = cron_post_entry(
+            "default",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "t", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cron_post_entry_validates_fields() {
+        // Invalid expression.
+        let req = cron_post_entry(
+            "default",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "bad",
+                "job": { "type": "t", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn cron_delete_entry_removes_entry() {
+        let app = pro_app();
+
+        // Create a group with two entries.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [
+                    { "name": "e1", "expression": "* * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                    { "name": "e2", "expression": "* * * * *", "job": { "type": "t", "queue": "q", "payload": {} } },
+                ]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Delete e1.
+        let req = empty_request("DELETE", "/crons/default/entries/e1");
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        // Verify e1 is gone, e2 remains.
+        let req = empty_request("GET", "/crons/default");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let entries = body["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["name"], "e2");
+    }
+
+    #[tokio::test]
+    async fn cron_delete_entry_returns_404_for_missing() {
+        let req = empty_request("DELETE", "/crons/default/entries/missing");
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cron_delete_entry_returns_403_on_free_tier() {
+        let req = empty_request("DELETE", "/crons/default/entries/e1");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cron_get_entry_returns_entry() {
+        let app = pro_app();
+
+        // Create a group with an entry.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "test", "queue": "q", "payload": { "x": 1 } }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // GET the entry.
+        let req = empty_request("GET", "/crons/default/entries/e1");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["name"], "e1");
+        assert_eq!(body["expression"], "* * * * *");
+        assert_eq!(body["job"]["type"], "test");
+    }
+
+    #[tokio::test]
+    async fn cron_get_entry_returns_404_for_missing() {
+        let req = empty_request("GET", "/crons/default/entries/missing");
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cron_get_entry_returns_403_on_free_tier() {
+        let req = empty_request("GET", "/crons/default/entries/e1");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    fn cron_put_entry(group: &str, entry: &str, body: &serde_json::Value) -> Request {
+        json_request("PUT", &format!("/crons/{group}/entries/{entry}"), body)
+    }
+
+    #[tokio::test]
+    async fn cron_put_entry_creates_new_entry() {
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "ignored",
+                "expression": "* * * * *",
+                "job": { "type": "test", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        // URL name takes precedence over body name.
+        assert_eq!(body["name"], "e1");
+        assert!(body["next_enqueue_at"].is_number());
+    }
+
+    #[tokio::test]
+    async fn cron_put_entry_replaces_existing_entry() {
+        let app = pro_app();
+
+        // Create entry.
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "old_type", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Replace with new job type.
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "new_type", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["job"]["type"], "new_type");
+    }
+
+    #[tokio::test]
+    async fn cron_put_entry_preserves_schedule_when_expression_unchanged() {
+        let app = pro_app();
+
+        // Create entry.
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "*/5 * * * *",
+                "job": { "type": "t", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body1: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let original_next = body1["next_enqueue_at"].as_u64().unwrap();
+
+        // Replace with same expression but different payload.
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "*/5 * * * *",
+                "job": { "type": "t", "queue": "q", "payload": { "updated": true } }
+            }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body2: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body2["next_enqueue_at"].as_u64().unwrap(), original_next);
+    }
+
+    #[tokio::test]
+    async fn cron_put_entry_returns_403_on_free_tier() {
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "t", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    fn cron_patch_entry(group: &str, entry: &str, body: &serde_json::Value) -> Request {
+        json_request("PATCH", &format!("/crons/{group}/entries/{entry}"), body)
+    }
+
+    #[tokio::test]
+    async fn cron_patch_entry_pauses() {
+        let app = pro_app();
+
+        // Create entry.
+        let req = cron_put_entry(
+            "default",
+            "e1",
+            &serde_json::json!({
+                "name": "e1",
+                "expression": "* * * * *",
+                "job": { "type": "t", "queue": "q", "payload": {} }
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Pause it.
+        let req = cron_patch_entry("default", "e1", &serde_json::json!({ "paused": true }));
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["paused"], true);
+        assert!(body["paused_at"].is_number());
+
+        // Unpause it.
+        let req = cron_patch_entry("default", "e1", &serde_json::json!({ "paused": false }));
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["paused"], false);
+        assert!(body["resumed_at"].is_number());
+    }
+
+    #[tokio::test]
+    async fn cron_patch_entry_returns_404_for_missing() {
+        let req = cron_patch_entry("default", "missing", &serde_json::json!({ "paused": true }));
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cron_patch_entry_returns_403_on_free_tier() {
+        let req = cron_patch_entry("default", "e1", &serde_json::json!({ "paused": true }));
         let res = test_app().oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -41,8 +41,8 @@ use super::scheduled_index::ScheduledIndex;
 use super::cron::{CronEntry, CronGroup};
 use super::group_committer::GroupCommitter;
 use super::options::{
-    BulkDeleteOptions, BulkPatchOptions, EnqueueOptions, FailureOptions, ListErrorsOptions,
-    ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
+    BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
+    ListErrorsOptions, ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
 };
 use super::results::{BulkCompleteResult, EnqueueResult, ListErrorsPage, ListJobsPage};
 use super::types::{
@@ -4028,56 +4028,14 @@ impl Store {
                 entries.iter().map(|e| e.name.clone()).collect();
 
             // Build the new entries with smart merge logic.
-            let mut new_entries = Vec::with_capacity(input_names.len());
-
-            for (input, computed) in entries.into_iter().zip(computed_next) {
-                let entry = if let Some(old) = existing_entries.get(&input.name) {
-                    let (next, last) = if old.expression == input.expression {
-                        // Cron expr is the same — don't reset state.
-                        (old.next_enqueue_at, old.last_enqueue_at)
-                    } else {
-                        // Cron expr changed — recalculate.
-                        (computed, old.last_enqueue_at)
-                    };
-
-                    // Preserve original paused state unless overridden.
-                    let paused = input.paused.unwrap_or(old.paused);
-                    let (paused_at, resumed_at) = match (old.paused, paused) {
-                        // Unpaused -> Paused: set paused_at
-                        (false, true) => (Some(now), old.resumed_at),
-                        // Paused -> Unpaused: set resumed_at
-                        (true, false) => (old.paused_at, Some(now)),
-                        // No change
-                        _ => (old.paused_at, old.resumed_at),
-                    };
-
-                    CronEntry {
-                        name: input.name,
-                        expression: input.expression,
-                        timezone: input.timezone,
-                        paused,
-                        paused_at,
-                        resumed_at,
-                        job: input.job,
-                        next_enqueue_at: next,
-                        last_enqueue_at: last,
-                    }
-                } else {
-                    CronEntry {
-                        name: input.name,
-                        expression: input.expression,
-                        timezone: input.timezone,
-                        paused: input.paused.unwrap_or(false),
-                        paused_at: None,
-                        resumed_at: None,
-                        job: input.job,
-                        next_enqueue_at: computed,
-                        last_enqueue_at: None,
-                    }
-                };
-
-                new_entries.push(entry);
-            }
+            let new_entries: Vec<CronEntry> = entries
+                .into_iter()
+                .zip(computed_next)
+                .map(|(input, computed)| {
+                    let existing = existing_entries.get(&input.name);
+                    merge_cron_entry(input, existing, computed, now)
+                })
+                .collect();
 
             // Delete removed entries (present in existing but not in input).
             for (name, _) in &existing_entries {
@@ -4091,11 +4049,6 @@ impl Store {
                 let entry_key = make_cron_entry_key(&group, &entry.name);
                 let entry_bytes = rmp_serde::to_vec_named(entry)?;
                 tx.insert(&ks.data, &entry_key, &entry_bytes);
-            }
-
-            // If the group is now empty, clean up the group metadata key.
-            if new_entries.is_empty() {
-                tx.remove(&ks.data, &group_key);
             }
 
             ks.commit(tx, ks.default_commit_mode)?;
@@ -4216,6 +4169,228 @@ impl Store {
                 Ok(Some((group_meta, entries)))
             },
         )
+        .await?
+    }
+
+    /// Add a single entry to a cron group.
+    ///
+    /// Creates the group if it does not exist. Returns `Err` with
+    /// `StoreError::Conflict` if an entry with the same name already
+    /// exists in the group.
+    pub async fn add_cron_entry(
+        &self,
+        group: &str,
+        opts: CronEntryOptions,
+        now: u64,
+    ) -> Result<CronEntry, StoreError> {
+        let ks = self.ks.clone();
+        let cron_index = self.cron_index.clone();
+        let event_tx = self.event_tx.clone();
+        let group = group.to_string();
+
+        task::spawn_blocking(move || -> Result<CronEntry, StoreError> {
+            // Validate the cron expression before acquiring the write lock.
+            let next_enqueue_at = cron_next_after(&opts.expression, now, opts.timezone.as_deref())?;
+
+            let group_key = make_cron_group_key(&group);
+            let entry_key = make_cron_entry_key(&group, &opts.name);
+
+            let mut tx = ks.write_tx();
+
+            // Load or create group metadata.
+            if ks.data.get(&group_key)?.is_none() {
+                let group_meta = CronGroup::default();
+                tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
+            }
+
+            // Check for conflict.
+            if ks.data.get(&entry_key)?.is_some() {
+                return Err(StoreError::Conflict(format!(
+                    "cron entry '{}' already exists in group '{}'",
+                    opts.name, group
+                )));
+            }
+
+            let entry = CronEntry {
+                name: opts.name,
+                expression: opts.expression,
+                timezone: opts.timezone,
+                paused: opts.paused.unwrap_or(false),
+                paused_at: None,
+                resumed_at: None,
+                job: opts.job,
+                next_enqueue_at,
+                last_enqueue_at: None,
+            };
+
+            tx.insert(&ks.data, &entry_key, &rmp_serde::to_vec_named(&entry)?);
+
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            // ---- outside tx: update in-memory cron index ----
+            if let Some(next) = entry.next_enqueue_at {
+                cron_index.insert(next, group.clone(), entry.name.clone());
+            }
+
+            let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+
+            Ok(entry)
+        })
+        .await?
+    }
+
+    /// Create or replace a single entry in a cron group.
+    ///
+    /// Creates the group if it does not exist. If the entry already exists,
+    /// applies the same smart merge as `replace_cron_group`: preserves
+    /// scheduling state when the expression is unchanged, preserves pause
+    /// state when omitted.
+    pub async fn put_cron_entry(
+        &self,
+        group: &str,
+        opts: CronEntryOptions,
+        now: u64,
+    ) -> Result<CronEntry, StoreError> {
+        let ks = self.ks.clone();
+        let cron_index = self.cron_index.clone();
+        let event_tx = self.event_tx.clone();
+        let group = group.to_string();
+
+        task::spawn_blocking(move || -> Result<CronEntry, StoreError> {
+            let next_enqueue_at = cron_next_after(&opts.expression, now, opts.timezone.as_deref())?;
+
+            let group_key = make_cron_group_key(&group);
+            let entry_key = make_cron_entry_key(&group, &opts.name);
+
+            let mut tx = ks.write_tx();
+
+            // Load or create group metadata.
+            if ks.data.get(&group_key)?.is_none() {
+                let group_meta = CronGroup::default();
+                tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
+            }
+
+            // Load existing entry for smart merge.
+            let old_entry: Option<CronEntry> = match ks.data.get(&entry_key)? {
+                Some(bytes) => Some(rmp_serde::from_slice(&bytes)?),
+                None => None,
+            };
+
+            let entry = merge_cron_entry(opts, old_entry.as_ref(), next_enqueue_at, now);
+
+            tx.insert(&ks.data, &entry_key, &rmp_serde::to_vec_named(&entry)?);
+
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            // ---- outside tx: update in-memory cron index ----
+            if let Some(old) = &old_entry {
+                if let Some(next) = old.next_enqueue_at {
+                    cron_index.remove(next, &group, &entry.name);
+                }
+            }
+            if let Some(next) = entry.next_enqueue_at {
+                cron_index.insert(next, group.clone(), entry.name.clone());
+            }
+
+            let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+
+            Ok(entry)
+        })
+        .await?
+    }
+
+    /// Delete a single entry from a cron group.
+    ///
+    /// Returns `true` if the entry existed and was deleted, `false` if
+    /// the group or entry does not exist.
+    /// Update a single cron entry's pause state.
+    ///
+    /// Returns the updated entry, or `None` if the group or entry does
+    /// not exist.
+    pub async fn patch_cron_entry(
+        &self,
+        group: &str,
+        entry_name: &str,
+        paused: bool,
+        now: u64,
+    ) -> Result<Option<CronEntry>, StoreError> {
+        let ks = self.ks.clone();
+        let event_tx = self.event_tx.clone();
+        let group = group.to_string();
+        let entry_name = entry_name.to_string();
+
+        task::spawn_blocking(move || -> Result<Option<CronEntry>, StoreError> {
+            let group_key = make_cron_group_key(&group);
+            let entry_key = make_cron_entry_key(&group, &entry_name);
+
+            // Check group exists.
+            if ks.data.get(&group_key)?.is_none() {
+                return Ok(None);
+            }
+
+            let mut tx = ks.write_tx();
+
+            let mut entry: CronEntry = match ks.data.get(&entry_key)? {
+                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                None => return Ok(None),
+            };
+
+            if paused != entry.paused {
+                match (entry.paused, paused) {
+                    (false, true) => entry.paused_at = Some(now),
+                    (true, false) => entry.resumed_at = Some(now),
+                    _ => {}
+                }
+                entry.paused = paused;
+                tx.insert(&ks.data, &entry_key, &rmp_serde::to_vec_named(&entry)?);
+                ks.commit(tx, ks.default_commit_mode)?;
+                let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+            }
+
+            Ok(Some(entry))
+        })
+        .await?
+    }
+
+    pub async fn delete_cron_entry(
+        &self,
+        group: &str,
+        entry_name: &str,
+    ) -> Result<bool, StoreError> {
+        let ks = self.ks.clone();
+        let cron_index = self.cron_index.clone();
+        let event_tx = self.event_tx.clone();
+        let group = group.to_string();
+        let entry_name = entry_name.to_string();
+
+        task::spawn_blocking(move || -> Result<bool, StoreError> {
+            let group_key = make_cron_group_key(&group);
+            let entry_key = make_cron_entry_key(&group, &entry_name);
+
+            // Check group exists.
+            if ks.data.get(&group_key)?.is_none() {
+                return Ok(false);
+            }
+
+            // Load entry for index cleanup.
+            let entry: CronEntry = match ks.data.get(&entry_key)? {
+                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                None => return Ok(false),
+            };
+
+            let mut tx = ks.write_tx();
+            tx.remove(&ks.data, &entry_key);
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            // ---- outside tx: update in-memory cron index ----
+            if let Some(next) = entry.next_enqueue_at {
+                cron_index.remove(next, &group, &entry_name);
+            }
+
+            let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+
+            Ok(true)
+        })
         .await?
     }
 
@@ -4571,6 +4746,62 @@ fn make_cron_group_prefix(group: &str) -> Vec<u8> {
 /// local timezone is used.
 ///
 /// Returns `None` if the expression has no future occurrences.
+/// Merge a `CronEntryOptions` with an optional existing `CronEntry`.
+///
+/// When an existing entry is present and the expression hasn't changed,
+/// preserves `next_enqueue_at` and `last_enqueue_at`. When `paused` is
+/// omitted in the options, preserves the existing pause state. Tracks
+/// `paused_at` / `resumed_at` transitions.
+///
+/// `computed_next` is the pre-computed next enqueue time from the new
+/// expression — used only when the expression has changed or the entry
+/// is new.
+fn merge_cron_entry(
+    opts: CronEntryOptions,
+    existing: Option<&CronEntry>,
+    computed_next: Option<u64>,
+    now: u64,
+) -> CronEntry {
+    if let Some(old) = existing {
+        let (next, last) = if old.expression == opts.expression {
+            (old.next_enqueue_at, old.last_enqueue_at)
+        } else {
+            (computed_next, old.last_enqueue_at)
+        };
+
+        let paused = opts.paused.unwrap_or(old.paused);
+        let (paused_at, resumed_at) = match (old.paused, paused) {
+            (false, true) => (Some(now), old.resumed_at),
+            (true, false) => (old.paused_at, Some(now)),
+            _ => (old.paused_at, old.resumed_at),
+        };
+
+        CronEntry {
+            name: opts.name,
+            expression: opts.expression,
+            timezone: opts.timezone,
+            paused,
+            paused_at,
+            resumed_at,
+            job: opts.job,
+            next_enqueue_at: next,
+            last_enqueue_at: last,
+        }
+    } else {
+        CronEntry {
+            name: opts.name,
+            expression: opts.expression,
+            timezone: opts.timezone,
+            paused: opts.paused.unwrap_or(false),
+            paused_at: None,
+            resumed_at: None,
+            job: opts.job,
+            next_enqueue_at: computed_next,
+            last_enqueue_at: None,
+        }
+    }
+}
+
 fn cron_next_after(
     expression: &str,
     now_ms: u64,
@@ -12141,7 +12372,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replace_cron_group_empty_entries_deletes_group() {
+    async fn replace_cron_group_empty_entries_removes_entries_but_keeps_group() {
         let store = test_store();
         let now = CRON_NOW;
 
@@ -12157,7 +12388,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Replace with empty entries — group should be cleaned up.
+        // Replace with empty entries — entries removed, group persists.
         let (_, entries) = store
             .replace_cron_group(
                 "default",
@@ -12172,9 +12403,13 @@ mod tests {
 
         assert!(entries.is_empty());
 
-        // Verify entry is gone.
+        // Entry should be gone.
         let e1 = store.get_cron_entry("default", "e1").await.unwrap();
         assert!(e1.is_none());
+
+        // Group should still exist.
+        let group = store.get_cron_group("default").await.unwrap();
+        assert!(group.is_some());
     }
 
     #[tokio::test]
@@ -12839,5 +13074,98 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn delete_cron_entry_removes_single_entry() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![
+                        cron_entry_opts("e1", "* * * * *", "q", "test"),
+                        cron_entry_opts("e2", "* * * * *", "q", "test"),
+                    ],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert!(store.delete_cron_entry("default", "e1").await.unwrap());
+
+        // e1 is gone, e2 remains.
+        assert!(
+            store
+                .get_cron_entry("default", "e1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .get_cron_entry("default", "e2")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Group still exists.
+        assert!(store.get_cron_group("default").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn delete_cron_entry_returns_false_for_missing_group() {
+        let store = test_store();
+        assert!(!store.delete_cron_entry("nonexistent", "e1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_cron_entry_returns_false_for_missing_entry() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert!(!store.delete_cron_entry("default", "missing").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_cron_entry_leaves_empty_group() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert!(store.delete_cron_entry("default", "e1").await.unwrap());
+
+        // Group persists with no entries.
+        let (group, entries) = store.get_cron_group("default").await.unwrap().unwrap();
+        assert!(!group.paused);
+        assert!(entries.is_empty());
     }
 }

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -33,6 +33,9 @@ pub enum StoreError {
     /// The requested operation is not valid for the job's current state.
     InvalidOperation(String),
 
+    /// A resource already exists (e.g. duplicate cron entry name).
+    Conflict(String),
+
     /// Internal error (e.g. sync channel closed).
     Internal(String),
 }
@@ -46,6 +49,7 @@ impl fmt::Display for StoreError {
             StoreError::TaskJoin(e) => write!(f, "blocking task failed: {e}"),
             StoreError::Corruption(msg) => write!(f, "data corruption: {msg}"),
             StoreError::InvalidOperation(msg) => write!(f, "invalid operation: {msg}"),
+            StoreError::Conflict(msg) => write!(f, "conflict: {msg}"),
             StoreError::Internal(msg) => write!(f, "internal error: {msg}"),
         }
     }


### PR DESCRIPTION
We've got APIs to manage entire cron groups, but nothing yet to manage individual entries within the group without touching the rest of the group.

This adds:

* `POST /crons/{name}/entries` - Add an entry to a group (lazily creates the group, 409 on duplicate)
* `PUT /crons/{name}/entries/{entry}` - Replace an existing entry
* `GET /crons/{name}/enties/{entry}` - Get just a single entry, or 404
* `PATCH /crons/{name}/entries/{entry}` - Currently on pause/unpause
* `DELETE /crons/{name}/entries/{entry}` - Delete just a single entry, or 404

All request and response shapes are exactly what you would expect.