### PR TITLE
Bump jaq-std and jaq-core to 3.0.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,9 +1518,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hifijson"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hkdf"
@@ -1884,9 +1895,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jaq-core"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77526a72eb79412c29fd141767a6549bbfcb1cb40e00556fe16532d5e878e098"
+checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -1895,32 +1906,80 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "1.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
+checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
 dependencies = [
+ "bstr",
+ "bytes",
  "foldhash 0.1.5",
  "hifijson",
  "indexmap",
  "jaq-core",
  "jaq-std",
- "serde_json",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
+ "serde_core",
 ]
 
 [[package]]
 name = "jaq-std"
-version = "2.1.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
+checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
 dependencies = [
  "aho-corasick",
  "base64",
- "chrono",
+ "bstr",
  "jaq-core",
+ "jiff",
  "libm",
  "log",
- "regex-lite",
+ "regex-bites",
  "urlencoding",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2683,6 +2742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,10 +3075,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
+name = "regex-bites"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2"
 rcgen = { version = "0.14.8", features = ["x509-parser"] }
 time = "0.3"
-jaq-core = "2.2.1"
-jaq-std = "2.1.2"
-jaq-json = { version = "1.1.3", features = ["serde_json"] }
+jaq-core = "3"
+jaq-std = "3"
+jaq-json = { version = "2", features = ["serde"] }
 urlencoding = "2.1.3"
 tar = "0.4"
 flate2 = "1"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -10,13 +10,13 @@
 //! heterogeneous in the store.
 
 use jaq_core::load::{Arena, File, Loader};
-use jaq_core::{Compiler, Ctx, RcIter};
+use jaq_core::{Compiler, Ctx, Vars, data, unwrap_valr};
 use jaq_json::Val;
 
 /// A compiled jq filter ready for repeated evaluation.
 pub struct PayloadFilter {
     expression: String,
-    filter: jaq_core::Filter<jaq_core::Native<Val>>,
+    filter: jaq_core::Filter<data::JustLut<Val>>,
 }
 
 impl PayloadFilter {
@@ -38,7 +38,16 @@ impl PayloadFilter {
     /// Compile a jq expression. Returns a human-readable error on failure.
     pub fn compile(expression: &str) -> Result<Self, String> {
         let arena = Arena::default();
-        let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
+        // jaq 3 split the bundled filters: core has the primitives
+        // (true/false/select/not), std adds the standard library
+        // (map/range/recurse), json adds JSON-specific helpers
+        // (test/contains). All three are required for parity with
+        // the pre-bump behaviour.
+        let loader = Loader::new(
+            jaq_core::defs()
+                .chain(jaq_std::defs())
+                .chain(jaq_json::defs()),
+        );
 
         let modules = loader
             .load(
@@ -51,7 +60,11 @@ impl PayloadFilter {
             .map_err(|errs| format_load_errors(errs))?;
 
         let filter = Compiler::default()
-            .with_funs(jaq_std::funs().chain(jaq_json::funs()))
+            .with_funs(
+                jaq_core::funs()
+                    .chain(jaq_std::funs())
+                    .chain(jaq_json::funs()),
+            )
             .compile(modules)
             .map_err(|errs| format_compile_errors(errs))?;
 
@@ -66,14 +79,22 @@ impl PayloadFilter {
     /// Returns `true` if the filter produces any truthy output (not `false`,
     /// not `null`). Runtime errors are treated as non-matches.
     pub fn matches(&self, payload: &serde_json::Value) -> bool {
-        let val: Val = payload.clone().into();
-        let inputs = RcIter::new(core::iter::empty());
-        let ctx = Ctx::new([], &inputs);
+        // jaq-json 2 dropped the direct From<serde_json::Value> impl —
+        // round-trip via Val's Deserialize impl (gated on the `serde`
+        // feature in jaq-json's manifest).
+        let Ok(val) = serde_json::from_value::<Val>(payload.clone()) else {
+            return false;
+        };
+        let ctx = Ctx::<data::JustLut<Val>>::new(&self.filter.lut, Vars::new([]));
 
-        self.filter.run((ctx, val)).any(|result| match result {
-            Ok(v) => is_truthy(&v),
-            Err(_) => false,
-        })
+        self.filter
+            .id
+            .run((ctx, val))
+            .map(unwrap_valr)
+            .any(|result| match result {
+                Ok(v) => is_truthy(&v),
+                Err(_) => false,
+            })
     }
 }
 


### PR DESCRIPTION
No new functionality. More composable/granular API.