### PR TITLE
Press "i" in `zizq top` to toggle details.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.1
 
 - Improved key bindings in `zizq top` (g, G, Home, End, ^C, ^Z)
+- Press `i` in `zizq top` to see job detail
 
 ## 0.3.0
 

--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -26,7 +26,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::sync::broadcast;
 
 use super::{
-    AdminEvent, AdminJobSummary, AdminMessage, ClientMessage, JobChangeStatus, JobWindow, ListName,
+    AdminEvent, AdminJob, AdminMessage, ClientMessage, JobChangeStatus, JobWindow, ListName,
     ServerStatus,
 };
 use crate::state::AppState;
@@ -75,6 +75,9 @@ struct ConnectionState {
     ready_sub: Subscription,
     in_flight_sub: Subscription,
     scheduled_sub: Subscription,
+
+    /// Whether to include full job details (payload, retry_limit, etc.).
+    detail: bool,
 }
 
 /// WebSocket endpoint that streams admin events to connected clients.
@@ -123,6 +126,20 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                 limit,
                             )
                             .await;
+                        }
+                        Some(ClientMessage::SetDetailLevel { detail }) => {
+                            conn.detail = detail;
+                            // Resend a snapshot so the client gets the new detail level.
+                            let event = build_snapshot(store, &mut conn).await;
+                            let msg = AdminMessage {
+                                server: server_status(&send_state),
+                                event,
+                            };
+                            if let Ok(json) = serde_json::to_string(&msg) {
+                                if sender.send(Message::Text(json.into())).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                         None => break,
                     }
@@ -312,6 +329,7 @@ async fn send_snapshot_with_subs(
         ready_sub,
         in_flight_sub,
         scheduled_sub,
+        detail: false,
     };
 
     let event = build_snapshot(&state.store, &mut conn).await;
@@ -447,17 +465,17 @@ async fn handle_subscribe(
     }
 
     // Re-send a full snapshot at the new window.
-    let ready_window = {
-        let jobs = store
-            .list_ready_jobs(conn.ready_sub.offset, conn.ready_sub.limit)
-            .await
-            .unwrap_or_default();
-        let keys: Vec<(u16, String)> = jobs.iter().map(|j| (j.priority, j.id.clone())).collect();
-        conn.prev_ready = keys;
-        JobWindow {
-            offset: conn.ready_sub.offset,
-            items: jobs.into_iter().map(AdminJobSummary::from).collect(),
-        }
+    let ready_jobs = store
+        .list_ready_jobs(conn.ready_sub.offset, conn.ready_sub.limit)
+        .await
+        .unwrap_or_default();
+    conn.prev_ready = ready_jobs
+        .iter()
+        .map(|j| (j.priority, j.id.clone()))
+        .collect();
+    let ready_window = JobWindow {
+        offset: conn.ready_sub.offset,
+        items: to_admin_jobs(store, ready_jobs, conn.detail).await,
     };
 
     let in_flight_items: Vec<store::Job> = {
@@ -482,21 +500,21 @@ async fn handle_subscribe(
         offset: conn.in_flight_sub.offset,
         items: in_flight_items
             .into_iter()
-            .map(AdminJobSummary::from)
+            .map(|j| AdminJob::from_store(j, conn.detail))
             .collect(),
     };
 
-    let scheduled_window = {
-        let jobs = store
-            .list_scheduled_jobs(conn.scheduled_sub.offset, conn.scheduled_sub.limit)
-            .await
-            .unwrap_or_default();
-        let keys: Vec<(u64, String)> = jobs.iter().map(|j| (j.ready_at, j.id.clone())).collect();
-        conn.prev_scheduled = keys;
-        JobWindow {
-            offset: conn.scheduled_sub.offset,
-            items: jobs.into_iter().map(AdminJobSummary::from).collect(),
-        }
+    let scheduled_jobs = store
+        .list_scheduled_jobs(conn.scheduled_sub.offset, conn.scheduled_sub.limit)
+        .await
+        .unwrap_or_default();
+    conn.prev_scheduled = scheduled_jobs
+        .iter()
+        .map(|j| (j.ready_at, j.id.clone()))
+        .collect();
+    let scheduled_window = JobWindow {
+        offset: conn.scheduled_sub.offset,
+        items: to_admin_jobs(store, scheduled_jobs, conn.detail).await,
     };
 
     let snapshot = AdminMessage {
@@ -537,7 +555,7 @@ async fn diff_ready(store: &store::Store, conn: &mut ConnectionState) -> Vec<Adm
             events.push(AdminEvent::JobChanged {
                 id,
                 status: JobChangeStatus::Ready,
-                job: Some(AdminJobSummary::from(job)),
+                job: Some(AdminJob::from_store(job, conn.detail)),
             });
         }
     }
@@ -574,7 +592,7 @@ async fn diff_in_flight(store: &store::Store, conn: &mut ConnectionState) -> Vec
             events.push(AdminEvent::JobChanged {
                 id,
                 status: JobChangeStatus::InFlight,
-                job: Some(AdminJobSummary::from(job)),
+                job: Some(AdminJob::from_store(job, conn.detail)),
             });
         }
     }
@@ -607,13 +625,34 @@ async fn diff_scheduled(store: &store::Store, conn: &mut ConnectionState) -> Vec
             events.push(AdminEvent::JobChanged {
                 id,
                 status: JobChangeStatus::Scheduled,
-                job: Some(AdminJobSummary::from(job)),
+                job: Some(AdminJob::from_store(job, conn.detail)),
             });
         }
     }
 
     conn.prev_scheduled = current;
     events
