### PR TITLE
Add Pause/Resume to `zizq top` to Freeze the List.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@
 - Added `DELETE /crons` to wipe every cron group in one call (Pro).
 - Added `POST /reset` to wipe every cron group and every job in a single
   request. Returns 204 No Content. Useful for testing.
+- Press `p` in `zizq top` to pause/resume the live job lists. Header totals
+  keep updating; the job rows freeze where they were so you can scroll
+  through them without the view shifting under your cursor. Navigation
+  keys (`j`/`k`/`g`/`G`/PgUp/PgDn) clamp to the frozen buffer rather than
+  the server-side total. Detail toggle is disabled while paused. A "Resume
+  to scroll further" hint appears at the buffer edges.
+- Fixed `zizq top`: pressing `G` (go to end) on a live, churning list could
+  leave the view blank because the in-flight Subscribe response landed with
+  an offset that no longer covered the cursor. The TUI now requeues a
+  Subscribe when a stale snapshot leaves the cursor outside the buffer.
+- Fixed admin WebSocket: when the store-event broadcast lagged (e.g. during
+  a large bulk enqueue), the server resynced by re-seeding the connection
+  with default subscriptions and `detail = false`, silently demoting the
+  client's prior `SetDetailLevel{detail: true}`. The resync now preserves
+  the connection's detail flag and subscription windows so payloads keep
+  flowing across all tabs in `zizq top`.
 
 ## 0.3.1
 

