### PR TITLE
Allow Deleting Jobs in `zizq top`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,33 @@
   client's prior `SetDetailLevel{detail: true}`. The resync now preserves
   the connection's detail flag and subscription windows so payloads keep
   flowing across all tabs in `zizq top`.
+- Press `D` (Shift+d) on a row in `zizq top` to delete a job. A `[y/N]`
+  confirmation prompt replaces the help bar; `y` confirms, `n`/Esc/`q`
+  cancel. New `delete_job` message type on the admin WebSocket protocol.
+- Fixed `GET /jobs/take`: the heartbeat used `send().await`, which would
+  block when the response body's `mpsc(1)` buffer was full. That parked
+  the take loop's `select!`, swallowing any subsequent `tx.closed()`
+  notification. The result was orphaned in-flight jobs that never got
+  requeued when a worker was killed. Heartbeats now use `try_send`, which
+  treats a full buffer as "the previous heartbeat is still in flight,
+  skip this tick" and keeps the disconnect path live.
+- Fixed `GET /jobs/take`: when a worker disconnected partway through a
+  prefetched batch, only the jobs that had been dispatched so far were
+  tracked in the local in-flight set and requeued on cleanup. The tail
+  of the batch was already InFlight on disk (committed by
+  `take_next_n_jobs`) and had bumped the in-flight counter, but was
+  never seen by cleanup — leaving those jobs stranded InFlight forever
+  and the counter drifting above the actual on-disk count. The handler
+  now records the entire batch in the in-flight set before dispatching,
+  so cleanup requeues every job in the batch.
+- Fixed admin WebSocket: when a job was requeued (worker disconnect
+  cleanup), the `JobCreated` event was treated only as "new ready job"
+  — the handler diffed the ready/scheduled windows but never evicted
+  the id from `in_flight_ids`. `zizq top` therefore kept showing
+  stale rows in the in-flight tab even though the header total had
+  dropped to zero. `JobCreated` now removes the id from the connection's
+  in-flight set if it was there, so the next `diff_in_flight` emits an
+  `in_flight_removed` event.
 
 ## 0.3.1
 

--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -141,6 +141,15 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                 }
                             }
                         }
+                        Some(ClientMessage::DeleteJob { id }) => {
+                            // Fire-and-forget — the deletion's JobDeleted
+                            // store event will fan out through the normal
+                            // event path and remove the row on every
+                            // connected client (including this one).
+                            if let Err(e) = send_state.store.delete_job(&id).await {
+                                tracing::warn!(%e, %id, "admin ws: delete_job failed");
+                            }
+                        }
                         None => break,
                     }
                 }