+}
+
+/// Convert a list of store jobs to admin jobs, hydrating payloads when detail
+/// mode is active. The list functions (`list_ready_jobs`, etc.) don't read
+/// payloads from disk, so when detail is on we re-fetch each job via `get_job`.
+async fn to_admin_jobs(store: &store::Store, jobs: Vec<store::Job>, detail: bool) -> Vec<AdminJob> {
+    if !detail {
+        return jobs
+            .into_iter()
+            .map(|j| AdminJob::from_store(j, false))
+            .collect();
+    }
+    let mut result = Vec::with_capacity(jobs.len());
+    for job in jobs {
+        let hydrated = store.get_job(now_millis(), &job.id).await;
+        match hydrated {
+            Ok(Some(j)) => result.push(AdminJob::from_store(j, true)),
+            _ => result.push(AdminJob::from_store(job, true)),
+        }
+    }
+    result
 }
 
 /// Build a fresh `JobSnapshot` event and reset the connection's diff baseline.
@@ -644,7 +683,7 @@ async fn build_snapshot(store: &store::Store, conn: &mut ConnectionState) -> Adm
     let mut in_flight_jobs = Vec::with_capacity(in_flight_window.len());
     for (_, id) in &in_flight_window {
         if let Ok(Some(job)) = store.get_job(now_millis(), id).await {
-            in_flight_jobs.push(AdminJobSummary::from(job));
+            in_flight_jobs.push(AdminJob::from_store(job, conn.detail));
         }
     }
 
@@ -659,13 +698,13 @@ async fn build_snapshot(store: &store::Store, conn: &mut ConnectionState) -> Adm
         .map(|j| (j.ready_at, j.id.clone()))
         .collect();
 
+    let ready_items = to_admin_jobs(store, capped_ready, conn.detail).await;
+    let scheduled_items = to_admin_jobs(store, capped_scheduled, conn.detail).await;
+
     AdminEvent::JobSnapshot {
         ready: JobWindow {
             offset: conn.ready_sub.offset,
-            items: capped_ready
-                .into_iter()
-                .map(AdminJobSummary::from)
-                .collect(),
+            items: ready_items,
         },
         in_flight: JobWindow {
             offset: conn.in_flight_sub.offset,
@@ -673,10 +712,7 @@ async fn build_snapshot(store: &store::Store, conn: &mut ConnectionState) -> Adm
         },
         scheduled: JobWindow {
             offset: conn.scheduled_sub.offset,
-            items: capped_scheduled
-                .into_iter()
-                .map(AdminJobSummary::from)
-                .collect(),
+            items: scheduled_items,
         },
     }
 }

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -15,6 +15,6 @@ mod types;
 
 pub use handlers::app;
 pub use types::{
-    AdminEvent, AdminJobSummary, AdminMessage, ClientMessage, JobChangeStatus, JobWindow, ListName,
-    ServerStatus,
+    AdminBackoff, AdminEvent, AdminJob, AdminMessage, AdminRetention, ClientMessage,
+    JobChangeStatus, JobWindow, ListName, ServerStatus,
 };

--- a/src/api/admin/types.rs
+++ b/src/api/admin/types.rs
@@ -51,7 +51,7 @@ pub enum AdminEvent {
         id: String,
         status: JobChangeStatus,
         #[serde(skip_serializing_if = "Option::is_none")]
-        job: Option<AdminJobSummary>,
+        job: Option<AdminJob>,
     },
 }
 
@@ -59,7 +59,7 @@ pub enum AdminEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobWindow {
     pub offset: usize,
-    pub items: Vec<AdminJobSummary>,
+    pub items: Vec<AdminJob>,
 }
 
 /// Client-to-server message for controlling subscriptions.
@@ -70,6 +70,9 @@ pub enum ClientMessage {
         list: ListName,
         offset: usize,
         limit: usize,
+    },
+    SetDetailLevel {
+        detail: bool,
     },
 }
 
