### PR TITLE
Add Ability to Force LSM Compaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## 0.3.2
+## 0.4.0
 
+- Force a full LSM compaction after large bulk deletes and bulk patches to
+  reclaim tombstone space that leveled compaction would otherwise leave in
+  upper levels on quiet databases. Threshold is configurable via
+  `ZIZQ_AUTO_COMPACT_THRESHOLD` (default 10000, set to 0 to disable).
+- Added `POST /compact` admin endpoint to trigger a full compaction on
+  demand. Returns 204 No Content on success.
+- Added `zizq compact` CLI subcommand that calls the admin endpoint.
 
 ## 0.3.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.2/zizq-0.3.2-linux-x86_64.tar.gz
-tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.0/zizq-0.4.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.0-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -56,7 +56,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.3.2
+Zizq 0.4.0
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.2/zizq-0.3.2-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.0/zizq-0.4.0-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.0-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.0-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -15,13 +15,13 @@ does almost all of the work.
 ### 1. Download the binary.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.3.2/zizq-0.3.2-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.0/zizq-0.4.0-linux-x86_64.tar.gz
 ```
 
 ### 2. Extract it.
 
 ```shell
-tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.0-linux-x86_64.tar.gz
 ```
 
 ### 3. Run it to start the server.
@@ -29,7 +29,7 @@ tar -xvzf zizq-0.3.2-linux-x86_64.tar.gz
 ```shell
 ./zizq serve
 
-Zizq 0.3.2
+Zizq 0.4.0
 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http

--- a/src/api/admin/compact.rs
+++ b/src/api/admin/compact.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Admin compaction endpoint.
+//!
+//! `POST /compact` forces a full LSM compaction of both keyspaces,
+//! reclaiming tombstone space that leveled compaction would otherwise
+//! leave behind on quiet databases. See `Store::compact_all`.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::state::AppState;
+
+/// Handle `POST /compact` — force a full compaction of all keyspaces.
+///
+/// Blocks until compaction finishes. May take many seconds on large
+/// databases.
+pub async fn handle_compact(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.store.compact_all().await {
+        Ok(()) => StatusCode::NO_CONTENT,
+        Err(e) => {
+            tracing::error!(%e, "compact_all failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}

--- a/src/api/admin/handlers.rs
+++ b/src/api/admin/handlers.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use axum::Router;
 use axum::routing::{get, post};
 
-use super::{backup, events};
+use super::{backup, compact, events};
 use crate::api::middleware;
 use crate::state::AppState;
 
@@ -20,6 +20,7 @@ pub fn app(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/events", get(events::event_stream))
         .route("/backup", post(backup::handle_backup))
+        .route("/compact", post(compact::handle_compact))
         .layer(axum::middleware::from_fn(middleware::admin_request_logging))
         .with_state(state)
 }
@@ -286,5 +287,33 @@ mod tests {
         let page = restored.list_jobs(opts).await.unwrap();
         assert_eq!(page.jobs.len(), 1);
         assert_eq!(page.jobs[0].payload, Some(serde_json::json!("backup_me")));
+    }
+
+    #[tokio::test]
+    async fn compact_endpoint_returns_ok() {
+        let (_, state) = test_state();
+
+        // Write some data so compaction has something to do.
+        state
+            .store
+            .enqueue(
+                now_millis(),
+                crate::store::EnqueueOptions::new("test", "q", serde_json::json!("hello")),
+            )
+            .await
+            .unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app(state)).await.unwrap() });
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("http://{addr}/compact"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), 204);
     }
 }

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -9,6 +9,7 @@
 //! that connects to it requires a license.
 
 pub mod backup;
+pub mod compact;
 pub mod events;
 mod handlers;
 mod types;

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! `zizq compact` subcommand.
+//!
+//! Connects to the admin API and triggers a full LSM compaction.
+
+use clap::Parser;
+
+use super::AdminClientArgs;
+
+/// Arguments for the `compact` subcommand.
+#[derive(Parser)]
+pub struct Args {
+    #[command(flatten)]
+    admin: AdminClientArgs,
+}
+
+/// Run the compact command.
+pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    args.admin.validate()?;
+
+    // No read/overall timeout — compaction on a large keyspace can take a
+    // while and the server doesn't return until it finishes.
+    let client = args.admin.build_http_client()?;
+    let endpoint_url = format!("{}/compact", args.admin.url.trim_end_matches('/'));
+
+    eprintln!("Requesting compaction from {}...", args.admin.url);
+
+    let response = client.post(&endpoint_url).send().await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("compact request failed: HTTP {status}: {body}").into());
+    }
+
+    eprintln!("Compaction complete.");
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@
 use clap::Parser;
 
 pub mod backup;
