### PR TITLE
Fix Bug in Release Publishing Step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,12 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
-        run: ./release.sh --target ${{ matrix.target }}
+        run: |
+          # Clear any stale packaged artifacts a restored `target/`
+          # cache may carry forward from an earlier version's build —
+          # otherwise the upload globs would sweep them into the release.
+          rm -f target/release/zizq-*
+          ./release.sh --target ${{ matrix.target }}
 
       - name: Clean up macOS keychain
         if: always() && runner.os == 'macOS'
@@ -425,4 +430,4 @@ jobs:
           gh release create "v${version}" \
             --title "v${version}" \
             --notes-file release-notes.md \
-            artifacts/zizq-*
+            artifacts/zizq-${version}-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.2
+
+
 ## 0.3.1
 
 - Improved key bindings in `zizq top` (g, G, Home, End, ^C, ^Z)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.1/zizq-0.3.1-linux-x86_64.tar.gz
-tar -xvzf zizq-0.3.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.2/zizq-0.3.2-linux-x86_64.tar.gz
+tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -56,7 +56,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.3.1
+Zizq 0.3.2
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.1/zizq-0.3.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.2/zizq-0.3.2-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.3.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.3.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -15,13 +15,13 @@ does almost all of the work.
 ### 1. Download the binary.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.1/zizq-0.3.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.2/zizq-0.3.2-linux-x86_64.tar.gz
 ```
 
 ### 2. Extract it.
 
 ```shell
-tar -xvzf zizq-0.3.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
 ```
 
 ### 3. Run it to start the server.
@@ -29,7 +29,7 @@ tar -xvzf zizq-0.3.1-linux-x86_64.tar.gz
 ```shell
 ./zizq serve
 
-Zizq 0.3.1
+Zizq 0.3.2
 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http


### PR DESCRIPTION
When we released 0.3.1, 0.3.0 and 0.2.1 we re-uploaded artifacts for all the older releases with them, which is wrong but also very confusing. You could download 0.2.1 from the 0.3.1 releases on GitHub.

This was happening because the `target/` directory is cached for performance reasons on CI, and we were using a wildcard glob to upload all the `target/release/zizq-*` artifacts.

Fixed here by `rm`'ing any existing release artifacts before building the versions to release *and* (defense in depth) not using a glob on all `zizq-*`, but instead restricting that glob to the current version being released.