@@ -96,9 +99,13 @@ pub enum JobChangeStatus {
     Dead,
 }
 
-/// Summary of a job for the admin dashboard (no payload).
+/// A job as seen by the admin API.
+///
+/// Always includes the core fields needed for the dashboard table. When
+/// detail mode is enabled, additional fields (payload, retry_limit, etc.)
+/// are populated. Extra fields are silently ignored by older clients.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AdminJobSummary {
+pub struct AdminJob {
     pub id: String,
     pub queue: String,
     pub job_type: String,
@@ -109,10 +116,62 @@ pub struct AdminJobSummary {
     pub dequeued_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failed_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backoff: Option<AdminBackoff>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retention: Option<AdminRetention>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique_while: Option<String>,
 }
 
-impl From<store::Job> for AdminJobSummary {
-    fn from(job: store::Job) -> Self {
+/// Backoff configuration for the admin API (human-readable field names).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminBackoff {
+    pub base_ms: u32,
+    pub exponent: f32,
+    pub jitter_ms: u32,
+}
+
+/// Retention configuration for the admin API (human-readable field names).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminRetention {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dead_ms: Option<u64>,
+}
+
+impl AdminJob {
+    /// Convert a store job to an admin job.
+    ///
+    /// When `detail` is true, includes payload and other extended fields.
+    pub fn from_store(job: store::Job, detail: bool) -> Self {
+        let (unique_key, unique_while) = if detail {
+            match job.unique {
+                Some(ref uc) => (
+                    Some(uc.key.clone()),
+                    Some(
+                        match uc.scope {
+                            0 => "queued",
+                            1 => "active",
+                            2 => "exists",
+                            _ => "queued",
+                        }
+                        .to_string(),
+                    ),
+                ),
+                None => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
         Self {
             id: job.id,
             queue: job.queue,
@@ -122,6 +181,27 @@ impl From<store::Job> for AdminJobSummary {
             attempts: job.attempts,
             dequeued_at: job.dequeued_at,
             failed_at: job.failed_at,
+            payload: if detail { job.payload } else { None },
+            retry_limit: if detail { job.retry_limit } else { None },
+            backoff: if detail {
+                job.backoff.map(|b| AdminBackoff {
+                    base_ms: b.base_ms,
+                    exponent: b.exponent,
+                    jitter_ms: b.jitter_ms,
+                })
+            } else {
+                None
+            },
+            retention: if detail {
+                job.retention.map(|r| AdminRetention {
+                    completed_ms: r.completed_ms,
+                    dead_ms: r.dead_ms,
+                })
+            } else {
+                None
+            },
+            unique_key,
+            unique_while,
         }
     }
 }

--- a/src/commands/top/app.rs
+++ b/src/commands/top/app.rs
@@ -5,7 +5,7 @@
 
 use tokio::sync::mpsc;
 
-use crate::api::admin::{AdminJobSummary, JobChangeStatus, JobWindow, ServerStatus};
+use crate::api::admin::{AdminJob, JobChangeStatus, JobWindow, ServerStatus};
 use crate::license::Tier;
 
 use super::events::{self, Event};
@@ -90,14 +90,15 @@ pub struct App {
     pub total_ready: usize,
     pub total_in_flight: usize,
     pub total_scheduled: usize,
-    pub ready_jobs: Vec<AdminJobSummary>,
-    pub in_flight_jobs: Vec<AdminJobSummary>,
-    pub scheduled_jobs: Vec<AdminJobSummary>,
+    pub ready_jobs: Vec<AdminJob>,
+    pub in_flight_jobs: Vec<AdminJob>,
+    pub scheduled_jobs: Vec<AdminJob>,
     pub now_ms: u64,
     pub active_tab: Tab,
     pub h_scroll: [u16; 3],
     pub list_states: [ListState; 3],
     pub viewport_height: usize,
+    pub show_detail: bool,
     pub ws_tx: Option<mpsc::Sender<String>>,
 }
 
@@ -121,6 +122,7 @@ impl Clone for App {
             h_scroll: self.h_scroll,
             list_states: self.list_states.clone(),
             viewport_height: self.viewport_height,
+            show_detail: self.show_detail,
             ws_tx: self.ws_tx.clone(),
         }
     }
@@ -146,6 +148,7 @@ impl App {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         }
     }
@@ -238,6 +241,14 @@ impl App {
         }
     }
 
+    /// Send the current detail level to the server.
+    fn send_detail_level(&self) {
+        if let Some(tx) = &self.ws_tx {
+            let msg = events::detail_level_message(self.show_detail);
+            let _ = tx.try_send(msg);
+        }
+    }
+
     /// Apply server status fields from any message.
     fn apply_server_status(&mut self, server: ServerStatus) {
         self.status = ConnectionStatus::Connected;
@@ -288,12 +299,21 @@ impl App {
             Event::GoToEnd => {
                 self.go_to_end();
             }
+            Event::ToggleDetail => {
+                self.show_detail = !self.show_detail;
+                self.send_detail_level();
+            }
             Event::ServerConnecting => {
                 self.status = ConnectionStatus::Connecting;
             }
             Event::ServerConnected { url } => {
                 self.status = ConnectionStatus::Connected;
                 self.host = url;
+                // Resend detail level so the server knows our preference
+                // after a reconnect.
+                if self.show_detail {
+                    self.send_detail_level();
+                }
             }
             Event::ServerHeartbeat { server } => {
                 self.apply_server_status(server);
@@ -516,6 +536,7 @@ impl App {
         ls.cursor = 0;
         ls.scroll_pos = 0;
         ls.follow_bottom = false;
+        self.maybe_prefetch();
     }
 
     fn go_to_end(&mut self) {
@@ -549,8 +570,8 @@ mod tests {
         }
     }
 
-    fn job(id: &str, priority: u16, dequeued_at: Option<u64>) -> AdminJobSummary {
-        AdminJobSummary {
+    fn job(id: &str, priority: u16, dequeued_at: Option<u64>) -> AdminJob {
+        AdminJob {
             id: id.to_string(),
             queue: "q".to_string(),
             job_type: "t".to_string(),
@@ -559,6 +580,12 @@ mod tests {
             attempts: 0,
             dequeued_at,
             failed_at: None,
+            payload: None,
+            retry_limit: None,
+            backoff: None,
+            retention: None,
+            unique_key: None,
+            unique_while: None,
         }
     }
 
@@ -580,7 +607,7 @@ mod tests {
         }
     }
 
-    fn ids(jobs: &[AdminJobSummary]) -> Vec<&str> {
+    fn ids(jobs: &[AdminJob]) -> Vec<&str> {
         jobs.iter().map(|j| j.id.as_str()).collect()
     }
 
@@ -835,7 +862,7 @@ mod tests {
                 server: default_server(),
                 id: id.to_string(),
                 status: JobChangeStatus::Scheduled,
-                job: Some(AdminJobSummary {
+                job: Some(AdminJob {
                     id: id.to_string(),
                     queue: "q".to_string(),
                     job_type: "t".to_string(),
@@ -844,6 +871,12 @@ mod tests {
                     attempts: 0,
                     dequeued_at: None,
                     failed_at: None,
+                    payload: None,
+                    retry_limit: None,
+                    backoff: None,
+                    retention: None,
+                    unique_key: None,
+                    unique_while: None,
                 }),
             }
         };
@@ -863,7 +896,7 @@ mod tests {
                 server: default_server(),
                 id: id.to_string(),
                 status: JobChangeStatus::Scheduled,
-                job: Some(AdminJobSummary {
+                job: Some(AdminJob {
                     id: id.to_string(),
                     queue: "q".to_string(),
                     job_type: "t".to_string(),
@@ -872,6 +905,12 @@ mod tests {
                     attempts: 0,
                     dequeued_at: None,
                     failed_at: None,
+                    payload: None,
+                    retry_limit: None,
+                    backoff: None,
+                    retention: None,
+                    unique_key: None,
+                    unique_while: None,
                 }),
             }
         };
@@ -897,7 +936,7 @@ mod tests {
                 server: default_server(),
                 id: id.to_string(),
                 status: JobChangeStatus::Scheduled,
-                job: Some(AdminJobSummary {
+                job: Some(AdminJob {
                     id: id.to_string(),
                     queue: "q".to_string(),
                     job_type: "t".to_string(),
@@ -906,6 +945,12 @@ mod tests {
                     attempts: 0,
                     dequeued_at: None,
                     failed_at: None,
+                    payload: None,
+                    retry_limit: None,
+                    backoff: None,
+                    retention: None,
+                    unique_key: None,
+                    unique_while: None,
                 }),
             }
         };

--- a/src/commands/top/events.rs
+++ b/src/commands/top/events.rs
@@ -9,7 +9,7 @@
 use tokio::sync::mpsc;
 
 use crate::api::admin::{
-    AdminEvent, AdminJobSummary, AdminMessage, JobChangeStatus, JobWindow, ServerStatus,
+    AdminEvent, AdminJob, AdminMessage, ClientMessage, JobChangeStatus, JobWindow, ServerStatus,
 };
 
 /// Unified event type for the TUI event loop.
@@ -36,6 +36,8 @@ pub enum Event {
     GoToStart,
     /// Jump to the last row.
     GoToEnd,
+    /// Toggle the detail panel.
+    ToggleDetail,
     /// Suspend the process (Ctrl-Z).
     Suspend,
     /// Server connection attempt in progress.
@@ -56,7 +58,7 @@ pub enum Event {
         server: ServerStatus,
         id: String,
         status: JobChangeStatus,
-        job: Option<AdminJobSummary>,
+        job: Option<AdminJob>,
     },
     /// Server connection lost.
     ServerDisconnected,
@@ -67,7 +69,12 @@ impl Event {
     pub fn is_user_input(&self) -> bool {
         matches!(
             self,
-            Event::Quit | Event::NextTab | Event::PrevTab | Event::ScrollLeft | Event::ScrollRight
+            Event::Quit
+                | Event::NextTab
+                | Event::PrevTab
+                | Event::ScrollLeft
+                | Event::ScrollRight
+                | Event::ToggleDetail
         )
     }
 
@@ -125,6 +132,9 @@ pub fn read_terminal_events(tx: mpsc::Sender<Event>) {
                         }
                         (KeyCode::PageDown, _) => {
                             let _ = tx.blocking_send(Event::PageDown);
+                        }
+                        (KeyCode::Char('i'), _) => {
+                            let _ = tx.blocking_send(Event::ToggleDetail);
                         }
                         (KeyCode::Char('g'), _) => {
                             let _ = tx.blocking_send(Event::GoToStart);
@@ -240,6 +250,12 @@ fn parse_ws_message(text: &str) -> Option<Event> {
             job,
         }),
     }
+}
+
+/// Serialize a detail-level message for sending over WebSocket.
+pub fn detail_level_message(detail: bool) -> String {
+    serde_json::to_string(&ClientMessage::SetDetailLevel { detail })
+        .expect("ClientMessage serialization cannot fail")
 }
 
 /// Serialize a subscribe message for sending over WebSocket.

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connected_with_server_info.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connected_with_server_info.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-expression: "render_to_string(&app, 160, 12)"
+expression: "render_to_string(&app, 160, 30)"
 ---
   Zizq 0.1.0
 ● Connected 127.0.0.1:8901
@@ -13,4 +13,22 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                        DURATION   ATTEMPTS TYPE
 70a2bb46e1f07a0c908d7a2bb40          0 default                            3s          1 generate_annual_report_email
 70a1aa35d0e06b0b807c691aa30          0 billing                         2m30s          3 charge_subscription
+
+
+
+
+
+
+
+
+
+
+
+
+  ATTRIBUTES                                                                     PAYLOAD
+  ID                      0195b70a2bb46e1f07a0c908d7a2bb40                       {
+  Queue                   default                                                  "subject": "Welcome!",
+  Type                    generate_annual_report_email                             "to": "user@example.com",
+  Priority                0                                                        "urgent": true
+  Status                  in_flight                                              }
  Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
@@ -9,4 +9,4 @@ expression: "render_to_string(&app, 120, 8)"
 
 
    In-Flight   Ready   Scheduled
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
@@ -9,4 +9,4 @@ expression: "render_to_string(&app, 120, 8)"
 
   Depth[                                                                                                       0 jobs]
    In-Flight   Ready   Scheduled
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 120, 12)"
 
                                          Display is currently capped at 10 jobs.
                                        Upgrade to a pro license to see everything.
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
@@ -21,4 +21,4 @@ expression: "render_to_string(&app, 80, 20)"
                      Display is currently capped at 10 jobs.
                    Upgrade to a pro license to see everything.
 
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
 70a2bb46e1f07a0c908d7a2bb40          0 default                  3s          1 ge
 70a1aa35d0e06b0b807c691aa30          0 billing               2m30s          3 ch
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
      ID   PRIORITY QUEUE              DURATION   ATTEMPTS TYPE
 7a2bb40          0 default                  3s          1 generate_annual_report
 691aa30          0 billing               2m30s          3 charge_subscription
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
 UEUE              DURATION   ATTEMPTS TYPE
 efault                  3s          1 generate_annual_report_email
 illing               2m30s          3 charge_subscription
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TY
 70a3cc87a1f0890da08e8b3cc86          0 default                  5s          0 ge
 70a3dd47c2308a1fb09e9c4dd97          5 default                1m2s          2 se
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                           DELAY   ATTEMPTS TYPE
 70a3cc87a1f0890da08e8b3cc86          0 default                            5s          0 generate_annual_report_email
 70a3dd47c2308a1fb09e9c4dd97          5 default                          1m2s          2 send_welcome_email
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                   DUE   ATTEMPTS TY
 70a4ee89f2f09a1eb0af9d5ee80          0 default               3m52s          0 se
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                  1h          1 ge
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
@@ -13,4 +13,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                             DUE   ATTEMPTS TYPE
 70a4ee89f2f09a1eb0af9d5ee80          0 default                         3m52s          0 send_reminder_email
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                            1h          1 generate_quarterly_report
- Tab Change Tab  q Quit
+ Tab Change Tab  i Info  q Quit

--- a/src/commands/top/ui.rs
+++ b/src/commands/top/ui.rs
@@ -10,7 +10,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Paragraph, Row, Table, Widget};
 
-use crate::api::admin::AdminJobSummary;
+use crate::api::admin::AdminJob;
 
 use super::app::{App, ConnectionStatus, Tab};
 
@@ -202,15 +202,41 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         None
     };
 
-    let (table_area, msg_area) = if subscription_limit.is_some() {
-        let split = Layout::vertical([
-            Constraint::Min(0),    // table
-            Constraint::Length(4), // blank line + 2-line message + blank line
-        ])
-        .split(content_area);
-        (split[0], Some(split[1]))
-    } else {
-        (content_area, None)
+    // Split content area into table + optional detail panel + optional cap message.
+    // Panel height: min(DETAIL_PANEL_MAX, 30% of content area).
+    // Suppressed if the table would get fewer than MIN_TABLE_ROWS body rows.
+    let detail_height = DETAIL_PANEL_MAX.min((content_area.height * 30 / 100).max(1));
+    let show_detail_panel =
+        app.show_detail && content_area.height > detail_height + MIN_TABLE_ROWS + 1;
+
+    let (table_area, detail_area, msg_area) = {
+        let mut constraints = vec![Constraint::Min(0)]; // table always first
+
+        if show_detail_panel {
+            constraints.push(Constraint::Length(detail_height));
+        }
+        if subscription_limit.is_some() {
+            constraints.push(Constraint::Length(4));
+        }
+
+        let split = Layout::vertical(constraints).split(content_area);
+        let mut idx = 1;
+
+        let detail = if show_detail_panel {
+            let area = split[idx];
+            idx += 1;
+            Some(area)
+        } else {
+            None
+        };
+
+        let msg = if subscription_limit.is_some() {
+            Some(split[idx])
+        } else {
+            None
+        };
+
+        (split[0], detail, msg)
     };
 
     // Store the viewport height (minus 1 for the header row) so
@@ -256,6 +282,149 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         render_scrollable(frame, table, table_area, tab_scroll);
     }
 
+    // Detail panel — job metadata on the left, payload on the right.
+    if let Some(area) = detail_area {
+        let heading_style = Style::default().fg(tab_fg()).bg(Color::Yellow);
+
+        let ls = &app.list_states[app.active_tab.idx()];
+        let jobs = match app.active_tab {
+            Tab::Ready => &app.ready_jobs,
+            Tab::InFlight => &app.in_flight_jobs,
+            Tab::Scheduled => &app.scheduled_jobs,
+        };
+
+        let buf_idx = ls.cursor.checked_sub(ls.buffer_offset);
+        let job = buf_idx.and_then(|i| jobs.get(i));
+
+        if let Some(job) = job {
+            // Split into left (metadata) and right (payload).
+            let halves =
+                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                    .split(area);
+
+            // Left column: heading + key-value metadata.
+            let dim = Style::default().fg(Color::DarkGray);
+            let val = Style::default().fg(Color::White);
+
+            let left_heading = Line::from(Span::styled(
+                pad_to("  ATTRIBUTES", halves[0].width),
+                heading_style,
+            ));
+
+            let status = match app.active_tab {
+                Tab::Ready => "ready",
+                Tab::InFlight => "in_flight",
+                Tab::Scheduled => "scheduled",
+            };
+
+            let attempts_value = match job.retry_limit {
+                Some(limit) => format!("{}/{}", job.attempts, limit),
+                None => job.attempts.to_string(),
+            };
+
+            let mut meta: Vec<Line> = vec![
+                left_heading,
+                detail_line("  ID", job.id.clone(), dim, val),
+                detail_line("  Queue", job.queue.clone(), dim, val),
+                detail_line("  Type", job.job_type.clone(), dim, val),
+                detail_line("  Priority", job.priority.to_string(), dim, val),
+                detail_line("  Status", status, dim, val),
+                detail_line("  Ready At", format_timestamp(job.ready_at), dim, val),
+            ];
+
+            if let Some(at) = job.failed_at {
+                meta.push(detail_line("  Failed At", format_timestamp(at), dim, val));
+            }
+            if let Some(at) = job.dequeued_at {
+                meta.push(detail_line("  Dequeued At", format_timestamp(at), dim, val));
+            }
+
+            meta.push(detail_line(
+                "  Attempts / Retry Limit",
+                attempts_value,
+                dim,
+                val,
+            ));
+
+            if let Some(ref b) = job.backoff {
+                meta.push(detail_line(
+                    "  Backoff",
+                    format!(
+                        "base={},exponent={},jitter={}",
+                        b.base_ms, b.exponent, b.jitter_ms
+                    ),
+                    dim,
+                    val,
+                ));
+            }
+
+            if let Some(ref r) = job.retention {
+                let parts: Vec<String> = [
+                    r.completed_ms
+                        .map(|ms| format!("completed={}", format_duration_ms(ms))),
+                    r.dead_ms
+                        .map(|ms| format!("dead={}", format_duration_ms(ms))),
+                ]
+                .into_iter()
+                .flatten()
+                .collect();
+                if !parts.is_empty() {
+                    meta.push(detail_line(
+                        "  Retention Policy",
+                        parts.join(", "),
+                        dim,
+                        val,
+                    ));
+                }
+            }
+
+            if let Some(ref key) = job.unique_key {
+                let scope = job.unique_while.as_deref().unwrap_or("queued");
+                meta.push(detail_line(
+                    "  Unique Key",
+                    format!("{scope} {key}"),
+                    dim,
+                    val,
+                ));
+            }
+
+            frame.render_widget(Paragraph::new(meta), halves[0]);
+
+            // Right column: heading + pretty-printed payload.
+            let right_heading = Line::from(Span::styled(
+                pad_to(" PAYLOAD", halves[1].width),
+                heading_style,
+            ));
+
+            let mut payload_lines: Vec<Line> = vec![right_heading];
+            match &job.payload {
+                Some(payload) => {
+                    let pretty = serde_json::to_string_pretty(payload)
+                        .unwrap_or_else(|_| payload.to_string());
+                    payload_lines.extend(pretty.lines().map(|l| Line::raw(format!(" {l}"))));
+                }
+                None => {
+                    payload_lines.push(Line::styled(" (not loaded)", dim));
+                }
+            }
+
+            frame.render_widget(Paragraph::new(payload_lines), halves[1]);
+        } else {
+            // Heading bar even when no job selected.
+            let heading = Line::from(Span::styled(
+                pad_to("  ATTRIBUTES", area.width),
+                heading_style,
+            ));
+            frame.render_widget(
+                Paragraph::new(vec![
+                    heading,
+                    Line::styled("  No job selected", Style::default().fg(Color::DarkGray)),
+                ]),
+                area,
+            );
+        }
+    }
+
     if let Some(cap) = subscription_limit {
         let msg = Paragraph::new(vec![
             Line::default(),
@@ -274,6 +443,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     let help = Paragraph::new(Line::from(vec![
         Span::styled(" Tab ", key_style),
         Span::styled("Change Tab", label_style),
+        Span::styled("  i ", key_style),
+        Span::styled("Info", label_style),
         Span::styled("  q ", key_style),
         Span::styled("Quit", label_style),
     ]));
@@ -284,6 +455,12 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 /// the table renders at this width and the visible portion is determined by
 /// the horizontal scroll offset.
 const MIN_TABLE_WIDTH: u16 = 120;
+
+/// Maximum height of the detail panel (heading + all possible fields).
+const DETAIL_PANEL_MAX: u16 = 13;
+
+/// Minimum table body rows required before showing the detail panel.
+const MIN_TABLE_ROWS: u16 = 3;
 
 /// Style for the cursor-highlighted row.
 const CURSOR_STYLE: Style = Style::new().fg(Color::Black).bg(Color::LightCyan);
@@ -494,7 +671,7 @@ fn priority_style(highlighted: bool) -> Style {
 }
 
 /// Build a table widget for the Ready pane.
-fn job_table_ready(jobs: &[AdminJobSummary], now_ms: u64, cursor_row: Option<usize>) -> Table<'_> {
+fn job_table_ready(jobs: &[AdminJob], now_ms: u64, cursor_row: Option<usize>) -> Table<'_> {
     let header = Row::new([
         Cell::from(Line::from("ID").alignment(Alignment::Right)),
         Cell::from(Line::from("PRIORITY").alignment(Alignment::Right)),
@@ -550,11 +727,7 @@ fn job_table_ready(jobs: &[AdminJobSummary], now_ms: u64, cursor_row: Option<usi
 }
 
 /// Build a table widget for the In-Flight pane.
-fn job_table_in_flight(
-    jobs: &[AdminJobSummary],
-    now_ms: u64,
-    cursor_row: Option<usize>,
-) -> Table<'_> {
+fn job_table_in_flight(jobs: &[AdminJob], now_ms: u64, cursor_row: Option<usize>) -> Table<'_> {
     let header = Row::new([
         Cell::from(Line::from("ID").alignment(Alignment::Right)),
         Cell::from(Line::from("PRIORITY").alignment(Alignment::Right)),
@@ -611,11 +784,7 @@ fn job_table_in_flight(
 }
 
 /// Build a table widget for the Scheduled pane.
-fn job_table_scheduled(
-    jobs: &[AdminJobSummary],
-    now_ms: u64,
-    cursor_row: Option<usize>,
-) -> Table<'_> {
+fn job_table_scheduled(jobs: &[AdminJob], now_ms: u64, cursor_row: Option<usize>) -> Table<'_> {
     let header = Row::new([
         Cell::from(Line::from("ID").alignment(Alignment::Right)),
         Cell::from(Line::from("PRIORITY").alignment(Alignment::Right)),
@@ -668,6 +837,39 @@ fn job_table_scheduled(
         ],
     )
     .header(header)
+}
+
+/// Build a single key-value line for the detail panel metadata column.
+/// Width of the label column in detail panel metadata lines.
+const DETAIL_LABEL_WIDTH: usize = 26;
+
+fn detail_line(
+    label: &str,
+    value: impl Into<String>,
+    label_style: Style,
+    value_style: Style,
+) -> Line<'static> {
+    let padded = format!("{:width$}", label, width = DETAIL_LABEL_WIDTH);
+    Line::from(vec![
+        Span::styled(padded, label_style),
+        Span::styled(value.into(), value_style),
+    ])
+}
+
+/// Pad a string to a given width with trailing spaces.
+fn pad_to(s: &str, width: u16) -> String {
+    format!("{:width$}", s, width = width as usize)
+}
+
+/// Format a millisecond timestamp as a local date/time with UTC offset.
+fn format_timestamp(ms: u64) -> String {
+    use chrono::{Local, TimeZone};
+    let secs = (ms / 1_000) as i64;
+    let nsecs = ((ms % 1_000) * 1_000_000) as u32;
+    match Local.timestamp_opt(secs, nsecs) {
+        chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d %H:%M:%S %:z").to_string(),
+        _ => format!("{ms}"),
+    }
 }
 
 /// Format time until a scheduled job is due, or how overdue it is.
@@ -791,6 +993,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         }
     }
@@ -821,6 +1024,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
@@ -846,6 +1050,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
@@ -860,8 +1065,8 @@ mod tests {
         attempts: u32,
         dequeued_at: Option<u64>,
         failed_at: Option<u64>,
-    ) -> AdminJobSummary {
-        AdminJobSummary {
+    ) -> AdminJob {
+        AdminJob {
             id: id.to_string(),
             queue: queue.to_string(),
             job_type: job_type.to_string(),
@@ -870,6 +1075,12 @@ mod tests {
             attempts,
             dequeued_at,
             failed_at,
+            payload: None,
+            retry_limit: None,
+            backoff: None,
+            retention: None,
+            unique_key: None,
+            unique_while: None,
         }
     }
 
@@ -956,6 +1167,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         }
     }
@@ -1011,6 +1223,35 @@ mod tests {
     }
 
     #[test]
+    fn render_detail_panel() {
+        use crate::api::admin::{AdminBackoff, AdminRetention};
+
+        let mut app = sample_app(Tab::InFlight);
+        app.show_detail = true;
+
+        // Give the first in-flight job full detail fields.
+        app.in_flight_jobs[0].payload = Some(serde_json::json!({
+            "to": "user@example.com",
+            "subject": "Welcome!",
+            "urgent": true,
+        }));
+        app.in_flight_jobs[0].retry_limit = Some(25);
+        app.in_flight_jobs[0].backoff = Some(AdminBackoff {
+            base_ms: 15000,
+            exponent: 4.0,
+            jitter_ms: 30000,
+        });
+        app.in_flight_jobs[0].retention = Some(AdminRetention {
+            completed_ms: Some(604_800_000),
+            dead_ms: Some(2_592_000_000),
+        });
+        app.in_flight_jobs[0].unique_key = Some("report:annual:2026".to_string());
+        app.in_flight_jobs[0].unique_while = Some("active".to_string());
+
+        assert_ui_snapshot!(render_to_string(&app, 160, 30));
+    }
+
+    #[test]
     fn render_empty_ready_tab() {
         let app = App {
             host: "127.0.0.1:8901".to_string(),
@@ -1030,6 +1271,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
@@ -1055,6 +1297,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
@@ -1102,6 +1345,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 80, 20));
@@ -1149,6 +1393,7 @@ mod tests {
             h_scroll: [0; 3],
             list_states: Default::default(),
             viewport_height: 0,
+            show_detail: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 12));


### PR DESCRIPTION
Previously `zizq top` would display a simple list but not all fields are included in the list, and in particular the payload is absent.

Now when you press "i" a split panel opens beneath the jobs list that shows the full details of the job under the cursor, including the payload.

We use the WebSocket to send a client message specifying the detail level it wants, and we extend the AdminJob struct with lots of optional fields for the extended info. The server sends the extended info, or the basic info depending on what the client currently wants.