+pub mod compact;
 pub mod restore;
 pub mod serve;
 pub mod tls;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@
 
 use clap::{Parser, Subcommand};
 
-use zizq::commands::{backup, restore, serve, tls, top};
+use zizq::commands::{backup, compact, restore, serve, tls, top};
 use zizq::license::License;
 
 /// Struct used to handle command line arguments.
@@ -74,6 +74,10 @@ enum Command {
     ///
     /// Writes the backup contents to `--root-dir`, which must not exist.
     Restore(restore::Args),
+
+    /// Force a full LSM compaction on a running server to reclaim
+    /// disk/tombstone space.
+    Compact(compact::Args),
 }
 
 /// Resolve a license key value, reading from a file if `@`-prefixed.
@@ -123,6 +127,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         Some(Command::Tls(args)) => tls::run(args, &cli.root_dir).await,
         Some(Command::Backup(args)) => backup::run(args).await,
         Some(Command::Restore(args)) => restore::run(args, &cli.root_dir).await,
+        Some(Command::Compact(args)) => compact::run(args).await,
         None => {
             serve::run(
                 serve::Args::parse_from(std::env::args()),

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -1206,6 +1206,12 @@ pub struct StorageConfig {
     /// Optional per-operation commit mode for enqueue. When `None`,
     /// enqueue inherits `default_commit_mode`.
     pub enqueue_commit_mode: Option<CommitMode>,
+
+    /// After a bulk mutation affects at least this many records, force a
+    /// full LSM compaction to reclaim tombstones. Without this, leveled
+    /// compaction can leave large pockets of garbage in the upper levels
+    /// for a long time on quiet databases. Set to 0 to disable.
+    pub auto_compact_threshold: u64,
 }
 
 /// Default block cache capacity (256 MiB).
@@ -1242,6 +1248,11 @@ pub const DEFAULT_COMPLETED_RETENTION_MS: u64 = 0;
 /// Default retention period for dead jobs (milliseconds). 7 days.
 pub const DEFAULT_DEAD_RETENTION_MS: u64 = 604_800_000;
 
+/// Default threshold for auto-compacting after a bulk mutation. Bulk
+/// operations that mutate at least this many records trigger a full
+/// compaction once they commit.
+pub const DEFAULT_AUTO_COMPACT_THRESHOLD: u64 = 10_000;
+
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
@@ -1260,6 +1271,7 @@ impl Default for StorageConfig {
             },
             default_commit_mode: CommitMode::default(),
             enqueue_commit_mode: None,
+            auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
         }
     }
 }
@@ -1278,6 +1290,7 @@ impl StorageConfig {
     /// | `ZIZQ_L0_THRESHOLD`       | `l0_threshold`     |
     /// | `ZIZQ_DEFAULT_COMMIT_MODE` | `default_commit_mode` |
     /// | `ZIZQ_ENQUEUE_COMMIT_MODE` | `enqueue_commit_mode` |
+    /// | `ZIZQ_AUTO_COMPACT_THRESHOLD` | `auto_compact_threshold` |
     pub fn from_env() -> Result<Self, EnvConfigError> {
         let defaults = Self::default();
         Ok(Self {
@@ -1313,6 +1326,8 @@ impl StorageConfig {
                     });
                 }
             },
+            auto_compact_threshold: env_parse("ZIZQ_AUTO_COMPACT_THRESHOLD")?
+                .unwrap_or(defaults.auto_compact_threshold),
         })
     }
 }
@@ -2698,6 +2713,34 @@ impl Store {
         .await?
     }
 
+    /// Force a full LSM compaction of both keyspaces, reclaiming tombstones
+    /// that leveled compaction has left in upper levels.
+    ///
+    /// Leveled compaction triggers on level-size ratios, so after a large
+    /// bulk delete (or any operation that produces many tombstones without
+    /// matching live writes) the upper levels can sit on garbage for a long
+    /// time on a quiet database. A full compaction merges every level down
+    /// and drops tombstones whose seqnos are safe to GC.
+    ///
+    /// Runs on a blocking thread and may take seconds for large keyspaces.
+    /// Excludes other (background leveled) compactions while running, but
+    /// reads and writes at the LSM level proceed normally — they don't
+    /// touch the compaction lock. Concurrent zizq transactions also aren't
+    /// serialized against this since we bypass the txn writer lock.
+    //
+    // `major_compact` is `#[doc(hidden)]` in fjall 3.0.x / 3.1.x. It works
+    // and is the intended escape hatch for this use case, but the API is
+    // not formally stable yet; recheck on each fjall upgrade.
+    pub async fn compact_all(&self) -> Result<(), StoreError> {
+        let ks = self.ks.clone();
+        task::spawn_blocking(move || -> Result<(), StoreError> {
+            ks.data.inner().major_compact()?;
+            ks.index.inner().major_compact()?;
+            Ok(())
+        })
+        .await?
+    }
+
     /// Create a consistent backup of the database at the given path.
     ///
     /// Takes a read snapshot of the live database and copies all key/value
