### PR TITLE
Drop rand in favour of rand_core.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4923,7 +4923,7 @@ dependencies = [
  "jaq-std",
  "jsonwebtoken",
  "libc",
- "rand 0.8.5",
+ "rand_core 0.6.4",
  "ratatui",
  "rcgen",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ criterion = { version = "0.8", features = ["async_tokio"] }
 tokio-tungstenite = { version = "0.29", features = ["connect", "handshake"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8", "pem"] }
-rand = "0.8"
+rand_core = { version = "0.6", features = ["getrandom"] }
 insta = { version = "1", features = ["filters"] }
 rcgen = "0.14.8"
 

--- a/src/license.rs
+++ b/src/license.rs
@@ -221,7 +221,7 @@ mod tests {
     use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
     use ed25519_dalek::pkcs8::{EncodePrivateKey, EncodePublicKey};
     use jsonwebtoken::{EncodingKey, Header};
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
     use serde::Serialize;
 
     #[derive(Serialize)]


### PR DESCRIPTION
Closes dependabot alert. There is a CVE on rand itself.