--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -203,8 +203,11 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                             }
                         }
                         Err(broadcast::error::RecvError::Lagged(_)) => {
-                            // Missed events — re-query full snapshot.
-                            match send_initial_snapshot(&send_state, &mut sender).await {
+                            // Missed events — re-query full snapshot, but
+                            // preserve the client's existing subscriptions
+                            // and detail flag so the resync doesn't silently
+                            // demote them to defaults.
+                            match resync_snapshot(&send_state, &mut sender, &conn).await {
                                 Ok(new_conn) => conn = new_conn,
                                 Err(e) => {
                                     tracing::error!(%e, "admin ws: resync snapshot failed");
@@ -287,7 +290,26 @@ async fn send_initial_snapshot(
         }
     };
 
-    send_snapshot_with_subs(state, sender, make_sub(), make_sub(), make_sub()).await
+    send_snapshot_with_subs(state, sender, make_sub(), make_sub(), make_sub(), false).await
+}
+
+/// Re-send a full snapshot using the existing connection's subscription
+/// windows and detail flag, used to recover from a `broadcast` lag without
+/// losing the client's prior `SetDetailLevel` / `Subscribe` choices.
+async fn resync_snapshot(
+    state: &AppState,
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    conn: &ConnectionState,
+) -> Result<ConnectionState, String> {
+    send_snapshot_with_subs(
+        state,
+        sender,
+        conn.ready_sub.clone(),
+        conn.in_flight_sub.clone(),
+        conn.scheduled_sub.clone(),
+        conn.detail,
+    )
+    .await
 }
 
 async fn send_snapshot_with_subs(
@@ -296,6 +318,7 @@ async fn send_snapshot_with_subs(
     ready_sub: Subscription,
     in_flight_sub: Subscription,
     scheduled_sub: Subscription,
+    detail: bool,
 ) -> Result<ConnectionState, String> {
     // Build the initial in-flight ID set from a full query.
     let mut in_flight_jobs = state
@@ -329,7 +352,7 @@ async fn send_snapshot_with_subs(
         ready_sub,
         in_flight_sub,
         scheduled_sub,
-        detail: false,
+        detail,
     };
 
     let event = build_snapshot(&state.store, &mut conn).await;

--- a/src/commands/top/app.rs
+++ b/src/commands/top/app.rs
@@ -99,6 +99,11 @@ pub struct App {
     pub list_states: [ListState; 3],
     pub viewport_height: usize,
     pub show_detail: bool,
+    /// When true, the displayed job lists are frozen at the snapshot they
+    /// held at the moment pause was toggled on. Header totals/heartbeat
+    /// fields keep updating; incoming `JobChanged` / `JobSnapshot` events
+    /// don't mutate the row buffers. Toggled by `p`.
+    pub paused: bool,
     pub ws_tx: Option<mpsc::Sender<String>>,
 }
 
@@ -123,6 +128,7 @@ impl Clone for App {
             list_states: self.list_states.clone(),
             viewport_height: self.viewport_height,
             show_detail: self.show_detail,
+            paused: self.paused,
             ws_tx: self.ws_tx.clone(),
         }
     }
@@ -149,6 +155,7 @@ impl App {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         }
     }
@@ -209,6 +216,12 @@ impl App {
     /// Deduplicates: won't re-send the same (offset, limit) for the same tab.
     fn maybe_prefetch(&mut self) {
         if self.subscription_limit.is_some() {
+            return;
+        }
+        // While paused the visible buffer is intentionally frozen — no
+        // prefetching, so scrolling clamps at whatever rows were already
+        // present at the moment of pause.
+        if self.paused {
             return;
         }
         let vh = self.viewport_height;
@@ -300,8 +313,30 @@ impl App {
                 self.go_to_end();
             }
             Event::ToggleDetail => {
+                // Detail level can't be changed while paused — the visible
+                // payloads are whatever was in the frozen snapshot.
+                if self.paused {
+                    return false;
+                }
                 self.show_detail = !self.show_detail;
                 self.send_detail_level();
+            }
+            Event::TogglePause => {
+                self.paused = !self.paused;
+                if !self.paused {
+                    // Resync the active tab on unpause so the visible rows
+                    // reflect current truth. Other tabs will refresh lazily
+                    // on next prefetch or when they become active.
+                    let tab = self.active_tab;
+                    let ls = &self.list_states[tab.idx()];
+                    if let Some((offset, limit)) = ls.last_subscribe {
+                        self.send_subscribe(tab, offset, limit);
+                    } else if self.viewport_height > 0 {
+                        let limit = self.viewport_height * 3;
+                        let offset = ls.cursor.saturating_sub(limit / 2);
+                        self.send_subscribe(tab, offset, limit);
+                    }
+                }
             }
             Event::ServerConnecting => {
                 self.status = ConnectionStatus::Connecting;
@@ -318,6 +353,10 @@ impl App {
             Event::ServerHeartbeat { server } => {
                 self.apply_server_status(server);
                 self.apply_follow_bottom();
+                // The follow-bottom clamp may have moved the cursor outside
+                // the current buffer (e.g. after G during list churn), so
+                // re-check whether we need a fresh window.
+                self.maybe_prefetch();
             }
             Event::ServerJobSnapshot {
                 server,
@@ -326,10 +365,20 @@ impl App {
                 scheduled,
             } => {
                 self.apply_server_status(server);
+                // Header totals/server status always update; the row
+                // windows are held frozen while paused.
+                if self.paused {
+                    return false;
+                }
                 self.apply_job_window(Tab::Ready, ready);
                 self.apply_job_window(Tab::InFlight, in_flight);
                 self.apply_job_window(Tab::Scheduled, scheduled);
                 self.apply_follow_bottom();
+                // A snapshot can land with an offset that pre-dates rapid
+                // server-side churn (jobs were enqueued/drained while the
+                // Subscribe was in flight), leaving the cursor outside the
+                // new buffer. Trigger another prefetch round so we converge.
+                self.maybe_prefetch();
             }
             Event::ServerJobChanged {
                 server,
@@ -338,6 +387,9 @@ impl App {
                 job,
             } => {
                 self.apply_server_status(server);
+                if self.paused {
+                    return false;
+                }
                 match status {
                     JobChangeStatus::Ready => {
                         if let Some(job) = job {
@@ -389,6 +441,9 @@ impl App {
                     }
                 }
                 self.apply_follow_bottom();
+                // Each JobChanged can move the follow-bottom cursor; same
+                // reasoning as the snapshot/heartbeat paths.
+                self.maybe_prefetch();
             }
             Event::ServerDisconnected => {
                 self.status = ConnectionStatus::Disconnected;
@@ -423,8 +478,41 @@ impl App {
         }
     }
 
+    /// Cursor navigation bounds for the active tab.
+    ///
+    /// While live this is the full server-side range. While paused it
+    /// clamps to the rows currently in the buffer so the user can only
+    /// scroll through the frozen snapshot. Returns `None` when there's
+    /// nothing to navigate.
+    fn cursor_bounds(&self) -> Option<(usize, usize)> {
+        if !self.paused {
+            let total = self.effective_total();
+            if total == 0 {
+                return None;
+            }
+            return Some((0, total - 1));
+        }
+        let tab = self.active_tab;
+        let ls = &self.list_states[tab.idx()];
+        let buffer_size = match tab {
+            Tab::Ready => self.ready_jobs.len(),
+            Tab::InFlight => self.in_flight_jobs.len(),
+            Tab::Scheduled => self.scheduled_jobs.len(),
+        };
+        if buffer_size == 0 {
+            return None;
+        }
+        Some((ls.buffer_offset, ls.buffer_offset + buffer_size - 1))
+    }
+
     /// Clamp cursor/scroll positions and apply follow-bottom tracking.
     fn apply_follow_bottom(&mut self) {
+        // While paused, the cursor is bounded to the frozen buffer (see
+        // `cursor_bounds`) — letting `follow_bottom` and the live total
+        // drag it around would break that contract.
+        if self.paused {
+            return;
+        }
         let cap = self.subscription_limit;
         for tab in [Tab::InFlight, Tab::Ready, Tab::Scheduled] {
             let raw_total = match tab {
@@ -466,12 +554,11 @@ impl App {
     }
 
     fn scroll_up(&mut self) {
-        let total = self.effective_total();
-        if total == 0 {
+        let Some((min, _)) = self.cursor_bounds() else {
             return;
-        }
+        };
         let ls = &mut self.list_states[self.active_tab.idx()];
-        if ls.cursor > 0 {
+        if ls.cursor > min {
             ls.cursor -= 1;
         }
         if ls.cursor < ls.scroll_pos {
@@ -482,29 +569,32 @@ impl App {
     }
 
     fn scroll_down(&mut self) {
-        let total = self.effective_total();
-        if total == 0 {
+        let Some((_, max)) = self.cursor_bounds() else {
             return;
-        }
+        };
         let ls = &mut self.list_states[self.active_tab.idx()];
-        if ls.cursor < total - 1 {
+        if ls.cursor < max {
             ls.cursor += 1;
         }
         if self.viewport_height > 0 && ls.cursor >= ls.scroll_pos + self.viewport_height {
             ls.scroll_pos = ls.cursor - self.viewport_height + 1;
         }
-        ls.follow_bottom = ls.cursor == total - 1;
+        // `follow_bottom` only makes sense while live — paused scrolling
+        // never wants the cursor pulled toward the server-side bottom.
+        ls.follow_bottom = !self.paused && ls.cursor == max;
         self.maybe_prefetch();
     }
 
     fn page_up(&mut self) {
-        let total = self.effective_total();
-        if total == 0 || self.viewport_height == 0 {
+        let Some((min, _)) = self.cursor_bounds() else {
+            return;
+        };
+        if self.viewport_height == 0 {
             return;
         }
         let ls = &mut self.list_states[self.active_tab.idx()];
         let jump = self.viewport_height.saturating_sub(1).max(1);
-        ls.cursor = ls.cursor.saturating_sub(jump);
+        ls.cursor = ls.cursor.saturating_sub(jump).max(min);
         if ls.cursor < ls.scroll_pos {
             ls.scroll_pos = ls.cursor;
         }
@@ -513,43 +603,45 @@ impl App {
     }
 
     fn page_down(&mut self) {
-        let total = self.effective_total();
-        if total == 0 || self.viewport_height == 0 {
+        let Some((_, max)) = self.cursor_bounds() else {
+            return;
+        };
+        if self.viewport_height == 0 {
             return;
         }
         let ls = &mut self.list_states[self.active_tab.idx()];
         let jump = self.viewport_height.saturating_sub(1).max(1);
-        ls.cursor = (ls.cursor + jump).min(total - 1);
+        ls.cursor = (ls.cursor + jump).min(max);
         if ls.cursor >= ls.scroll_pos + self.viewport_height {
             ls.scroll_pos = ls.cursor - self.viewport_height + 1;
         }
-        ls.follow_bottom = ls.cursor == total - 1;
+        ls.follow_bottom = !self.paused && ls.cursor == max;
         self.maybe_prefetch();
     }
 
     fn go_to_start(&mut self) {
-        let total = self.effective_total();
-        if total == 0 {
+        let Some((min, _)) = self.cursor_bounds() else {
             return;
-        }
+        };
         let ls = &mut self.list_states[self.active_tab.idx()];
-        ls.cursor = 0;
-        ls.scroll_pos = 0;
+        ls.cursor = min;
+        ls.scroll_pos = min;
         ls.follow_bottom = false;
         self.maybe_prefetch();
     }
 
     fn go_to_end(&mut self) {
-        let total = self.effective_total();
-        if total == 0 {
+        let Some((_, max)) = self.cursor_bounds() else {
             return;
-        }
+        };
         let ls = &mut self.list_states[self.active_tab.idx()];
-        ls.cursor = total - 1;
-        if self.viewport_height > 0 && ls.cursor >= self.viewport_height {
-            ls.scroll_pos = ls.cursor - self.viewport_height + 1;
+        ls.cursor = max;
+        if self.viewport_height > 0 && ls.cursor + 1 >= self.viewport_height {
+            ls.scroll_pos = ls.cursor + 1 - self.viewport_height;
+        } else {
+            ls.scroll_pos = 0;
         }
-        ls.follow_bottom = true;
+        ls.follow_bottom = !self.paused;
         self.maybe_prefetch();
     }
 }
@@ -965,5 +1057,316 @@ mod tests {
         });
 
         assert!(app.scheduled_jobs.is_empty());
+    }
+
+    // ── Stale-snapshot prefetch ─────────────────────────────────────
+
+    /// When a snapshot lands with an offset that no longer covers the
+    /// cursor (because the list shifted while a Subscribe was in flight),
+    /// the app must immediately request another window. Otherwise the
+    /// render falls through to empty until the user keypresses again.
+    /// This is the bug behind G producing a blank list under churn.
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_snapshot_triggers_followup_prefetch() {
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.set_ws_tx(tx);
+        app.viewport_height = 20;
+        app.active_tab = Tab::Ready;
+
+        // Pretend the user pressed G with the server reporting 1000 ready
+        // jobs but our local buffer holding rows 100..160.
+        let mut srv = default_server();
+        srv.total_ready = 1000;
+        app.handle_event(Event::ServerHeartbeat {
+            server: srv.clone(),
+        });
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv.clone(),
+            ready: JobWindow {
+                offset: 100,
+                items: (100..160).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+        app.handle_event(Event::GoToEnd);
+
+        // Drain whatever subscribes the events above produced.
+        while rx.try_recv().is_ok() {}
+
+        // Now simulate a stale snapshot landing: server total has dropped
+        // to 500, and the requested window came back as offset=969 with
+        // zero items because that range no longer exists.
+        srv.total_ready = 500;
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv,
+            ready: JobWindow {
+                offset: 969,
+                items: vec![],
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+
+        // The fix should have queued another Subscribe so the buffer can
+        // catch up with the new cursor position (499, the new bottom).
+        let msg = rx.try_recv().expect("expected a follow-up Subscribe");
+        assert!(
+            msg.contains("\"type\":\"subscribe\"") && msg.contains("\"list\":\"ready\""),
+            "expected a Subscribe to the ready list, got: {msg}"
+        );
+    }
+
+    // ── Pause ───────────────────────────────────────────────────────
+
+    #[test]
+    fn toggle_pause_flips_paused_flag() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        assert!(!app.paused);
+
+        app.handle_event(Event::TogglePause);
+        assert!(app.paused);
+
+        app.handle_event(Event::TogglePause);
+        assert!(!app.paused);
+    }
+
+    #[test]
+    fn paused_ignores_job_changed_mutations() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(ready_event("j1", 0));
+        assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
+
+        app.handle_event(Event::TogglePause);
+
+        // These should not mutate the ready list.
+        app.handle_event(ready_event("j2", 0));
+        app.handle_event(Event::ServerJobChanged {
+            server: default_server(),
+            id: "j1".into(),
+            status: JobChangeStatus::ReadyRemoved,
+            job: None,
+        });
+
+        assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
+    }
+
+    #[test]
+    fn paused_ignores_snapshot_windows_but_keeps_server_status() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(ready_event("j1", 0));
+        app.handle_event(Event::TogglePause);
+
+        let mut srv = default_server();
+        srv.total_ready = 999;
+        srv.uptime_ms = 12345;
+
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv,
+            ready: JobWindow {
+                offset: 0,
+                items: vec![job("snap", 0, None)],
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+
+        // Row list stays frozen.
+        assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
+        // Header / totals continue to update.
+        assert_eq!(app.total_ready, 999);
+        assert_eq!(app.server_uptime_ms, Some(12345));
+    }
+
+    #[test]
+    fn paused_heartbeat_still_updates_server_status() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::TogglePause);
+
+        let mut srv = default_server();
+        srv.uptime_ms = 99_999;
+        app.handle_event(Event::ServerHeartbeat { server: srv });
+
+        assert_eq!(app.server_uptime_ms, Some(99_999));
+    }
+
+    /// While paused, navigation must stay inside whatever rows are
+    /// currently in the buffer. The server-side total is irrelevant —
+    /// the user is looking at a frozen subset.
+    #[test]
+    fn paused_g_jumps_to_buffer_end_not_server_total() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.viewport_height = 20;
+        app.active_tab = Tab::Ready;
+
+        // Server claims 1000 ready jobs but the local buffer holds only
+        // 20 of them, anchored at offset 100.
+        let mut srv = default_server();
+        srv.total_ready = 1000;
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv,
+            ready: JobWindow {
+                offset: 100,
+                items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+
+        app.handle_event(Event::TogglePause);
+        app.handle_event(Event::GoToEnd);
+
+        // Last buffer row is index 119, not 999.
+        let ls = &app.list_states[Tab::Ready.idx()];
+        assert_eq!(ls.cursor, 119);
+        assert!(
+            !ls.follow_bottom,
+            "follow_bottom should not stick when paused"
+        );
+    }
+
+    #[test]
+    fn paused_g_then_g_lower_jumps_to_buffer_start() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.viewport_height = 20;
+        app.active_tab = Tab::Ready;
+
+        let mut srv = default_server();
+        srv.total_ready = 1000;
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv,
+            ready: JobWindow {
+                offset: 100,
+                items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+
+        app.handle_event(Event::TogglePause);
+        app.handle_event(Event::GoToStart);
+
+        // First buffer row is index 100, not 0.
+        let ls = &app.list_states[Tab::Ready.idx()];
+        assert_eq!(ls.cursor, 100);
+    }
+
+    #[test]
+    fn paused_scroll_down_clamps_at_buffer_end() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.viewport_height = 20;
+        app.active_tab = Tab::Ready;
+
+        let mut srv = default_server();
+        srv.total_ready = 1000;
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv,
+            ready: JobWindow {
+                offset: 100,
+                items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+
+        // Position cursor at the last buffer row, then pause.
+        app.handle_event(Event::GoToEnd);
+        // GoToEnd while live sets cursor=999; clamp at buffer once we pause.
+        app.handle_event(Event::TogglePause);
+        app.list_states[Tab::Ready.idx()].cursor = 119;
+
+        // j past the buffer must not move the cursor.
+        app.handle_event(Event::ScrollDown);
+        let ls = &app.list_states[Tab::Ready.idx()];
+        assert_eq!(ls.cursor, 119);
+    }
+
+    #[test]
+    fn paused_heartbeat_does_not_drag_cursor_to_server_bottom() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.viewport_height = 20;
+        app.active_tab = Tab::Ready;
+
+        // Buffer covers 100..120.
+        let mut srv = default_server();
+        srv.total_ready = 1000;
+        app.handle_event(Event::ServerJobSnapshot {
+            server: srv.clone(),
+            ready: JobWindow {
+                offset: 100,
+                items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+            },
+            in_flight: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+            scheduled: JobWindow {
+                offset: 0,
+                items: vec![],
+            },
+        });
+
+        // Press G live (sets follow_bottom = true, cursor near server end).
+        app.handle_event(Event::GoToEnd);
+        app.handle_event(Event::TogglePause);
+        // Snap cursor back inside buffer to simulate the user navigating.
+        app.list_states[Tab::Ready.idx()].cursor = 110;
+
+        // Heartbeat with churn — server now has 2000 ready jobs.
+        srv.total_ready = 2000;
+        app.handle_event(Event::ServerHeartbeat { server: srv });
+
+        // The follow-bottom logic must NOT have fired while paused.
+        let ls = &app.list_states[Tab::Ready.idx()];
+        assert_eq!(ls.cursor, 110);
+    }
+
+    #[test]
+    fn paused_toggle_detail_is_noop() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        assert!(!app.show_detail);
+        app.handle_event(Event::TogglePause);
+
+        app.handle_event(Event::ToggleDetail);
+
+        // Detail level didn't change because the snapshot was frozen.
+        assert!(!app.show_detail);
     }
 }

--- a/src/commands/top/events.rs
+++ b/src/commands/top/events.rs
@@ -38,6 +38,8 @@ pub enum Event {
     GoToEnd,
     /// Toggle the detail panel.
     ToggleDetail,
+    /// Toggle paused state — freeze/unfreeze the live job lists.
+    TogglePause,
     /// Suspend the process (Ctrl-Z).
     Suspend,
     /// Server connection attempt in progress.
@@ -75,6 +77,7 @@ impl Event {
                 | Event::ScrollLeft
                 | Event::ScrollRight
                 | Event::ToggleDetail
+                | Event::TogglePause
         )
     }
 
@@ -135,6 +138,9 @@ pub fn read_terminal_events(tx: mpsc::Sender<Event>) {
                         }
                         (KeyCode::Char('i'), _) => {
                             let _ = tx.blocking_send(Event::ToggleDetail);
+                        }
+                        (KeyCode::Char('p'), _) => {
+                            let _ = tx.blocking_send(Event::TogglePause);
                         }
                         (KeyCode::Char('g'), _) => {
                             let _ = tx.blocking_send(Event::GoToStart);

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1034
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -11,4 +12,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1292
 expression: "render_to_string(&app, 160, 30)"
 ---
   Zizq 0.1.0
@@ -31,4 +32,4 @@ expression: "render_to_string(&app, 160, 30)"
   Type                    generate_annual_report_email                             "to": "user@example.com",
   Priority                0                                                        "urgent": true
   Status                  in_flight                                              }
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1096
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -11,4 +12,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1346
 expression: "render_to_string(&app, 120, 8)"
 ---
   Zizq 0.1.0
@@ -9,4 +10,4 @@ expression: "render_to_string(&app, 120, 8)"
 
 
    In-Flight   Ready   Scheduled
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1319
 expression: "render_to_string(&app, 120, 8)"
 ---
   Zizq 0.1.0
@@ -9,4 +10,4 @@ expression: "render_to_string(&app, 120, 8)"
 
   Depth[                                                                                                       0 jobs]
    In-Flight   Ready   Scheduled
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1444
 expression: "render_to_string(&app, 120, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 120, 12)"
 
                                          Display is currently capped at 10 jobs.
                                        Upgrade to a pro license to see everything.
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1395
 expression: "render_to_string(&app, 80, 20)"
 ---
   Zizq 0.1.0
@@ -21,4 +22,4 @@ expression: "render_to_string(&app, 80, 20)"
                      Display is currently capped at 10 jobs.
                    Upgrade to a pro license to see everything.
 
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1237
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
 70a2bb46e1f07a0c908d7a2bb40          0 default                  3s          1 ge
 70a1aa35d0e06b0b807c691aa30          0 billing               2m30s          3 ch
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1244
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
      ID   PRIORITY QUEUE              DURATION   ATTEMPTS TYPE
 7a2bb40          0 default                  3s          1 generate_annual_report
 691aa30          0 billing               2m30s          3 charge_subscription
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1251
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
 UEUE              DURATION   ATTEMPTS TYPE
 efault                  3s          1 generate_annual_report_email
 illing               2m30s          3 charge_subscription
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_wide.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1231
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                        DURATION   ATTEMPTS TYPE
 70a2bb46e1f07a0c908d7a2bb40          0 default                            3s          1 generate_annual_report_email
 70a1aa35d0e06b0b807c691aa30          0 billing                         2m30s          3 charge_subscription
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_at_buffer_edge_shows_resume_hint.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_at_buffer_edge_shows_resume_hint.snap
@@ -1,0 +1,17 @@
+---
+source: src/commands/top/ui.rs
+assertion_line: 1086
+expression: "render_to_string(&app, 90, 12)"
+---
+  Zizq 0.1.0
+● Connected 127.0.0.1:8901   PAUSED
+  Server version: ?, Uptime: ?
+  Queue: 0 in-flight, 2 ready, 0 scheduled
+         ▼
+  Depth[││                                                                       2 jobs]
+         ▲
+   In-Flight   Ready   Scheduled
+                         ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TYPE
+                         j1          0 queue1                    -          0 type1
+                         j2          0 queue1                    -          0 type1
+ Tab Change Tab  i Info  p Resume  q Quit   ↓ Resume to scroll further

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_shows_indicator_and_swaps_help_labels.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_shows_indicator_and_swaps_help_labels.snap
@@ -1,15 +1,15 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1069
+assertion_line: 1042
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
-● Connected 127.0.0.1:8901
-  Server version: 1.0.0, Uptime: 1m5s
+● Connected 127.0.0.1:8901   PAUSED
+  Server version: ?, Uptime: ?
   Queue: 0 in-flight, 0 ready, 0 scheduled
 
   Depth[                                           0 jobs]
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Resume  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1225
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TY
 70a3cc87a1f0890da08e8b3cc86          0 default                  5s          0 ge
 70a3dd47c2308a1fb09e9c4dd97          5 default                1m2s          2 se
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1219
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                           DELAY   ATTEMPTS TYPE
 70a3cc87a1f0890da08e8b3cc86          0 default                            5s          0 generate_annual_report_email
 70a3dd47c2308a1fb09e9c4dd97          5 default                          1m2s          2 send_welcome_email
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1263
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                   DUE   ATTEMPTS TY
 70a4ee89f2f09a1eb0af9d5ee80          0 default               3m52s          0 se
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                  1h          1 ge
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
@@ -1,5 +1,6 @@
 ---
 source: src/commands/top/ui.rs
+assertion_line: 1257
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -13,4 +14,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                             DUE   ATTEMPTS TYPE
 70a4ee89f2f09a1eb0af9d5ee80          0 default                         3m52s          0 send_reminder_email
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                            1h          1 generate_quarterly_report
- Tab Change Tab  i Info  q Quit
+ Tab Change Tab  i Info  p Pause  q Quit

--- a/src/commands/top/ui.rs
+++ b/src/commands/top/ui.rs
@@ -70,12 +70,23 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         ConnectionStatus::Connecting => Style::default().fg(Color::LightYellow),
         ConnectionStatus::Disconnected => Style::default().fg(Color::LightRed),
     };
-    let status_line = Line::from(vec![
+    let mut status_spans = vec![
         Span::styled("\u{25cf} ", status_style),
         Span::styled(indicator, status_text_style),
         Span::raw(" "),
         Span::styled(&*app.host, cyan),
-    ]);
+    ];
+    if app.paused {
+        status_spans.push(Span::raw("   "));
+        status_spans.push(Span::styled(
+            "PAUSED",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::LightYellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    let status_line = Line::from(status_spans);
 
     let server_info_line = if connected {
         let version = app.server_version.as_deref().unwrap_or("?");
@@ -440,14 +451,59 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     // Help bar.
     let key_style = Style::default();
     let label_style = Style::default().fg(Color::Black).bg(Color::LightCyan);
-    let help = Paragraph::new(Line::from(vec![
+    // While paused the `i` slot strikes through (rather than vanishing
+    // entirely) so it reads as "disabled" without depending on a
+    // light/dark terminal theme. We only mark the glyphs themselves with
+    // CROSSED_OUT so the strike-through line doesn't spill through the
+    // padding spaces and touch the neighbouring labels.
+    let pause_label = if app.paused { "Resume" } else { "Pause" };
+    let mut help_spans: Vec<Span> = vec![
         Span::styled(" Tab ", key_style),
         Span::styled("Change Tab", label_style),
-        Span::styled("  i ", key_style),
-        Span::styled("Info", label_style),
+        Span::raw("  "),
+    ];
+    if app.paused {
+        let crossed = Modifier::CROSSED_OUT;
+        help_spans.push(Span::styled("i", key_style.add_modifier(crossed)));
+        help_spans.push(Span::raw(" "));
+        help_spans.push(Span::styled("Info", label_style.add_modifier(crossed)));
+    } else {
+        help_spans.push(Span::styled("i", key_style));
+        help_spans.push(Span::raw(" "));
+        help_spans.push(Span::styled("Info", label_style));
+    }
+    help_spans.extend([
+        Span::styled("  p ", key_style),
+        Span::styled(pause_label, label_style),
         Span::styled("  q ", key_style),
         Span::styled("Quit", label_style),
-    ]));
+    ]);
+
+    // When paused and the cursor is at the edge of the frozen buffer,
+    // tell the user the only way to scroll further is to resume.
+    if app.paused {
+        let ls = &app.list_states[app.active_tab.idx()];
+        let buffer_size = match app.active_tab {
+            Tab::Ready => app.ready_jobs.len(),
+            Tab::InFlight => app.in_flight_jobs.len(),
+            Tab::Scheduled => app.scheduled_jobs.len(),
+        };
+        if buffer_size > 0 {
+            let buffer_end = ls.buffer_offset + buffer_size - 1;
+            let at_top = ls.cursor == ls.buffer_offset;
+            let at_bottom = ls.cursor == buffer_end;
+            if at_top || at_bottom {
+                let arrow = if at_bottom { "\u{2193}" } else { "\u{2191}" };
+                help_spans.push(Span::raw("   "));
+                help_spans.push(Span::styled(
+                    format!("{arrow} Resume to scroll further"),
+                    Style::default().fg(Color::LightYellow),
+                ));
+            }
+        }
+    }
+
+    let help = Paragraph::new(Line::from(help_spans));
     frame.render_widget(help, chunks[3]);
 }
 
@@ -994,6 +1050,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         }
     }
@@ -1002,6 +1059,50 @@ mod tests {
     fn render_connecting() {
         let app = new_app();
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
+    }
+
+    #[test]
+    fn render_paused_shows_indicator_and_swaps_help_labels() {
+        let mut app = new_app();
+        app.status = ConnectionStatus::Connected;
+        app.paused = true;
+        assert_ui_snapshot!(render_to_string(&app, 60, 10));
+    }
+
+    #[test]
+    fn render_paused_at_buffer_edge_shows_resume_hint() {
+        let mut app = new_app();
+        app.status = ConnectionStatus::Connected;
+        app.paused = true;
+        app.active_tab = Tab::Ready;
+        app.total_ready = 2;
+        app.ready_jobs = vec![
+            job_admin("j1", "queue1", "type1"),
+            job_admin("j2", "queue1", "type1"),
+        ];
+        app.list_states[Tab::Ready.idx()].buffer_offset = 0;
+        // Cursor at last row → bottom edge → "↓ Resume to scroll further".
+        app.list_states[Tab::Ready.idx()].cursor = 1;
+        assert_ui_snapshot!(render_to_string(&app, 90, 12));
+    }
+
+    fn job_admin(id: &str, queue: &str, job_type: &str) -> AdminJob {
+        AdminJob {
+            id: id.into(),
+            queue: queue.into(),
+            job_type: job_type.into(),
+            priority: 0,
+            ready_at: 0,
+            attempts: 0,
+            dequeued_at: None,
+            failed_at: None,
+            payload: None,
+            retry_limit: None,
+            backoff: None,
+            retention: None,
+            unique_key: None,
+            unique_while: None,
+        }
     }
 
     #[test]
@@ -1025,6 +1126,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
@@ -1051,6 +1153,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
@@ -1168,6 +1271,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         }
     }
@@ -1272,6 +1376,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
@@ -1298,6 +1403,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
@@ -1346,6 +1452,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 80, 20));
@@ -1394,6 +1501,7 @@ mod tests {
             list_states: Default::default(),
             viewport_height: 0,
             show_detail: false,
+            paused: false,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 12));


### PR DESCRIPTION
When scrolling in `zizq top` the list keeps chaging because it's a live view of activity on the server. But if you're actively looking at a job you kinda wanna pause the list so it remains stable until unpaused. Now pressing `p` in the TUI pauses the list. You can't scroll beyond whatever is buffered locally, but you can scroll within a consistent buffer at least.

Also includes some fixes around the handling of the detail toggle when switching between tabs, and the bounds handling with `G` and `g` (go to end/start).