### PR TITLE
Implement `DELETE /crons` and `POST /reset`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added `POST /compact` admin endpoint to trigger a full compaction on
   demand. Returns 204 No Content on success.
 - Added `zizq compact` CLI subcommand that calls the admin endpoint.
+- Added `DELETE /crons` to wipe every cron group in one call (Pro).
+- Added `POST /reset` to wipe every cron group and every job in a single
+  request. Returns 204 No Content. Useful for testing.
 
 ## 0.3.1
 

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -402,7 +402,10 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/jobs/{id}/failure", post(report_failure))
         .route("/jobs/{id}/errors", get(list_errors))
         .route("/jobs/{id}/errors/{attempt}", get(get_error))
-        .route("/crons", get(list_cron_groups))
+        .route(
+            "/crons",
+            get(list_cron_groups).delete(bulk_delete_cron_groups),
+        )
         .route(
             "/crons/{name}",
             get(get_cron_group)
@@ -418,6 +421,7 @@ pub fn app(state: Arc<AppState>) -> Router {
                 .patch(patch_cron_entry)
                 .delete(delete_cron_entry),
         )
+        .route("/reset", post(reset))
         .fallback(not_found)
         .layer(axum::middleware::from_fn(
             middleware::primary_request_logging,
@@ -2647,6 +2651,43 @@ async fn add_cron_entry(
     }
 }
 
+/// Handle `DELETE /crons` — delete every cron group in a single batch.
+async fn bulk_delete_cron_groups(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::CronScheduling)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    match state.store.delete_cron_groups().await {
+        Ok(count) => {
+            tracing::debug!(count, "bulk delete cron groups completed");
+            respond(
+                fmt,
+                StatusCode::OK,
+                &serde_json::json!({ "deleted": count }),
+            )
+        }
+        Err(e) => {
+            tracing::error!(%e, "bulk_delete_cron_groups failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
 /// Handle `DELETE /crons/{name}` — delete a cron group and all its entries.
 async fn delete_cron_group(
     AcceptFormat(fmt): AcceptFormat,
@@ -2683,6 +2724,42 @@ async fn delete_cron_group(
             )
         }
     }
+}
+
+/// Handle `POST /reset` — wipe every cron group and every job.
+///
+/// Composes `Store::delete_cron_groups` + `Store::delete_jobs` (no filter),
+/// so existing event subscribers (cron scheduler, take streams, etc.) see
+/// the normal per-deletion events without needing any reset-specific
+/// handling.
+async fn reset(AcceptFormat(fmt): AcceptFormat, State(state): State<Arc<AppState>>) -> Response {
+    if let Err(e) = state.store.delete_cron_groups().await {
+        tracing::error!(%e, "reset: delete_cron_groups failed");
+        return respond(
+            fmt,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &ErrorResponse {
+                error: "internal error".into(),
+            },
+        );
+    }
+
+    if let Err(e) = state
+        .store
+        .delete_jobs(store::BulkDeleteOptions::new())
+        .await
+    {
+        tracing::error!(%e, "reset: delete_jobs failed");
+        return respond(
+            fmt,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &ErrorResponse {
+                error: "internal error".into(),
+            },
+        );
+    }
+
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Fallback handler for unmatched routes.
@@ -7420,6 +7497,53 @@ mod tests {
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 
+    #[tokio::test]
+    async fn cron_bulk_delete_removes_all_groups() {
+        let app = pro_app();
+
+        for name in ["g1", "g2"] {
+            let req = cron_put(
+                name,
+                &serde_json::json!({
+                    "entries": [{
+                        "name": "e1",
+                        "expression": "* * * * *",
+                        "job": { "type": "t", "queue": "q", "payload": {} }
+                    }]
+                }),
+            );
+            let res = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+        }
+
+        let req = empty_request("DELETE", "/crons");
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["deleted"], 2);
+
+        let req = empty_request("GET", "/crons");
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["crons"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn cron_bulk_delete_empty_returns_zero() {
+        let req = empty_request("DELETE", "/crons");
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["deleted"], 0);
+    }
+
+    #[tokio::test]
+    async fn cron_bulk_delete_returns_403_on_free_tier() {
+        let req = empty_request("DELETE", "/crons");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
     fn cron_patch(name: &str, body: &serde_json::Value) -> Request {
         json_request("PATCH", &format!("/crons/{name}"), body)
     }
@@ -7898,5 +8022,69 @@ mod tests {
         let req = cron_patch_entry("default", "e1", &serde_json::json!({ "paused": true }));
         let res = test_app().oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    // --- POST /reset ---
+
+    #[tokio::test]
+    async fn reset_clears_jobs_and_crons() {
+        let app = pro_app();
+
+        // Enqueue a job.
+        let req = json_request(
+            "POST",
+            "/jobs",
+            &serde_json::json!({ "type": "t", "queue": "q", "payload": {} }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        // Create a cron group.
+        let req = cron_put(
+            "g1",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "* * * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Reset.
+        let req = empty_request("POST", "/reset");
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        // Jobs gone.
+        let req = empty_request("GET", "/jobs/count");
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 0);
+
+        // Crons gone.
+        let req = empty_request("GET", "/crons");
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["crons"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn reset_is_noop_on_empty_store() {
+        let req = empty_request("POST", "/reset");
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn reset_works_on_free_tier() {
+        // /reset is unrestricted; the cron delete step internally finds
+        // nothing on a free tier (since crons couldn't be created) and
+        // the job delete proceeds normally.
+        let req = empty_request("POST", "/reset");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/src/store/cron.rs
+++ b/src/store/cron.rs
@@ -127,6 +127,11 @@ impl CronScheduleIndex {
         }
     }
 
+    /// Drop every entry from the index.
+    pub fn clear(&self) {
+        self.inner.lock().unwrap().clear();
+    }
+
     /// Peek at the earliest due timestamp, if any.
     pub fn next_due_at(&self) -> Option<u64> {
         let map = self.inner.lock().unwrap();

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -4493,6 +4493,66 @@ impl Store {
         .await?
     }
 
+    /// Delete every cron group and entry in a single transaction.
+    ///
+    /// Returns the number of groups deleted. Emits a single
+    /// `CronScheduleChanged` event regardless of how many groups were
+    /// removed.
+    pub async fn delete_cron_groups(&self) -> Result<usize, StoreError> {
+        let ks = self.ks.clone();
+        let cron_index = self.cron_index.clone();
+        let event_tx = self.event_tx.clone();
+
+        let count = task::spawn_blocking(move || -> Result<usize, StoreError> {
+            let data: &fjall::Keyspace = ks.data.as_ref();
+            let start: Vec<u8> = vec![RecordKind::Cron as u8];
+            let end: Vec<u8> = vec![RecordKind::Cron as u8 + 1];
+
+            let mut tx = ks.write_tx();
+            let mut groups_seen: HashSet<Vec<u8>> = HashSet::new();
+
+            for guard in data.range::<Vec<u8>, _>((Bound::Included(start), Bound::Excluded(end))) {
+                let (key, _) = guard.into_inner()?;
+                let key_bytes = key.as_ref();
+
+                // Key layout: C{group}\0... — the group-meta key is C{group}
+                // (no trailing \0). We dedupe by the prefix up to and
+                // including the first \0 (or the whole key for the meta).
+                let group_end = key_bytes[1..]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .map(|p| 1 + p)
+                    .unwrap_or(key_bytes.len());
+                groups_seen.insert(key_bytes[..group_end].to_vec());
+
+                tx.remove(&ks.data, key_bytes);
+            }
+
+            if groups_seen.is_empty() {
+                return Ok(0);
+            }
+
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            cron_index.clear();
+
+            Ok(groups_seen.len())
+        })
+        .await??;
+
+        if count > 0 {
+            let _ = event_tx.send(StoreEvent::CronScheduleChanged);
+        }
+
+        // Reclaim tombstone space when the wipe was large enough.
+        let threshold = self.config.auto_compact_threshold;
+        if threshold > 0 && count as u64 >= threshold {
+            self.compact_all().await?;
+        }
+
+        Ok(count)
+    }
+
     /// Delete a cron group and all its entries.
     ///
     /// Returns `true` if the group existed and was deleted, `false` if it
@@ -13090,6 +13150,44 @@ mod tests {
     async fn delete_cron_group_returns_false_for_missing() {
         let store = test_store();
         assert!(!store.delete_cron_group("nonexistent").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_cron_groups_returns_zero_for_empty_store() {
+        let store = test_store();
+        let count = store.delete_cron_groups().await.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_cron_groups_removes_all_groups_and_entries() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        for name in &["g1", "g2", "g3"] {
+            store
+                .replace_cron_group(
+                    name,
+                    ReplaceCronGroupOptions {
+                        paused: None,
+                        entries: vec![
+                            cron_entry_opts("e1", "* * * * *", "q", "test"),
+                            cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
+                        ],
+                    },
+                    now,
+                )
+                .await
+                .unwrap();
+        }
+
+        let count = store.delete_cron_groups().await.unwrap();
+        assert_eq!(count, 3);
+
+        assert!(store.list_cron_groups().await.unwrap().is_empty());
+        assert!(store.cron_next_due_at().is_none());
+        assert!(store.get_cron_entry("g1", "e1").await.unwrap().is_none());
+        assert!(store.get_cron_group("g2").await.unwrap().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Previously it was possible to wipe the database by doing a simple `DELETE /jobs` but now with cron schedules in addition to jobs on queues we also have to delete all those cron schedules. This adds a bulk `DELETE /crons`, and also adds a broader `POST /reset` operation, which are both useful for testing purposes.