@@ -3663,6 +3706,14 @@ impl Store {
             let _ = event_tx.send(StoreEvent::JobDeleted { id: id.clone() });
         }
 
+        // Force a full compaction when we've written enough tombstones that
+        // leveled compaction would otherwise leave them sitting in upper
+        // levels on a quiet database.
+        let threshold = self.config.auto_compact_threshold;
+        if threshold > 0 && deleted_ids.len() as u64 >= threshold {
+            self.compact_all().await?;
+        }
+
         Ok(deleted_ids.len())
     }
 
@@ -3877,6 +3928,14 @@ impl Store {
 
         for diff in &diffs {
             diff.emit_events(&event_tx);
+        }
+
+        // See the equivalent block in `delete_jobs` — bulk patches that
+        // change indexed fields write tombstones to the index keyspace,
+        // and we want to reclaim those once the batch is large enough.
+        let threshold = self.config.auto_compact_threshold;
+        if threshold > 0 && diffs.len() as u64 >= threshold {
+            self.compact_all().await?;
         }
 
         Ok(diffs.len())
@@ -11078,6 +11137,74 @@ mod tests {
         opts.ids = [j1.id, "0000000000000000000000000".into()].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 1);
+    }
+
+    // --- compact_all + auto-compact ---
+
+    #[tokio::test]
+    async fn compact_all_succeeds_on_empty_store() {
+        let store = test_store();
+        store.compact_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn compact_all_succeeds_after_writes_and_deletes() {
+        let store = test_store();
+        let now = now_millis();
+
+        for _ in 0..50 {
+            store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(null)))
+                .await
+                .unwrap();
+        }
+        let count = store.delete_jobs(BulkDeleteOptions::new()).await.unwrap();
+        assert_eq!(count, 50);
+
+        store.compact_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_jobs_triggers_auto_compact_above_threshold() {
+        // Threshold = 5 means a 5-job delete should pass the trigger path.
+        // We can't easily observe major_compact ran from the public API,
+        // so the assertion is that delete_jobs still succeeds and returns
+        // the correct count when the auto-compact branch fires.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageConfig::default();
+        config.auto_compact_threshold = 5;
+        let store = Store::open(dir.path().join("data"), config).unwrap();
+        std::mem::forget(dir);
+
+        let now = now_millis();
+        for _ in 0..5 {
+            store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(null)))
+                .await
+                .unwrap();
+        }
+        let count = store.delete_jobs(BulkDeleteOptions::new()).await.unwrap();
+        assert_eq!(count, 5);
+    }
+
+    #[tokio::test]
+    async fn delete_jobs_skips_auto_compact_when_disabled() {
+        // threshold = 0 disables auto-compact entirely.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageConfig::default();
+        config.auto_compact_threshold = 0;
+        let store = Store::open(dir.path().join("data"), config).unwrap();
+        std::mem::forget(dir);
+
+        let now = now_millis();
+        for _ in 0..3 {
+            store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(null)))
+                .await
+                .unwrap();
+        }
+        let count = store.delete_jobs(BulkDeleteOptions::new()).await.unwrap();
+        assert_eq!(count, 3);
     }
 
     // --- patch_job ---


### PR DESCRIPTION
LSM databases manage write churn by merging and compacting data across levels as writes occur. In the meantime, dead entries (tombstones) accumulate within the data and lead to a progressive slow down until they are merged out during compaction. Ordinarily (FIFO throughput) this goes largely unnoticed because compaction runs incrementally and frequently enough that tombstones don't accumulate enough for it to be an issue.

But when a massive write operation occurs that generates a flood of tombstones, this incremental compaction can't keep up and therefore tombstones can stick around for a long time until a huge number of other write occur to trigger enough compactions and reclaim that space. As as extreme example, if the database contains 10M jobs and all 10M are deleted in a bulk operation, that creates 10M dead entries. Successive accesses of the database need to scan over and skip these tombstones, even though for practical purposes the database is empty.

We now force a full compaction run any time a bulk delete or a bulk update touches > 10K jobs. This could potentially take a while on a large database, but it is non-blocking to other writes and avoids the issue where huge volumes of tombstones accumulate after such bulk operations.

Additionally, an Admin-level operation `zizq compact` now exists which is intended for situations where you know you want compaction to occur but don't want to wait for it to naturally happen.