@@ -381,9 +390,23 @@ async fn process_store_event(
     conn: &mut ConnectionState,
 ) -> Vec<AdminEvent> {
     match event {
-        StoreEvent::JobCreated { .. } => {
+        StoreEvent::JobCreated { ref id, .. } => {
+            // `JobCreated` covers both fresh enqueues and `requeue` calls
+            // (worker disconnect cleanup). For requeues, the job was
+            // previously InFlight from this connection's perspective —
+            // it has to be evicted from `in_flight_ids` so the next
+            // `diff_in_flight` emits an `InFlightRemoved` event. For
+            // fresh enqueues the set never contained the id so this is
+            // a harmless no-op.
+            let was_in_flight = conn.in_flight_ids.iter().any(|(_, wid)| wid == id);
+            if was_in_flight {
+                conn.in_flight_ids.retain(|(_, wid)| wid != id);
+            }
             let mut events = diff_ready(store, conn).await;
             events.extend(diff_scheduled(store, conn).await);
+            if was_in_flight {
+                events.extend(diff_in_flight(store, conn).await);
+            }
             events
         }
         StoreEvent::JobInFlight { id } => {
@@ -1079,6 +1102,58 @@ mod tests {
         assert_eq!(statuses, vec!["in_flight", "ready_removed"]);
     }
 
+    /// Regression: when a worker disconnected, the take handler called
+    /// `store.requeue(id)` for each in-flight job. That emits a
+    /// `JobCreated` event. The admin handler used to handle `JobCreated`
+    /// only as "new ready job" — diffing the ready/scheduled windows but
+    /// never removing the id from `conn.in_flight_ids`. The result was
+    /// stale rows lingering in the `zizq top` in-flight tab even though
+    /// the header total had dropped to zero. The handler now evicts the
+    /// id from `in_flight_ids` on `JobCreated`, so the next
+    /// `diff_in_flight` emits an `in_flight_removed`.
+    #[tokio::test]
+    async fn requeue_emits_in_flight_removed_and_ready() {
+        let state = test_state();
+        let now = now_millis();
+
+        let job = state
+            .store
+            .enqueue(
+                now,
+                EnqueueOptions::new("task", "q", serde_json::json!(null)),
+            )
+            .await
+            .unwrap()
+            .into_job();
+        state
+            .store
+            .take_next_job(now, &HashSet::new())
+            .await
+            .unwrap();
+
+        let (_addr, mut rx) = connect(state.clone()).await;
+
+        // Consume the initial snapshot (1 in-flight, 0 ready).
+        let snapshot = next_json(&mut rx).await;
+        assert_eq!(snapshot["in_flight"]["items"].as_array().unwrap().len(), 1);
+        assert_eq!(snapshot["ready"]["items"].as_array().unwrap().len(), 0);
+
+        // Requeue — same path the take loop uses for disconnect cleanup.
+        state.store.requeue(&job.id).await.unwrap();
+
+        // Should observe both `in_flight_removed` and `ready` for the
+        // same id (order may vary).
+        let mut statuses = Vec::new();
+        for _ in 0..2 {
+            let msg = next_json(&mut rx).await;
+            assert_eq!(msg["event"], "job_changed");
+            assert_eq!(msg["id"], job.id);
+            statuses.push(msg["status"].as_str().unwrap().to_string());
+        }
+        statuses.sort();
+        assert_eq!(statuses, vec!["in_flight_removed", "ready"]);
+    }
+
     #[tokio::test]
     async fn complete_job_sends_completed_and_in_flight_removed() {
         let state = test_state();
@@ -1318,6 +1393,78 @@ mod tests {
         assert_eq!(msg["event"], "job_changed");
         assert_eq!(msg["status"], "ready");
         assert_eq!(msg["server"]["tier"], "free");
+    }
+
+    #[tokio::test]
+    async fn delete_job_message_deletes_the_job_and_emits_event() {
+        use futures_util::SinkExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        let state = test_state();
+        let now = now_millis();
+
+        // Enqueue a job so there's something to delete.
+        let job = state
+            .store
+            .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(null)))
+            .await
+            .unwrap()
+            .into_job();
+
+        // Connect a bidirectional WebSocket.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let state_clone = state.clone();
+        tokio::spawn(async move {
+            axum::serve(listener, super::super::app(state_clone))
+                .await
+                .unwrap();
+        });
+        let (ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/events"))
+            .await
+            .unwrap();
+        let (mut tx, mut rx) = ws.split();
+
+        // Drain the initial snapshot.
+        let snapshot = next_json(&mut rx).await;
+        assert_eq!(snapshot["event"], "job_snapshot");
+
+        // Send the delete request.
+        let delete_msg = serde_json::json!({
+            "type": "delete_job",
+            "id": job.id,
+        })
+        .to_string();
+        tx.send(Message::Text(delete_msg.into())).await.unwrap();
+
+        // We should observe a `job_changed` event with the deletion.
+        // Status is `completed` or `dead` (existing JobDeleted store path
+        // doesn't use a distinct semantic status — the row simply leaves
+        // every list).
+        let mut got_removal = false;
+        for _ in 0..5 {
+            let msg = next_json(&mut rx).await;
+            if msg["event"] == "job_changed"
+                && (msg["status"] == "ready_removed"
+                    || msg["status"] == "in_flight_removed"
+                    || msg["status"] == "scheduled_removed")
+                && msg["id"] == job.id
+            {
+                got_removal = true;
+                break;
+            }
+        }
+        assert!(
+            got_removal,
+            "expected a *_removed event for the deleted job"
+        );
+
+        // The job should be gone from the store.
+        let gone = state.store.get_job(now_millis(), &job.id).await.unwrap();
+        assert!(
+            gone.is_none(),
+            "job should have been deleted from the store"
+        );
     }
 
     #[tokio::test]

--- a/src/api/admin/types.rs
+++ b/src/api/admin/types.rs
@@ -74,6 +74,12 @@ pub enum ClientMessage {
     SetDetailLevel {
         detail: bool,
     },
+    /// Request deletion of a single job. The server doesn't ack — the
+    /// resulting `JobDeleted` store event flows back through the normal
+    /// admin event stream and removes the row on every connected client.
+    DeleteJob {
+        id: String,
+    },
 }
 
 /// Which job list a subscription targets.

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -1915,8 +1915,19 @@ async fn take_jobs(
                     // next heartbeat or reserve() call.
                     _ = tx.closed() => break,
                     _ = &mut heartbeat_sleep => {
-                        if tx.send(TakeMessage::Heartbeat).await.is_err() {
-                            break;
+                        // `try_send` instead of `send().await`: when the
+                        // channel buffer is full (the previous heartbeat
+                        // hasn't been pulled by the response stream yet)
+                        // an awaited `send` would block here, parking the
+                        // whole `select!` and silently swallowing future
+                        // `tx.closed()` notifications.
+                        //
+                        // `Full` is harmless — the existing pending
+                        // heartbeat will go out when the channel drains, or
+                        // we'll skip a tick and try again.
+                        match tx.try_send(TakeMessage::Heartbeat) {
+                            Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                            Err(mpsc::error::TrySendError::Closed(_)) => break,
                         }
                         heartbeat_sleep
                             .as_mut()
@@ -1986,31 +1997,49 @@ async fn take_jobs(
                                             // send all jobs uniformly via tx.send().
                                             drop(permit);
 
-                                            let mut send_err = false;
+                                            // Decode and add every job from the batch to
+                                            // the in-flight set BEFORE attempting any
+                                            // sends. `take_next_n_jobs` has already
+                                            // committed every job to InFlight on disk
+                                            // and incremented the global counter — if
+                                            // the worker dies mid-dispatch, cleanup
+                                            // needs to see the whole batch so it can
+                                            // requeue everything. Otherwise the taken jobs
+                                            // are stranded InFlight forever and the counter
+                                            // drifts above the actual in-flight count.
+                                            let mut to_send: Vec<Job> = Vec::with_capacity(jobs.len());
                                             for store_job in jobs {
                                                 match Job::try_from(store_job) {
                                                     Ok(job) => {
                                                         in_flight.insert(job.id.clone(), job.attempts);
-                                                        tracing::debug!(
-                                                            job_id = %job.id,
-                                                            job_type = %job.job_type,
-                                                            queue = %job.queue,
-                                                            priority = job.priority,
-                                                            "job dispatched"
-                                                        );
-                                                        if tx.send(TakeMessage::Job(Arc::new(job))).await.is_err() {
-                                                            send_err = true;
-                                                            break;
-                                                        }
+                                                        to_send.push(job);
                                                     }
                                                     Err(e) => {
+                                                        // Corrupt jobs stay InFlight on
+                                                        // disk but aren't tracked here —
+                                                        // skipping them lets the
+                                                        // connection keep going. (This
+                                                        // does leak a counter increment
+                                                        // for each, but it's a real
+                                                        // corruption signal, not a
+                                                        // routine path.)
                                                         tracing::error!(%e, "corrupt job data");
-                                                        // Skip this job — it's marked InFlight
-                                                        // in the store but we can't decode it.
-                                                        // Don't track it in in_flight so the
-                                                        // connection stays healthy.
-                                                        continue;
                                                     }
+                                                }
+                                            }
+
+                                            let mut send_err = false;
+                                            for job in to_send {
+                                                tracing::debug!(
+                                                    job_id = %job.id,
+                                                    job_type = %job.job_type,
+                                                    queue = %job.queue,
+                                                    priority = job.priority,
+                                                    "job dispatched"
+                                                );
+                                                if tx.send(TakeMessage::Job(Arc::new(job))).await.is_err() {
+                                                    send_err = true;
+                                                    break;
                                                 }
                                             }
 
@@ -4866,6 +4895,137 @@ mod tests {
         assert_eq!(
             res.headers().get("content-type").unwrap(),
             "application/x-ndjson"
+        );
+    }
+
+    /// Regression: when `take_next_n_jobs` returned a batch but the
+    /// worker disconnected partway through dispatch, the tail of the
+    /// batch was stranded InFlight on disk (and `in_flight_count` was
+    /// left over-counted). The in-flight HashMap was only populated as
+    /// each job was dispatched, so jobs after the first `tx.send`
+    /// failure were never tracked and never requeued. The handler now
+    /// inserts the whole batch before dispatching.
+    #[tokio::test]
+    async fn take_requeues_entire_batch_when_worker_dies_mid_dispatch() {
+        let (state, app) = test_state_and_app();
+
+        // Enqueue 5 jobs.
+        let mut enqueued_ids = Vec::new();
+        for i in 0..5 {
+            let job = state
+                .store
+                .enqueue(
+                    crate::time::now_millis(),
+                    EnqueueOptions::new("t", "default", serde_json::json!(i)),
+                )
+                .await
+                .unwrap()
+                .into_job();
+            enqueued_ids.push(job.id);
+        }
+
+        // Request all of them in a single batch; only read one line
+        // before disconnecting. That leaves `tx.send` blocked on the
+        // buffer for the next dispatch, and the drop then propagates
+        // a closed-channel error — simulating the worker dying with
+        // most of the batch still in the dispatch loop.
+        let req = empty_request("GET", "/jobs/take?prefetch=5");
+        let res = app.oneshot(req).await.unwrap();
+        let mut body = res.into_body();
+
+        let bytes = next_body_bytes(&mut body).await;
+        let _ = std::str::from_utf8(&bytes).unwrap();
+
+        drop(body);
+
+        // Give the cleanup pass time to run.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Every enqueued job should be requeued (Ready again).
+        let mut ids = Vec::new();
+        while let Some(job) = state
+            .store
+            .take_next_job(crate::time::now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+        {
+            ids.push(job.id);
+        }
+        for id in &enqueued_ids {
+            assert!(
+                ids.contains(id),
+                "expected job {id} to be requeued after mid-batch disconnect"
+            );
+        }
+
+        // The in-flight counter should have come back down to zero now
+        // that the cleanup pass ran for every job.
+        assert_eq!(
+            state.store.in_flight_count(),
+            ids.len(),
+            "in_flight_count must match what we re-took after cleanup"
+        );
+    }
+
+    /// Coverage for the stalled-rx path: the worker isn't reading
+    /// heartbeats off the body for a while (which fills the `mpsc(1)`
+    /// buffer), and then disconnects. With the old `send().await`
+    /// heartbeat path the loop was wedged for the full stall window —
+    /// the response drop happened to unwedge it in this in-process
+    /// test, but in production where hyper was slow to drop `rx` the
+    /// same scenario stranded all in-flight jobs. `try_send` keeps the
+    /// loop responsive across the wedge window.
+    #[tokio::test]
+    async fn take_requeues_when_body_stalled_then_dropped() {
+        let (_clock, mut state) = test_app_state();
+        // Short heartbeats so several fire during the stall window.
+        state.heartbeat_interval_ms = Duration::from_millis(20);
+        let state = Arc::new(state);
+        let app = app(state.clone());
+
+        let enqueued = state
+            .store
+            .enqueue(
+                crate::time::now_millis(),
+                EnqueueOptions::new("test", "default", serde_json::json!("stalled")),
+            )
+            .await
+            .unwrap()
+            .into_job();
+
+        let req = empty_request("GET", "/jobs/take?prefetch=2");
+        let res = app.oneshot(req).await.unwrap();
+        let mut body = res.into_body();
+
+        // Read just the job line — leaves any subsequent heartbeats
+        // unread, so the channel buffer will fill.
+        let bytes = next_body_bytes(&mut body).await;
+        let line = std::str::from_utf8(&bytes).unwrap().trim();
+        let job: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(job["id"], enqueued.id);
+
+        // Stall: don't poll the body for several heartbeat intervals.
+        // With the buggy version this leaves the take loop wedged in
+        // `tx.send.await`, so the subsequent drop never triggers the
+        // requeue path.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        drop(body);
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let mut ids = Vec::new();
+        while let Some(job) = state
+            .store
+            .take_next_job(crate::time::now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+        {
+            ids.push(job.id);
+        }
+        assert!(
+            ids.contains(&enqueued.id),
+            "stalled-then-dropped take should still requeue its in-flight job"
         );
     }
 

--- a/src/commands/top/app.rs
+++ b/src/commands/top/app.rs
@@ -104,6 +104,10 @@ pub struct App {
     /// fields keep updating; incoming `JobChanged` / `JobSnapshot` events
     /// don't mutate the row buffers. Toggled by `p`.
     pub paused: bool,
+    /// When `Some`, the user has pressed `D` on a row and the help bar
+    /// is showing a `Delete job …? [y/N]` prompt. While set, user input
+    /// is restricted to confirming (`y`) or cancelling (`n` / Esc / `q`).
+    pub pending_delete: Option<String>,
     pub ws_tx: Option<mpsc::Sender<String>>,
 }
 
@@ -129,6 +133,7 @@ impl Clone for App {
             viewport_height: self.viewport_height,
             show_detail: self.show_detail,
             paused: self.paused,
+            pending_delete: self.pending_delete.clone(),
             ws_tx: self.ws_tx.clone(),
         }
     }
@@ -156,6 +161,7 @@ impl App {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         }
     }
@@ -262,6 +268,37 @@ impl App {
         }
     }
 
+    /// Return the id of the job under the cursor in the active tab,
+    /// or `None` if the buffer doesn't cover that row.
+    fn selected_job_id(&self) -> Option<String> {
+        let ls = &self.list_states[self.active_tab.idx()];
+        let idx = ls.cursor.checked_sub(ls.buffer_offset)?;
+        let jobs = match self.active_tab {
+            Tab::Ready => &self.ready_jobs,
+            Tab::InFlight => &self.in_flight_jobs,
+            Tab::Scheduled => &self.scheduled_jobs,
+        };
+        jobs.get(idx).map(|j| j.id.clone())
+    }
+
+    /// Send a delete-job message over WebSocket and remove the row from
+    /// every local buffer. The server will also broadcast a `JobDeleted`
+    /// store event, but applying the removal eagerly keeps the cursor
+    /// behaving sensibly even while paused (when incoming events are
+    /// otherwise ignored).
+    fn confirm_pending_delete(&mut self) {
+        let Some(id) = self.pending_delete.take() else {
+            return;
+        };
+        if let Some(tx) = &self.ws_tx {
+            let msg = events::delete_job_message(id.clone());
+            let _ = tx.try_send(msg);
+        }
+        self.ready_jobs.retain(|j| j.id != id);
+        self.in_flight_jobs.retain(|j| j.id != id);
+        self.scheduled_jobs.retain(|j| j.id != id);
+    }
+
     /// Apply server status fields from any message.
     fn apply_server_status(&mut self, server: ServerStatus) {
         self.status = ConnectionStatus::Connected;
@@ -278,6 +315,22 @@ impl App {
     ///
     /// Returns `true` if the application should quit.
     pub fn handle_event(&mut self, event: Event) -> bool {
+        // While a delete prompt is pending, gate user input down to
+        // confirm/cancel. Server-pushed events still flow through and
+        // update state — only keypresses are restricted. `is_user_input`
+        // and `is_scroll` together cover every keyboard-originated event.
+        if self.pending_delete.is_some() && (event.is_user_input() || event.is_scroll()) {
+            match event {
+                Event::ConfirmDelete => self.confirm_pending_delete(),
+                // Quit while prompting cancels the prompt rather than
+                // exiting; a second `q` (or any other quit gesture) after
+                // cancellation will quit normally.
+                Event::CancelDelete | Event::Quit => self.pending_delete = None,
+                _ => {}
+            }
+            return false;
+        }
+
         match event {
             Event::Quit => return true,
             Event::NextTab => {
@@ -321,6 +374,14 @@ impl App {
                 self.show_detail = !self.show_detail;
                 self.send_detail_level();
             }
+            Event::RequestDelete => {
+                if let Some(id) = self.selected_job_id() {
+                    self.pending_delete = Some(id);
+                }
+            }
+            // Outside of an active prompt these are no-ops — the prompt
+            // path above is the only thing that interprets them.
+            Event::ConfirmDelete | Event::CancelDelete => {}
             Event::TogglePause => {
                 self.paused = !self.paused;
                 if !self.paused {
@@ -1368,5 +1429,108 @@ mod tests {
 
         // Detail level didn't change because the snapshot was frozen.
         assert!(!app.show_detail);
+    }
+
+    // ── Delete prompt ───────────────────────────────────────────────
+
+    /// Seed the app with a ready job, cursor pointing at it.
+    fn seed_ready_with_cursor(id: &str) -> App {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.viewport_height = 20;
+        app.active_tab = Tab::Ready;
+        app.total_ready = 1;
+        app.ready_jobs = vec![job(id, 0, None)];
+        app.list_states[Tab::Ready.idx()].buffer_offset = 0;
+        app.list_states[Tab::Ready.idx()].cursor = 0;
+        app
+    }
+
+    #[test]
+    fn d_opens_delete_prompt_for_cursor_row() {
+        let mut app = seed_ready_with_cursor("j1");
+        app.handle_event(Event::RequestDelete);
+        assert_eq!(app.pending_delete.as_deref(), Some("j1"));
+    }
+
+    #[test]
+    fn d_on_empty_buffer_does_not_open_prompt() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::RequestDelete);
+        assert!(app.pending_delete.is_none());
+    }
+
+    #[test]
+    fn confirm_outside_prompt_is_noop() {
+        let mut app = seed_ready_with_cursor("j1");
+        app.handle_event(Event::ConfirmDelete);
+        assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
+    }
+
+    #[test]
+    fn cancel_clears_pending_delete() {
+        let mut app = seed_ready_with_cursor("j1");
+        app.handle_event(Event::RequestDelete);
+        app.handle_event(Event::CancelDelete);
+        assert!(app.pending_delete.is_none());
+        assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
+    }
+
+    #[test]
+    fn quit_during_prompt_cancels_instead_of_quitting() {
+        let mut app = seed_ready_with_cursor("j1");
+        app.handle_event(Event::RequestDelete);
+        let quit = app.handle_event(Event::Quit);
+        assert!(!quit, "Quit during prompt must not exit the app");
+        assert!(app.pending_delete.is_none());
+
+        // Second quit, no prompt active — should now exit.
+        assert!(app.handle_event(Event::Quit));
+    }
+
+    #[test]
+    fn confirm_sends_delete_message_and_removes_row() {
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let mut app = seed_ready_with_cursor("j_to_delete");
+        app.set_ws_tx(tx);
+
+        app.handle_event(Event::RequestDelete);
+        app.handle_event(Event::ConfirmDelete);
+
+        assert!(app.pending_delete.is_none());
+        assert!(app.ready_jobs.is_empty(), "row should be removed locally");
+
+        let msg = rx.try_recv().expect("expected a delete_job message");
+        assert!(
+            msg.contains("\"type\":\"delete_job\"") && msg.contains("j_to_delete"),
+            "expected DeleteJob with id j_to_delete, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn navigation_keys_are_swallowed_while_prompt_pending() {
+        let mut app = seed_ready_with_cursor("j1");
+        // Add a second job so scrolling has somewhere to go.
+        app.ready_jobs.push(job("j2", 0, None));
+        app.total_ready = 2;
+
+        app.handle_event(Event::RequestDelete);
+        let cursor_before = app.list_states[Tab::Ready.idx()].cursor;
+
+        app.handle_event(Event::ScrollDown);
+        app.handle_event(Event::TogglePause);
+
+        assert_eq!(
+            app.list_states[Tab::Ready.idx()].cursor,
+            cursor_before,
+            "navigation should be ignored while prompt is pending"
+        );
+        assert!(
+            !app.paused,
+            "pause toggle should be ignored while prompt is pending"
+        );
+        assert!(
+            app.pending_delete.is_some(),
+            "prompt should still be pending"
+        );
     }
 }

--- a/src/commands/top/events.rs
+++ b/src/commands/top/events.rs
@@ -40,6 +40,12 @@ pub enum Event {
     ToggleDetail,
     /// Toggle paused state — freeze/unfreeze the live job lists.
     TogglePause,
+    /// Begin a delete-confirmation prompt for the cursor row.
+    RequestDelete,
+    /// Confirm the pending delete (sends the WS message + removes the row).
+    ConfirmDelete,
+    /// Dismiss the pending delete prompt without doing anything.
+    CancelDelete,
     /// Suspend the process (Ctrl-Z).
     Suspend,
     /// Server connection attempt in progress.
@@ -78,6 +84,9 @@ impl Event {
                 | Event::ScrollRight
                 | Event::ToggleDetail
                 | Event::TogglePause
+                | Event::RequestDelete
+                | Event::ConfirmDelete
+                | Event::CancelDelete
         )
     }
 
@@ -147,6 +156,15 @@ pub fn read_terminal_events(tx: mpsc::Sender<Event>) {
                         }
                         (KeyCode::Char('G'), _) => {
                             let _ = tx.blocking_send(Event::GoToEnd);
+                        }
+                        (KeyCode::Char('D'), _) => {
+                            let _ = tx.blocking_send(Event::RequestDelete);
+                        }
+                        (KeyCode::Char('y'), _) => {
+                            let _ = tx.blocking_send(Event::ConfirmDelete);
+                        }
+                        (KeyCode::Char('n'), _) | (KeyCode::Esc, _) => {
+                            let _ = tx.blocking_send(Event::CancelDelete);
                         }
                         (KeyCode::Home, _) => {
                             let _ = tx.blocking_send(Event::GoToStart);
@@ -261,6 +279,12 @@ fn parse_ws_message(text: &str) -> Option<Event> {
 /// Serialize a detail-level message for sending over WebSocket.
 pub fn detail_level_message(detail: bool) -> String {
     serde_json::to_string(&ClientMessage::SetDetailLevel { detail })
+        .expect("ClientMessage serialization cannot fail")
+}
+
+/// Serialize a delete-job message for sending over WebSocket.
+pub fn delete_job_message(id: String) -> String {
+    serde_json::to_string(&ClientMessage::DeleteJob { id })
         .expect("ClientMessage serialization cannot fail")
 }
 

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connected_with_server_info.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connected_with_server_info.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1069
+assertion_line: 1166
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +12,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1034
+assertion_line: 1094
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +12,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_delete_prompt_replaces_help_bar.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_delete_prompt_replaces_help_bar.snap
@@ -1,0 +1,15 @@
+---
+source: src/commands/top/ui.rs
+assertion_line: 1110
+expression: "render_to_string(&app, 80, 10)"
+---
+  Zizq 0.1.0
+● Connected 127.0.0.1:8901
+  Server version: ?, Uptime: ?
+  Queue: 0 in-flight, 0 ready, 0 scheduled
+
+  Depth[                                                               0 jobs]
+
+   In-Flight   Ready   Scheduled
+                         ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
+ Delete job j_abc123?   y Yes  n No

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1292
+assertion_line: 1391
 expression: "render_to_string(&app, 160, 30)"
 ---
   Zizq 0.1.0
@@ -32,4 +32,4 @@ expression: "render_to_string(&app, 160, 30)"
   Type                    generate_annual_report_email                             "to": "user@example.com",
   Priority                0                                                        "urgent": true
   Status                  in_flight                                              }
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1096
+assertion_line: 1194
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +12,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1346
+assertion_line: 1447
 expression: "render_to_string(&app, 120, 8)"
 ---
   Zizq 0.1.0
@@ -10,4 +10,4 @@ expression: "render_to_string(&app, 120, 8)"
 
 
    In-Flight   Ready   Scheduled
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1319
+assertion_line: 1419
 expression: "render_to_string(&app, 120, 8)"
 ---
   Zizq 0.1.0
@@ -10,4 +10,4 @@ expression: "render_to_string(&app, 120, 8)"
 
   Depth[                                                                                                       0 jobs]
    In-Flight   Ready   Scheduled
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1444
+assertion_line: 1547
 expression: "render_to_string(&app, 120, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 120, 12)"
 
                                          Display is currently capped at 10 jobs.
                                        Upgrade to a pro license to see everything.
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1395
+assertion_line: 1497
 expression: "render_to_string(&app, 80, 20)"
 ---
   Zizq 0.1.0
@@ -22,4 +22,4 @@ expression: "render_to_string(&app, 80, 20)"
                      Display is currently capped at 10 jobs.
                    Upgrade to a pro license to see everything.
 
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1237
+assertion_line: 1336
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
 70a2bb46e1f07a0c908d7a2bb40          0 default                  3s          1 ge
 70a1aa35d0e06b0b807c691aa30          0 billing               2m30s          3 ch
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1244
+assertion_line: 1343
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
      ID   PRIORITY QUEUE              DURATION   ATTEMPTS TYPE
 7a2bb40          0 default                  3s          1 generate_annual_report
 691aa30          0 billing               2m30s          3 charge_subscription
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1251
+assertion_line: 1350
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
 UEUE              DURATION   ATTEMPTS TYPE
 efault                  3s          1 generate_annual_report_email
 illing               2m30s          3 charge_subscription
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_wide.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1231
+assertion_line: 1330
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                        DURATION   ATTEMPTS TYPE
 70a2bb46e1f07a0c908d7a2bb40          0 default                            3s          1 generate_annual_report_email
 70a1aa35d0e06b0b807c691aa30          0 billing                         2m30s          3 charge_subscription
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_at_buffer_edge_shows_resume_hint.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_at_buffer_edge_shows_resume_hint.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1086
+assertion_line: 1119
 expression: "render_to_string(&app, 90, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 90, 12)"
                          ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TYPE
                          j1          0 queue1                    -          0 type1
                          j2          0 queue1                    -          0 type1
- Tab Change Tab  i Info  p Resume  q Quit   ↓ Resume to scroll further
+ Tab Change Tab  i Info  p Resume  D Delete  q Quit   ↓ Resume to scroll further

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_shows_indicator_and_swaps_help_labels.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_paused_shows_indicator_and_swaps_help_labels.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1042
+assertion_line: 1102
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +12,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Resume  q Quit
+ Tab Change Tab  i Info  p Resume  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1225
+assertion_line: 1324
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TY
 70a3cc87a1f0890da08e8b3cc86          0 default                  5s          0 ge
 70a3dd47c2308a1fb09e9c4dd97          5 default                1m2s          2 se
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1219
+assertion_line: 1318
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                           DELAY   ATTEMPTS TYPE
 70a3cc87a1f0890da08e8b3cc86          0 default                            5s          0 generate_annual_report_email
 70a3dd47c2308a1fb09e9c4dd97          5 default                          1m2s          2 send_welcome_email
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1263
+assertion_line: 1362
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                   DUE   ATTEMPTS TY
 70a4ee89f2f09a1eb0af9d5ee80          0 default               3m52s          0 se
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                  1h          1 ge
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
+++ b/src/commands/top/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/top/ui.rs
-assertion_line: 1257
+assertion_line: 1356
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +14,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                             DUE   ATTEMPTS TYPE
 70a4ee89f2f09a1eb0af9d5ee80          0 default                         3m52s          0 send_reminder_email
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                            1h          1 generate_quarterly_report
- Tab Change Tab  i Info  p Pause  q Quit
+ Tab Change Tab  i Info  p Pause  D Delete  q Quit

--- a/src/commands/top/ui.rs
+++ b/src/commands/top/ui.rs
@@ -451,6 +451,33 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     // Help bar.
     let key_style = Style::default();
     let label_style = Style::default().fg(Color::Black).bg(Color::LightCyan);
+
+    // When a delete confirmation is pending, the help bar becomes a modal
+    // prompt — replaces the shortcuts entirely so the user is never in
+    // doubt about what `y` and `n` will do.
+    if let Some(id) = &app.pending_delete {
+        let prompt = Paragraph::new(Line::from(vec![
+            Span::styled(
+                " Delete job ",
+                Style::default().fg(Color::Black).bg(Color::LightRed),
+            ),
+            Span::styled(
+                id.as_str(),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::LightRed)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("?  ", Style::default().fg(Color::Black).bg(Color::LightRed)),
+            Span::styled(" y ", key_style),
+            Span::styled("Yes", label_style),
+            Span::styled("  n ", key_style),
+            Span::styled("No", label_style),
+        ]));
+        frame.render_widget(prompt, chunks[3]);
+        return;
+    }
+
     // While paused the `i` slot strikes through (rather than vanishing
     // entirely) so it reads as "disabled" without depending on a
     // light/dark terminal theme. We only mark the glyphs themselves with
@@ -475,6 +502,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     help_spans.extend([
         Span::styled("  p ", key_style),
         Span::styled(pause_label, label_style),
+        Span::styled("  D ", key_style),
+        Span::styled("Delete", label_style),
         Span::styled("  q ", key_style),
         Span::styled("Quit", label_style),
     ]);
@@ -1051,6 +1080,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         }
     }
@@ -1067,6 +1097,14 @@ mod tests {
         app.status = ConnectionStatus::Connected;
         app.paused = true;
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
+    }
+
+    #[test]
+    fn render_delete_prompt_replaces_help_bar() {
+        let mut app = new_app();
+        app.status = ConnectionStatus::Connected;
+        app.pending_delete = Some("j_abc123".into());
+        assert_ui_snapshot!(render_to_string(&app, 80, 10));
     }
 
     #[test]
@@ -1127,6 +1165,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
@@ -1154,6 +1193,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
@@ -1272,6 +1312,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         }
     }
@@ -1377,6 +1418,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
@@ -1404,6 +1446,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
@@ -1453,6 +1496,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 80, 20));
@@ -1502,6 +1546,7 @@ mod tests {
             viewport_height: 0,
             show_detail: false,
             paused: false,
+            pending_delete: None,
             ws_tx: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 12));


### PR DESCRIPTION
> [!NOTE]
> This includes a couple of fixes for bugs encountered along the way
> (in-flight set management race conditions).

In `zizq top`, pressing `D` while over a job row, even in the paused state, present a `y`/`n` confirmation dialog and allows deleting the job from the server (e.g. to stop it retrying if it's causing issues).

The job is optimistically removed from the UI while the event is processed on the WebSocket.