### PR TITLE
Add Server Side Coalescing for Enqueues and Acknowledgments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.4.2
+
+- Added server-side opportunistic batching for enqueue requests.
+  Singular `enqueue` and bulk `enqueue_bulk` now route through one
+  shared channel; a dedicated background thread coalesces whatever
+  arrived at fjall-mutex-acquire time into a single write
+  transaction. Atomicity is preserved at the commit boundary — a
+  bulk's all-or-nothing contract still holds because the coalesced
+  commit succeeds or fails as a unit. Op-count bounded via
+  `--enqueue-batch-size` (`ZIZQ_ENQUEUE_BATCH_SIZE`, default 1000); a
+  bulk request counts as one op regardless of job count. The win
+  materializes when many independent client processes are enqueueing
+  concurrently — local single-client benchmarks see no measurable
+  difference, neither helps nor hurts.
+- Added server-side opportunistic batching for completion (ack)
+  requests, same shape as the enqueue batcher. Composes with the
+  per-worker `AckProcessor`-style batching that clients already do:
+  the client batcher reduces HTTP framing per-request; the server
+  batcher reduces `tx.commit()` cost when many independent workers
+  ack concurrently. Configurable via `--complete-batch-size`
+  (`ZIZQ_COMPLETE_BATCH_SIZE`, default 1000).
+
 ## 0.4.1
 
 - Internal refactoring of the `zizq top` code structure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.1/zizq-0.4.1-linux-x86_64.tar.gz
-tar -xvzf zizq-0.4.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.2/zizq-0.4.2-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.2-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -57,7 +57,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.4.1
+Zizq 0.4.2
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.1/zizq-0.4.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.2/zizq-0.4.2-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.4.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.2-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.4.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.2-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -15,13 +15,13 @@ does almost all of the work.
 ### 1. Download the binary.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.1/zizq-0.4.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.4.2/zizq-0.4.2-linux-x86_64.tar.gz
 ```
 
 ### 2. Extract it.
 
 ```shell
-tar -xvzf zizq-0.4.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.4.2-linux-x86_64.tar.gz
 ```
 
 ### 3. Run it to start the server.
@@ -29,7 +29,7 @@ tar -xvzf zizq-0.4.1-linux-x86_64.tar.gz
 ```shell
 ./zizq serve
 
-Zizq 0.4.1
+Zizq 0.4.2
 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http

--- a/src/commands/serve/mod.rs
+++ b/src/commands/serve/mod.rs
@@ -184,13 +184,21 @@ pub struct Args {
     #[arg(long, default_value = "256MB", value_name = "SIZE", value_parser = parse_byte_size, env = "ZIZQ_CACHE_SIZE")]
     cache_size: u64,
 
-    /// Maximum number of concurrent single-job enqueues coalesced into
+    /// Maximum number of concurrent enqueue requests coalesced into
     /// one auto-batched commit. Server-side optimization that lets many
-    /// parallel client enqueue requests share one LSM-tree write transaction.
-    /// Does NOT affect explicit bulk-enqueue requests, which run their own
-    /// transaction independently.
+    /// parallel client enqueue requests share one LSM-tree write
+    /// transaction. Op-count bounded — a bulk-enqueue counts as one op
+    /// regardless of how many jobs it carries.
     #[arg(long, default_value_t = store::DEFAULT_ENQUEUE_BATCH_SIZE, value_name = "NUMBER", env = "ZIZQ_ENQUEUE_BATCH_SIZE")]
     enqueue_batch_size: usize,
+
+    /// Maximum number of concurrent completion (ack) requests coalesced
+    /// into one auto-batched commit. Same shape as `--enqueue-batch-size`:
+    /// op-count bounded, with bulk-acks counting as one op regardless of
+    /// job count. Helps under horizontally-scaled workloads where many
+    /// independent worker processes are acking concurrently.
+    #[arg(long, default_value_t = store::DEFAULT_COMPLETE_BATCH_SIZE, value_name = "NUMBER", env = "ZIZQ_COMPLETE_BATCH_SIZE")]
+    complete_batch_size: usize,
 
     /// Address to bind the admin API server to.
     #[arg(long, default_value = "127.0.0.1", env = "ZIZQ_ADMIN_HOST")]
@@ -561,6 +569,7 @@ async fn init_store(
     storage_config.default_commit_mode = args.default_commit_mode;
     storage_config.enqueue_commit_mode = args.enqueue_commit_mode;
     storage_config.enqueue_batch_size = args.enqueue_batch_size;
+    storage_config.complete_batch_size = args.complete_batch_size;
     let store = Store::open(root.join(DATABASE_DIR), storage_config)?;
     tracing::info!(root_dir = %root.display(), "store opened");
 

--- a/src/commands/serve/mod.rs
+++ b/src/commands/serve/mod.rs
@@ -184,6 +184,14 @@ pub struct Args {
     #[arg(long, default_value = "256MB", value_name = "SIZE", value_parser = parse_byte_size, env = "ZIZQ_CACHE_SIZE")]
     cache_size: u64,
 
+    /// Maximum number of concurrent single-job enqueues coalesced into
+    /// one auto-batched commit. Server-side optimization that lets many
+    /// parallel client enqueue requests share one LSM-tree write transaction.
+    /// Does NOT affect explicit bulk-enqueue requests, which run their own
+    /// transaction independently.
+    #[arg(long, default_value_t = store::DEFAULT_ENQUEUE_BATCH_SIZE, value_name = "NUMBER", env = "ZIZQ_ENQUEUE_BATCH_SIZE")]
+    enqueue_batch_size: usize,
+
     /// Address to bind the admin API server to.
     #[arg(long, default_value = "127.0.0.1", env = "ZIZQ_ADMIN_HOST")]
     admin_host: String,
@@ -552,6 +560,7 @@ async fn init_store(
     };
     storage_config.default_commit_mode = args.default_commit_mode;
     storage_config.enqueue_commit_mode = args.enqueue_commit_mode;
+    storage_config.enqueue_batch_size = args.enqueue_batch_size;
     let store = Store::open(root.join(DATABASE_DIR), storage_config)?;
     tracing::info!(root_dir = %root.display(), "store opened");
 

--- a/src/store/complete_batcher.rs
+++ b/src/store/complete_batcher.rs
@@ -1,0 +1,312 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Server-side opportunistic batching for concurrent completions
+//! (a.k.a. acks).
+//!
+//! Worker processes typically dequeue a prefetch batch of jobs and
+//! process them concurrently, then ack the completed ones. Each client
+//! SDK's `AckProcessor` already batches acks *within* one worker by
+//! buffering them into a single bulk-ack HTTP request. This batcher
+//! coalesces a second layer: bulk-ack requests *across many concurrent
+//! workers* into one fjall transaction.
+//!
+//! Both layers compose: per-worker batching saves HTTP framing
+//! overhead (one request for N jobs); this server-side batcher saves
+//! commit-side cost (one `tx.commit()` for N requests' worth of jobs).
+//!
+//! Both singular `mark_completed` and bulk `mark_completed_bulk` calls
+//! flow through this batcher. Each op carries `Vec<String>` ids and a
+//! `now` timestamp. The batcher flattens (with per-op + global dedup),
+//! pre-reads + CAS-retries inside the batcher thread, commits, then
+//! slices per-job results back into per-op `BulkCompleteResult`s for
+//! fan-out.
+//!
+//! Design echoes `EnqueueBatcher`:
+//!
+//! - Single dedicated OS thread (`complete-batcher`) drains a bounded
+//!   `std::sync::mpsc::sync_channel`.
+//! - Each request enters the channel with a `oneshot` reply slot.
+//! - The batcher blocks on `recv()` for the first op, then
+//!   opportunistically drains additional queued ops via `try_recv()`
+//!   up to the configured batch size — no time-based windowing, so
+//!   single-op traffic gets zero added latency.
+//! - Pre-read happens *in the batcher thread*, not in spawn_blocking
+//!   like enqueue's prepare. This is a deliberate trade — the CAS
+//!   retry loop must re-read on conflict, and doing that inline
+//!   inside the batcher is simpler than orchestrating retries across
+//!   submitter threads. Per-id reads are fast on hot data.
+//! - Backpressure: bounded channel + spawn_blocking-caller pattern.
+//! - Shutdown: drop the `CompleteBatcher` → `SyncSender` drops →
+//!   `recv()` returns `Err` → worker exits cleanly after draining.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::broadcast;
+
+use super::ready_index::ReadyIndex;
+use super::results::BulkCompleteResult;
+use super::store::{Keyspaces, StoreEvent, apply_complete_batch, pre_read_completes};
+use super::types::StoreError;
+
+/// A single completion request in flight: ids to ack, the caller's
+/// `now` timestamp, and a oneshot for the per-op `BulkCompleteResult`.
+pub(super) struct CompleteOp {
+    pub ids: Vec<String>,
+    pub now: u64,
+    pub reply: tokio::sync::oneshot::Sender<Result<BulkCompleteResult, StoreError>>,
+}
+
+/// Auto-batcher for completion ops (singular + bulk). Owns the
+/// channel sender; the batcher thread runs detached and exits
+/// naturally when the sender drops.
+pub(super) struct CompleteBatcher {
+    tx: std::sync::mpsc::SyncSender<CompleteOp>,
+}
+
+impl CompleteBatcher {
+    /// Spawn the batcher's background thread. The thread holds clones
+    /// of the store internals it needs to apply + finalize batches.
+    pub(super) fn start(
+        ks: Arc<Keyspaces>,
+        ready_index: Arc<ReadyIndex>,
+        in_flight_count: Arc<AtomicU64>,
+        event_tx: broadcast::Sender<StoreEvent>,
+        default_completed_retention_ms: u64,
+        batch_size: usize,
+    ) -> Self {
+        let batch_size = batch_size.max(1);
+        let (tx, rx) = std::sync::mpsc::sync_channel::<CompleteOp>(batch_size);
+
+        std::thread::Builder::new()
+            .name("complete-batcher".into())
+            .spawn(move || {
+                while let Ok(first) = rx.recv() {
+                    let mut batch = Vec::with_capacity(batch_size);
+                    batch.push(first);
+
+                    while batch.len() < batch_size {
+                        match rx.try_recv() {
+                            Ok(op) => batch.push(op),
+                            Err(_) => break,
+                        }
+                    }
+
+                    process_batch(
+                        &ks,
+                        &ready_index,
+                        &in_flight_count,
+                        &event_tx,
+                        default_completed_retention_ms,
+                        batch,
+                    );
+                }
+            })
+            .expect("failed to spawn complete-batcher thread");
+
+        Self { tx }
+    }
+
+    /// Push a completion op onto the channel and return a receiver
+    /// that resolves when the batch has been committed (or failed).
+    /// Blocks the calling thread if the channel is full — callers
+    /// must invoke this from `spawn_blocking`.
+    pub(super) fn submit(
+        &self,
+        ids: Vec<String>,
+        now: u64,
+    ) -> tokio::sync::oneshot::Receiver<Result<BulkCompleteResult, StoreError>> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        let _ = self.tx.send(CompleteOp {
+            ids,
+            now,
+            reply: reply_tx,
+        });
+        reply_rx
+    }
+}
+
+/// Apply a coalesced batch in one CAS-retry loop and fan results back
+/// to each waiter's oneshot.
+fn process_batch(
+    ks: &Keyspaces,
+    ready_index: &ReadyIndex,
+    in_flight_count: &AtomicU64,
+    event_tx: &broadcast::Sender<StoreEvent>,
+    default_completed_retention_ms: u64,
+    batch: Vec<CompleteOp>,
+) {
+    let ops_count = batch.len();
+
+    // Per-op dedup (mirroring the existing single-op behaviour) then
+    // assemble the per-op id lists for fan-out, the globally dedup'd
+    // flat id list for pre-read, the replies, and a representative
+    // `now` (smallest seen — most conservative purge_at).
+    let mut per_op_ids: Vec<Vec<String>> = Vec::with_capacity(ops_count);
+    let mut replies: Vec<tokio::sync::oneshot::Sender<_>> = Vec::with_capacity(ops_count);
+    let mut flat_ids: Vec<String> = Vec::new();
+    let mut global_seen: HashSet<String> = HashSet::new();
+    let mut now: u64 = u64::MAX;
+
+    for op in batch {
+        now = now.min(op.now);
+
+        let mut op_seen: HashSet<String> = HashSet::with_capacity(op.ids.len());
+        let mut op_ids: Vec<String> = Vec::with_capacity(op.ids.len());
+        for id in op.ids {
+            if !op_seen.insert(id.clone()) {
+                continue;
+            }
+            if global_seen.insert(id.clone()) {
+                flat_ids.push(id.clone());
+            }
+            op_ids.push(id);
+        }
+        per_op_ids.push(op_ids);
+        replies.push(op.reply);
+    }
+
+    let jobs_count = flat_ids.len();
+    tracing::debug!(
+        ops = ops_count,
+        jobs = jobs_count,
+        "complete auto-batcher: coalesced batch from channel"
+    );
+
+    // CAS-retry loop: re-read everything on conflict. Conflicts are
+    // rare (most common cause is a concurrent patch_job on a job
+    // being completed), so re-reading the full batch is acceptable.
+    let (prepared, not_found_set) = loop {
+        let (prepared, not_found) =
+            match pre_read_completes(&flat_ids, now, ks, default_completed_retention_ms) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!(
+                        ops = ops_count,
+                        jobs = jobs_count,
+                        error = %e,
+                        "complete auto-batcher: pre_read_completes failed"
+                    );
+                    let msg = e.to_string();
+                    for reply in replies {
+                        let _ = reply.send(Err(StoreError::Internal(msg.clone())));
+                    }
+                    return;
+                }
+            };
+
+        if prepared.is_empty() {
+            let not_found_set: HashSet<String> = not_found.into_iter().collect();
+            tracing::debug!(
+                ops = ops_count,
+                jobs = jobs_count,
+                "complete auto-batcher: nothing to commit"
+            );
+            fan_out(per_op_ids, replies, &HashSet::new(), &not_found_set);
+            return;
+        }
+
+        let mut tx = ks.write_tx();
+        let cas_ok = match apply_complete_batch(&mut tx, ks, &prepared) {
+            Ok(b) => b,
+            Err(e) => {
+                drop(tx);
+                tracing::error!(
+                    ops = ops_count,
+                    jobs = jobs_count,
+                    error = %e,
+                    "complete auto-batcher: apply_complete_batch failed"
+                );
+                let msg = e.to_string();
+                for reply in replies {
+                    let _ = reply.send(Err(StoreError::Internal(msg.clone())));
+                }
+                return;
+            }
+        };
+
+        if !cas_ok {
+            drop(tx);
+            // Re-read and retry. Same loop iteration.
+            continue;
+        }
+
+        if let Err(e) = ks.commit(tx, ks.default_commit_mode) {
+            tracing::error!(
+                ops = ops_count,
+                jobs = jobs_count,
+                error = %e,
+                "complete auto-batcher: commit failed"
+            );
+            let msg = e.to_string();
+            for reply in replies {
+                let _ = reply.send(Err(StoreError::Internal(msg.clone())));
+            }
+            return;
+        }
+
+        let not_found_set: HashSet<String> = not_found.into_iter().collect();
+        break (prepared, not_found_set);
+    };
+
+    // Update ready_index once per unique completed id.
+    for p in &prepared {
+        ready_index.remove(&p.queue, p.priority, &p.id);
+    }
+
+    // Broadcast JobCompleted + decrement in_flight_count once per
+    // unique completed id (not per occurrence across ops).
+    let completed_set: HashSet<String> = prepared.into_iter().map(|p| p.id).collect();
+    for id in &completed_set {
+        let _ = event_tx.send(StoreEvent::JobCompleted { id: id.clone() });
+    }
+    let unique_completed = completed_set.len() as u64;
+    if unique_completed > 0 {
+        let _ = in_flight_count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            Some(v.saturating_sub(unique_completed))
+        });
+    }
+
+    tracing::debug!(
+        ops = ops_count,
+        jobs = jobs_count,
+        completed = unique_completed,
+        not_found = not_found_set.len(),
+        "complete auto-batcher: committed batch"
+    );
+
+    fan_out(per_op_ids, replies, &completed_set, &not_found_set);
+}
+
+/// Build per-op `BulkCompleteResult`s by looking each op's submitted
+/// ids up against the global completed/not_found sets and send each
+/// op's reply.
+fn fan_out(
+    per_op_ids: Vec<Vec<String>>,
+    replies: Vec<tokio::sync::oneshot::Sender<Result<BulkCompleteResult, StoreError>>>,
+    completed_set: &HashSet<String>,
+    not_found_set: &HashSet<String>,
+) {
+    for (op_ids, reply) in per_op_ids.into_iter().zip(replies) {
+        let mut completed: Vec<String> = Vec::new();
+        let mut not_found: Vec<String> = Vec::new();
+        for id in op_ids {
+            if completed_set.contains(&id) {
+                completed.push(id);
+            } else if not_found_set.contains(&id) {
+                not_found.push(id);
+            }
+            // Otherwise: id was submitted but didn't appear in either
+            // set. Shouldn't happen given that pre_read_completes
+            // partitions every read id into one bucket. Swallow
+            // silently if it does — surfacing as a third "unknown"
+            // status would break the existing API contract.
+        }
+        let _ = reply.send(Ok(BulkCompleteResult {
+            completed,
+            not_found,
+        }));
+    }
+}

--- a/src/store/enqueue_batcher.rs
+++ b/src/store/enqueue_batcher.rs
@@ -1,0 +1,253 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Server-side opportunistic batching for concurrent enqueues.
+//!
+//! Concurrent applications typically enqueue jobs one at a time across
+//! each application thread/process, with occasional callers using the
+//! explicit `enqueue_bulk` path to submit many jobs together. At the
+//! storage layer all of these calls serialize behind fjall's
+//! single-writer tx mutex anyway, so coalescing them into one
+//! transaction is a pure win: one `tx.commit()` instead of N, one
+//! journal write instead of N (which is then further coalesced by the
+//! `GroupCommitter` for fsync).
+//!
+//! Both singular `enqueue` and `enqueue_bulk` calls flow through this
+//! batcher. Each op carries a `Vec<PreparedEnqueue>` — Vec-of-1 for
+//! singles, Vec-of-N for bulks. The batcher flat-maps them into one
+//! contiguous slice for `apply_enqueue_batch`, runs one commit, then
+//! slices the per-job results back into per-op chunks for fan-out to
+//! each waiter's oneshot.
+//!
+//! Atomicity is preserved: a bulk's "all-or-nothing" contract holds
+//! because the entire coalesced commit succeeds or fails as a unit.
+//! The channel is op-count bounded — a bulk counts as one op against
+//! the channel/batch budget regardless of how many jobs it carries,
+//! so a single in-flight bulk can be of any size. Memory pressure
+//! under pathological loads (1000 concurrent huge bulks) is in
+//! principle possible but practically rare; backpressure still works.
+//!
+//! Design:
+//!
+//! - Single dedicated OS thread (`enqueue-batcher`) drains a bounded
+//!   `std::sync::mpsc::sync_channel`.
+//! - Each request enters the channel with a `oneshot` reply slot.
+//! - The batcher blocks on `recv()` for the first op, then opportunistically
+//!   drains additional queued ops via `try_recv()` up to the configured
+//!   batch size — no time-based windowing, so single-op traffic gets zero
+//!   added latency.
+//! - One open `write_tx` is shared across the batch; on commit success,
+//!   each waiter's oneshot resolves with its individual results.
+//! - On commit failure, all waiters in the batch receive the same error
+//!   (wrapped as `StoreError::Internal` since the underlying error types
+//!   are not `Clone`).
+//! - Backpressure: a bounded channel means `send()` blocks when the
+//!   channel is full. Combined with the request being made from inside
+//!   `spawn_blocking`, this naturally throttles HTTP-handler concurrency.
+//! - Shutdown: dropping the `EnqueueBatcher` drops the `SyncSender`,
+//!   closing the channel. The batcher's `recv()` returns `Err`, after
+//!   draining any remaining queued ops via the inner `try_recv` loop.
+//!   In-flight HTTP handlers awaiting their oneshot are kept alive by
+//!   axum's `with_graceful_shutdown`, which transitively keeps the
+//!   `Arc<Store>` (and therefore this batcher) alive until they finish.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use super::ready_index::ReadyIndex;
+use super::results::EnqueueResult;
+use super::scheduled_index::ScheduledIndex;
+use super::store::{Keyspaces, PreparedEnqueue, StoreEvent, apply_enqueue_batch, finalize_enqueue};
+use super::types::StoreError;
+
+/// A single enqueue request in flight: the prepared jobs plus a
+/// oneshot slot for the per-request results. `prepared.len() == 1`
+/// for a singular `enqueue` call; `>= 1` for `enqueue_bulk`.
+pub(super) struct EnqueueOp {
+    pub prepared: Vec<PreparedEnqueue>,
+    pub reply: tokio::sync::oneshot::Sender<Result<Vec<EnqueueResult>, StoreError>>,
+}
+
+/// Auto-batcher for enqueue ops (singular + bulk). Owns the channel
+/// sender; the batcher thread runs detached and exits naturally when
+/// the sender drops.
+pub(super) struct EnqueueBatcher {
+    tx: std::sync::mpsc::SyncSender<EnqueueOp>,
+}
+
+impl EnqueueBatcher {
+    /// Spawn the batcher's background thread. The thread holds clones of
+    /// the store internals it needs to commit and finalize batches.
+    ///
+    /// `batch_size` is both the channel capacity (so backpressure kicks
+    /// in at the same point a single batch could absorb everything in
+    /// flight) and the max ops drained into a single `tx.commit()`.
+    /// Counts ops (i.e. requests), not jobs — a bulk request counts as
+    /// one op regardless of how many jobs it carries.
+    pub(super) fn start(
+        ks: Arc<Keyspaces>,
+        ready_index: Arc<ReadyIndex>,
+        scheduled_index: Arc<ScheduledIndex>,
+        event_tx: broadcast::Sender<StoreEvent>,
+        batch_size: usize,
+    ) -> Self {
+        // Defend against pathological config — a zero-cap channel would
+        // deadlock on send; size 1 effectively disables batching.
+        let batch_size = batch_size.max(1);
+
+        let (tx, rx) = std::sync::mpsc::sync_channel::<EnqueueOp>(batch_size);
+
+        std::thread::Builder::new()
+            .name("enqueue-batcher".into())
+            .spawn(move || {
+                // Block on the first op (sleeps the thread when idle).
+                // When the sender drops, recv() returns Err and we exit.
+                while let Ok(first) = rx.recv() {
+                    let mut batch = Vec::with_capacity(batch_size);
+                    batch.push(first);
+
+                    // Opportunistically drain whatever else is already
+                    // queued, up to the batch limit. Non-blocking — if
+                    // nothing more is waiting, process what we have.
+                    while batch.len() < batch_size {
+                        match rx.try_recv() {
+                            Ok(op) => batch.push(op),
+                            Err(_) => break,
+                        }
+                    }
+
+                    process_batch(&ks, &ready_index, &scheduled_index, &event_tx, batch);
+                }
+            })
+            .expect("failed to spawn enqueue-batcher thread");
+
+        Self { tx }
+    }
+
+    /// Push prepared enqueue(s) onto the channel and return a receiver
+    /// that resolves when the batch containing this op has been
+    /// committed (or failed). Blocks the calling thread if the channel
+    /// is full — callers must invoke this from `spawn_blocking`.
+    ///
+    /// `prepared.len() == 1` for singular enqueue; longer for bulk.
+    pub(super) fn submit(
+        &self,
+        prepared: Vec<PreparedEnqueue>,
+    ) -> tokio::sync::oneshot::Receiver<Result<Vec<EnqueueResult>, StoreError>> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        // If `send` errors, the channel is disconnected (batcher thread
+        // gone). The caller will see the receiver close and surface a
+        // StoreError::Internal from the `recv` side.
+        let _ = self.tx.send(EnqueueOp {
+            prepared,
+            reply: reply_tx,
+        });
+        reply_rx
+    }
+}
+
+/// Apply a coalesced batch to one write tx and fan results back to
+/// each waiter's oneshot. Each waiter receives the slice of results
+/// corresponding to the jobs they submitted.
+fn process_batch(
+    ks: &Keyspaces,
+    ready_index: &ReadyIndex,
+    scheduled_index: &ScheduledIndex,
+    event_tx: &broadcast::Sender<StoreEvent>,
+    batch: Vec<EnqueueOp>,
+) {
+    // Flatten per-op `Vec<PreparedEnqueue>`s into one contiguous slice
+    // for `apply_enqueue_batch`, recording each op's job count so we
+    // can slice the result Vec back into per-op chunks afterwards.
+    let ops_count = batch.len();
+    let mut sizes: Vec<usize> = Vec::with_capacity(ops_count);
+    let mut replies: Vec<tokio::sync::oneshot::Sender<_>> = Vec::with_capacity(ops_count);
+    let mut prepared: Vec<PreparedEnqueue> = Vec::new();
+
+    for op in batch {
+        sizes.push(op.prepared.len());
+        replies.push(op.reply);
+        prepared.extend(op.prepared);
+    }
+    let jobs_count = prepared.len();
+
+    tracing::debug!(
+        ops = ops_count,
+        jobs = jobs_count,
+        "enqueue auto-batcher: coalesced batch from channel"
+    );
+
+    let mut tx = ks.write_tx();
+    let results = match apply_enqueue_batch(&mut tx, ks, &prepared) {
+        Ok(r) => r,
+        Err(e) => {
+            // apply_enqueue_batch failed for the whole batch (e.g. a
+            // corruption error reading existing unique-index entries).
+            // Drop the tx and report the same error to every waiter.
+            drop(tx);
+            tracing::error!(
+                ops = ops_count,
+                jobs = jobs_count,
+                error = %e,
+                "enqueue auto-batcher: apply_enqueue_batch failed"
+            );
+            let msg = e.to_string();
+            for reply in replies {
+                let _ = reply.send(Err(StoreError::Internal(msg.clone())));
+            }
+            return;
+        }
+    };
+
+    // Skip the commit when every result was a duplicate —
+    // `apply_enqueue` makes zero tx writes in that case so committing
+    // would be wasteful. Mirrors the single-enqueue fast path.
+    let created = results
+        .iter()
+        .filter(|r| matches!(r, EnqueueResult::Created(_)))
+        .count();
+    let duplicate = jobs_count - created;
+
+    if created > 0 {
+        if let Err(e) = ks.commit(tx, ks.enqueue_commit_mode) {
+            tracing::error!(
+                ops = ops_count,
+                jobs = jobs_count,
+                error = %e,
+                "enqueue auto-batcher: commit failed"
+            );
+            let msg = e.to_string();
+            for reply in replies {
+                let _ = reply.send(Err(StoreError::Internal(msg.clone())));
+            }
+            return;
+        }
+        tracing::debug!(
+            ops = ops_count,
+            jobs = jobs_count,
+            created,
+            duplicate,
+            "enqueue auto-batcher: committed batch"
+        );
+    } else {
+        drop(tx);
+        tracing::debug!(
+            ops = ops_count,
+            jobs = jobs_count,
+            duplicate,
+            "enqueue auto-batcher: skipped commit (all duplicates)"
+        );
+    }
+
+    // Finalize each result (index updates, events), then slice the
+    // flat result Vec back into per-op chunks and reply.
+    let mut result_iter = results.into_iter();
+    for (size, reply) in sizes.into_iter().zip(replies) {
+        let chunk: Vec<EnqueueResult> = result_iter.by_ref().take(size).collect();
+        for r in &chunk {
+            finalize_enqueue(r, ready_index, scheduled_index, event_tx);
+        }
+        let _ = reply.send(Ok(chunk));
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 mod cron;
+mod enqueue_batcher;
 mod group_committer;
 mod options;
 mod ready_index;
@@ -21,8 +22,9 @@ pub use results::{BulkCompleteResult, EnqueueResult, ListErrorsPage, ListJobsPag
 pub use store::{
     DEFAULT_BACKOFF_BASE_MS, DEFAULT_BACKOFF_EXPONENT, DEFAULT_BACKOFF_JITTER_MS,
     DEFAULT_CACHE_SIZE, DEFAULT_COMPLETED_RETENTION_MS, DEFAULT_DATA_TABLE_SIZE,
-    DEFAULT_DEAD_RETENTION_MS, DEFAULT_INDEX_TABLE_SIZE, DEFAULT_JOURNAL_SIZE,
-    DEFAULT_L0_THRESHOLD, DEFAULT_RETRY_LIMIT, StorageConfig, Store, StoreEvent,
+    DEFAULT_DEAD_RETENTION_MS, DEFAULT_ENQUEUE_BATCH_SIZE, DEFAULT_INDEX_TABLE_SIZE,
+    DEFAULT_JOURNAL_SIZE, DEFAULT_L0_THRESHOLD, DEFAULT_RETRY_LIMIT, StorageConfig, Store,
+    StoreEvent,
 };
 
 pub use cron::{CronEntry, CronGroup};

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
+mod complete_batcher;
 mod cron;
 mod enqueue_batcher;
 mod group_committer;
@@ -21,10 +22,10 @@ pub use results::{BulkCompleteResult, EnqueueResult, ListErrorsPage, ListJobsPag
 
 pub use store::{
     DEFAULT_BACKOFF_BASE_MS, DEFAULT_BACKOFF_EXPONENT, DEFAULT_BACKOFF_JITTER_MS,
-    DEFAULT_CACHE_SIZE, DEFAULT_COMPLETED_RETENTION_MS, DEFAULT_DATA_TABLE_SIZE,
-    DEFAULT_DEAD_RETENTION_MS, DEFAULT_ENQUEUE_BATCH_SIZE, DEFAULT_INDEX_TABLE_SIZE,
-    DEFAULT_JOURNAL_SIZE, DEFAULT_L0_THRESHOLD, DEFAULT_RETRY_LIMIT, StorageConfig, Store,
-    StoreEvent,
+    DEFAULT_CACHE_SIZE, DEFAULT_COMPLETE_BATCH_SIZE, DEFAULT_COMPLETED_RETENTION_MS,
+    DEFAULT_DATA_TABLE_SIZE, DEFAULT_DEAD_RETENTION_MS, DEFAULT_ENQUEUE_BATCH_SIZE,
+    DEFAULT_INDEX_TABLE_SIZE, DEFAULT_JOURNAL_SIZE, DEFAULT_L0_THRESHOLD, DEFAULT_RETRY_LIMIT,
+    StorageConfig, Store, StoreEvent,
 };
 
 pub use cron::{CronEntry, CronGroup};

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -1504,42 +1504,13 @@ impl Store {
         let event_tx = self.event_tx.clone();
 
         task::spawn_blocking(move || -> Result<_, StoreError> {
-            use std::collections::HashMap;
-
             let prepared: Vec<PreparedEnqueue> = batch
                 .into_iter()
                 .map(|opts| prepare_enqueue(opts, now))
                 .collect::<Result<_, StoreError>>()?;
 
             let mut tx = ks.write_tx();
-
-            // Maps unique_key -> index in `results` for intra-batch conflicts.
-            let mut batch_unique_keys: HashMap<String, usize> = HashMap::new();
-            let mut results: Vec<EnqueueResult> = Vec::with_capacity(prepared.len());
-
-            for p in &prepared {
-                // Intra-batch unique conflict check (no DB read needed).
-                if let Some(ref uc) = p.job.unique {
-                    if let Some(&existing_idx) = batch_unique_keys.get(&uc.key) {
-                        results.push(EnqueueResult::Duplicate(
-                            results[existing_idx].job().clone(),
-                        ));
-                        continue;
-                    }
-                }
-
-                let result = apply_enqueue(&mut tx, &ks, p)?;
-
-                // Track unique keys for intra-batch dedup.
-                if let EnqueueResult::Created(ref job) = result {
-                    if let Some(ref uc) = job.unique {
-                        batch_unique_keys.insert(uc.key.clone(), results.len());
-                    }
-                }
-
-                results.push(result);
-            }
-
+            let results = apply_enqueue_batch(&mut tx, &ks, &prepared)?;
             ks.commit(tx, ks.enqueue_commit_mode)?;
 
             for r in &results {
@@ -5163,6 +5134,53 @@ fn apply_enqueue(
     }
 
     Ok(EnqueueResult::Created(p.job.clone()))
+}
+
+/// Apply a batch of prepared enqueues to an open write transaction with
+/// intra-batch unique-key dedup.
+///
+/// When two prepared jobs in the same batch share a `unique` key, the
+/// second one returns `EnqueueResult::Duplicate(...)` referring to the
+/// first without performing a tx insert. Cross-batch dedup against
+/// already-committed jobs is handled by `apply_enqueue` itself.
+///
+/// Does NOT commit the transaction — the caller commits and runs
+/// `finalize_enqueue` per result post-commit.
+fn apply_enqueue_batch(
+    tx: &mut fjall::SingleWriterWriteTx<'_>,
+    ks: &Keyspaces,
+    prepared: &[PreparedEnqueue],
+) -> Result<Vec<EnqueueResult>, StoreError> {
+    use std::collections::HashMap;
+
+    // Maps unique_key -> index in `results` for intra-batch conflicts.
+    let mut batch_unique_keys: HashMap<String, usize> = HashMap::new();
+    let mut results: Vec<EnqueueResult> = Vec::with_capacity(prepared.len());
+
+    for p in prepared {
+        // Intra-batch unique conflict check (no DB read needed).
+        if let Some(ref uc) = p.job.unique {
+            if let Some(&existing_idx) = batch_unique_keys.get(&uc.key) {
+                results.push(EnqueueResult::Duplicate(
+                    results[existing_idx].job().clone(),
+                ));
+                continue;
+            }
+        }
+
+        let result = apply_enqueue(tx, ks, p)?;
+
+        // Track unique keys for intra-batch dedup.
+        if let EnqueueResult::Created(ref job) = result {
+            if let Some(ref uc) = job.unique {
+                batch_unique_keys.insert(uc.key.clone(), results.len());
+            }
+        }
+
+        results.push(result);
+    }
+
+    Ok(results)
 }
 
 /// Update in-memory indexes for a successfully enqueued job.

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -38,6 +38,7 @@ use super::cron::CronScheduleIndex;
 use super::ready_index::ReadyIndex;
 use super::scheduled_index::ScheduledIndex;
 
+use super::complete_batcher::CompleteBatcher;
 use super::cron::{CronEntry, CronGroup};
 use super::enqueue_batcher::EnqueueBatcher;
 use super::group_committer::GroupCommitter;
@@ -324,9 +325,6 @@ pub struct Store {
     /// In-memory index of cron entries ordered by `next_enqueue_at`.
     cron_index: Arc<CronScheduleIndex>,
 
-    /// Default retention period for completed jobs (milliseconds).
-    default_completed_retention_ms: u64,
-
     /// Default retention period for dead jobs (milliseconds).
     default_dead_retention_ms: u64,
 
@@ -364,6 +362,10 @@ pub struct Store {
     /// Shut down by dropping (the inner `SyncSender` closes, the worker
     /// drains queued ops and exits).
     enqueue_batcher: Arc<EnqueueBatcher>,
+
+    /// Server-side auto-batcher for concurrent completions (acks).
+    /// Mirrors `enqueue_batcher` in structure and lifecycle.
+    complete_batcher: Arc<CompleteBatcher>,
 }
 
 /// One-byte tag prefix for records in the `data` keyspace.
@@ -416,7 +418,7 @@ pub(super) struct Keyspaces {
     group_committer: GroupCommitter,
 
     /// Default commit mode for most operations (dequeue, complete, fail, etc.).
-    default_commit_mode: CommitMode,
+    pub(super) default_commit_mode: CommitMode,
 
     /// Commit mode for enqueue operations (resolved at construction;
     /// inherits the default when not overridden).
@@ -1222,6 +1224,11 @@ pub struct StorageConfig {
     /// explicit `enqueue_bulk` calls, which run their own tx.
     pub enqueue_batch_size: usize,
 
+    /// Maximum number of completion (ack) requests coalesced into one
+    /// write transaction. Op-count bounded — a bulk-ack of N jobs
+    /// still counts as one op. Same shape as `enqueue_batch_size`.
+    pub complete_batch_size: usize,
+
     /// After a bulk mutation affects at least this many records, force a
     /// full LSM compaction to reclaim tombstones. Without this, leveled
     /// compaction can leave large pockets of garbage in the upper levels
@@ -1272,6 +1279,11 @@ pub const DEFAULT_AUTO_COMPACT_THRESHOLD: u64 = 10_000;
 /// into one auto-batched commit. Also the bounded channel capacity.
 pub const DEFAULT_ENQUEUE_BATCH_SIZE: usize = 1000;
 
+/// Default maximum number of concurrent completion (ack) requests
+/// coalesced into one auto-batched commit. Also the bounded channel
+/// capacity.
+pub const DEFAULT_COMPLETE_BATCH_SIZE: usize = 1000;
+
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
@@ -1291,6 +1303,7 @@ impl Default for StorageConfig {
             default_commit_mode: CommitMode::default(),
             enqueue_commit_mode: None,
             enqueue_batch_size: DEFAULT_ENQUEUE_BATCH_SIZE,
+            complete_batch_size: DEFAULT_COMPLETE_BATCH_SIZE,
             auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
         }
     }
@@ -1311,6 +1324,7 @@ impl StorageConfig {
     /// | `ZIZQ_DEFAULT_COMMIT_MODE` | `default_commit_mode` |
     /// | `ZIZQ_ENQUEUE_COMMIT_MODE` | `enqueue_commit_mode` |
     /// | `ZIZQ_ENQUEUE_BATCH_SIZE` | `enqueue_batch_size` |
+    /// | `ZIZQ_COMPLETE_BATCH_SIZE` | `complete_batch_size` |
     /// | `ZIZQ_AUTO_COMPACT_THRESHOLD` | `auto_compact_threshold` |
     pub fn from_env() -> Result<Self, EnvConfigError> {
         let defaults = Self::default();
@@ -1349,6 +1363,8 @@ impl StorageConfig {
             },
             enqueue_batch_size: env_parse("ZIZQ_ENQUEUE_BATCH_SIZE")?
                 .unwrap_or(defaults.enqueue_batch_size),
+            complete_batch_size: env_parse("ZIZQ_COMPLETE_BATCH_SIZE")?
+                .unwrap_or(defaults.complete_batch_size),
             auto_compact_threshold: env_parse("ZIZQ_AUTO_COMPACT_THRESHOLD")?
                 .unwrap_or(defaults.auto_compact_threshold),
         })
@@ -1458,10 +1474,10 @@ impl Store {
         let scheduled_index = Arc::new(ScheduledIndex::new());
 
         // Start the enqueue auto-batcher — a dedicated OS thread that
-        // coalesces concurrent single-job enqueues into one tx.commit().
-        // Shuts down when this Store (and any spawn_blocking clones of
-        // the Arc) drops — the inner SyncSender closes, the worker
-        // drains remaining ops and exits.
+        // coalesces concurrent enqueue requests (singular + bulk) into
+        // one tx.commit(). Shuts down when this Store (and any
+        // spawn_blocking clones of the Arc) drops — the inner
+        // SyncSender closes, the worker drains remaining ops and exits.
         let enqueue_batcher = Arc::new(EnqueueBatcher::start(
             ks.clone(),
             ready_index.clone(),
@@ -1470,20 +1486,33 @@ impl Store {
             config.enqueue_batch_size,
         ));
 
+        let in_flight_count = Arc::new(AtomicU64::new(0));
+
+        // Start the complete auto-batcher — same shape as the enqueue
+        // batcher, coalesces concurrent completion (ack) requests.
+        let complete_batcher = Arc::new(CompleteBatcher::start(
+            ks.clone(),
+            ready_index.clone(),
+            in_flight_count.clone(),
+            event_tx.clone(),
+            config.default_completed_retention_ms,
+            config.complete_batch_size,
+        ));
+
         Ok(Self {
             config: config.clone(),
             ks,
             ready_index,
             scheduled_index,
             cron_index: Arc::new(CronScheduleIndex::new()),
-            default_completed_retention_ms: config.default_completed_retention_ms,
             default_dead_retention_ms: config.default_dead_retention_ms,
             default_retry_limit: config.default_retry_limit,
             default_backoff: config.default_backoff,
             index_ready: Arc::new(AtomicBool::new(true)),
-            in_flight_count: Arc::new(AtomicU64::new(0)),
+            in_flight_count,
             event_tx,
             enqueue_batcher,
+            complete_batcher,
         })
     }
 
@@ -1802,119 +1831,12 @@ impl Store {
     /// reaper will hard-delete it after the retention period. Returns `true`
     /// if the job was found in the in-flight state, `false` if it was not.
     ///
-    /// Subscribers are notified on success.
+    /// Subscribers are notified on success. Routes through the same
+    /// auto-batcher as `mark_completed_bulk` — a singular ack is a
+    /// Vec-of-1 trip through the channel.
     pub async fn mark_completed(&self, now: u64, id: &str) -> Result<bool, StoreError> {
-        let ks = self.ks.clone();
-        let ready_index = self.ready_index.clone();
-        let default_completed_retention_ms = self.default_completed_retention_ms;
-        let id = id.to_string();
-        let id_for_event = id.clone();
-
-        let completed = task::spawn_blocking(move || -> Result<_, StoreError> {
-            // Retry loop: pre-read and pre-compute changes outside the tx,
-            // then compare-and-write inside. Retries only if a concurrent job
-            // metadata update modified the job between the pre-read and lock
-            // acquisition.
-            let job_key = make_job_key(&id);
-            loop {
-                // ---- outside tx ----
-                let pre_bytes = match ks.data.get(&job_key)? {
-                    Some(bytes) => bytes,
-                    None => return Ok(false),
-                };
-
-                let mut job: Job = rmp_serde::from_slice(&pre_bytes)?;
-
-                if job.status != JobStatus::InFlight as u8 {
-                    return Ok(false);
-                }
-
-                let retention_ms = job
-                    .retention
-                    .as_ref()
-                    .and_then(|r| r.completed_ms)
-                    .unwrap_or(default_completed_retention_ms);
-
-                if retention_ms == 0 {
-                    // Zero retention: prepare deletion keys outside tx.
-                    let del = prepare_job_deletion(&job, JobStatus::InFlight, &ks);
-
-                    // ---- inside tx ----
-                    let mut tx = ks.write_tx();
-                    let prev = tx.take(&ks.data, &job_key)?;
-                    if prev.as_deref() != Some(&*pre_bytes) {
-                        drop(tx);
-                        continue;
-                    }
-                    apply_job_deletion(&mut tx, &del, &ks);
-                    ks.commit(tx, ks.default_commit_mode)?;
-
-                    ready_index.remove(&job.queue, job.priority, &id);
-
-                    return Ok(true);
-                }
-
-                // Non-zero retention: defer deletion to the reaper.
-                let purge_at = now + retention_ms;
-
-                let old_status_key = make_status_key(JobStatus::InFlight, &id);
-                let new_status_key = make_status_key(JobStatus::Completed, &id);
-                let purge_key = make_purge_key(purge_at, &id);
-
-                job.status = JobStatus::Completed.into();
-                job.purge_at = Some(purge_at);
-                job.completed_at = Some(now);
-
-                let updated_slice: Slice = rmp_serde::to_vec_named(&job)?.into();
-
-                // ---- inside tx ----
-                let mut tx = ks.write_tx();
-
-                let prev = tx.fetch_update(&ks.data, &job_key, |_| Some(updated_slice.clone()))?;
-
-                if prev.as_deref() != Some(&*pre_bytes) {
-                    drop(tx);
-                    continue;
-                }
-
-                tx.remove(&ks.index, &old_status_key);
-                tx.insert(&ks.index, &new_status_key, b"");
-                tx.insert(&ks.index, &purge_key, b"");
-
-                // Remove unique index for Queued or Active scope on completion,
-                // but only if it still belongs to this job.
-                if let Some(ref uc) = job.unique {
-                    let scope = uc.unique_while();
-                    if scope == UniqueWhile::Queued || scope == UniqueWhile::Active {
-                        let job_id = id.as_bytes();
-                        tx.fetch_update(&ks.index, &make_unique_key(&uc.key), |v| match v {
-                            Some(v) if v.as_ref() == job_id => None,
-                            other => other.cloned(),
-                        })?;
-                    }
-                }
-
-                ks.commit(tx, ks.default_commit_mode)?;
-
-                ready_index.remove(&job.queue, job.priority, &id);
-
-                return Ok(true);
-            }
-        })
-        .await??;
-
-        if completed {
-            let _ = self
-                .in_flight_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_sub(1))
-                });
-            let _ = self
-                .event_tx
-                .send(StoreEvent::JobCompleted { id: id_for_event });
-        }
-
-        Ok(completed)
+        let result = self.mark_completed_bulk(now, &[id.to_string()]).await?;
+        Ok(!result.completed.is_empty())
     }
 
     /// Mark multiple jobs as successfully completed in a single transaction.
@@ -1927,74 +1849,25 @@ impl Store {
         now: u64,
         ids: &[String],
     ) -> Result<BulkCompleteResult, StoreError> {
-        let ks = self.ks.clone();
-        let ready_index = self.ready_index.clone();
-        let default_completed_retention_ms = self.default_completed_retention_ms;
-        let mut seen = HashSet::with_capacity(ids.len());
-        let ids: Vec<String> = ids.iter().filter(|id| seen.insert(*id)).cloned().collect();
-        let event_tx = self.event_tx.clone();
-
-        let result = task::spawn_blocking(move || -> Result<_, StoreError> {
-            // CAS-retry loop: re-read all jobs on conflict and re-attempt
-            // the apply. Conflicts are rare in practice (the most common
-            // cause is a concurrent patch_job on a job being completed),
-            // so the cost of re-reading is amortised across normal runs.
-            loop {
-                let (prepared, not_found) =
-                    pre_read_completes(&ids, now, &ks, default_completed_retention_ms)?;
-
-                if prepared.is_empty() {
-                    return Ok(BulkCompleteResult {
-                        completed: Vec::new(),
-                        not_found,
-                    });
-                }
-
-                let mut tx = ks.write_tx();
-                if !apply_complete_batch(&mut tx, &ks, &prepared)? {
-                    // CAS mismatch on at least one job — drop the tx
-                    // (rolls back any partial writes), then re-read
-                    // everything and try again.
-                    drop(tx);
-                    continue;
-                }
-
-                ks.commit(tx, ks.default_commit_mode)?;
-
-                // Update ready_index for all completed jobs (the
-                // status-transition path; ready_index entries for InFlight
-                // jobs were already removed at take time, but this is the
-                // canonical cleanup for any stragglers).
-                for p in &prepared {
-                    ready_index.remove(&p.queue, p.priority, &p.id);
-                }
-
-                let completed: Vec<String> = prepared.into_iter().map(|p| p.id).collect();
-
-                return Ok(BulkCompleteResult {
-                    completed,
-                    not_found,
-                });
-            }
-        })
-        .await?;
-
-        let bulk_result = result?;
-
-        if !bulk_result.completed.is_empty() {
-            let _ = self
-                .in_flight_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_sub(bulk_result.completed.len() as u64))
-                });
+        if ids.is_empty() {
+            return Ok(BulkCompleteResult {
+                completed: Vec::new(),
+                not_found: Vec::new(),
+            });
         }
 
-        // Broadcast JobCompleted for each completed job.
-        for id in &bulk_result.completed {
-            let _ = event_tx.send(StoreEvent::JobCompleted { id: id.clone() });
-        }
+        // Route through the auto-batcher. Per-op dedup happens inside
+        // the batcher; ready_index updates, in_flight_count decrement,
+        // and JobCompleted event broadcasts are all performed once per
+        // unique completed job in the batcher thread.
+        let batcher = self.complete_batcher.clone();
+        let ids: Vec<String> = ids.to_vec();
 
-        Ok(bulk_result)
+        let reply_rx = task::spawn_blocking(move || batcher.submit(ids, now)).await?;
+
+        reply_rx
+            .await
+            .map_err(|_| StoreError::Internal("complete auto-batcher channel closed".into()))?
     }
 
     /// Record a job failure and either schedule a retry or kill the job

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -1934,178 +1934,50 @@ impl Store {
         let ids: Vec<String> = ids.iter().filter(|id| seen.insert(*id)).cloned().collect();
         let event_tx = self.event_tx.clone();
 
-        let result =
-            task::spawn_blocking(move || -> Result<_, StoreError> {
-                /// A job that has been pre-read and prepared for completion.
-                struct Prepared {
-                    id: String,
-                    queue: String,
-                    pre_bytes: Slice,
-                    priority: u16,
-                    /// `None` for zero-retention (will be deleted).
-                    updated_bytes: Option<Slice>,
-                    /// `Some` for zero-retention (will be deleted).
-                    deletion: Option<JobDeletion>,
-                    /// Index key updates for non-zero retention jobs.
-                    index_keys: Option<RetentionKeys>,
-                    /// Unique constraint for this job (if any).
-                    unique: Option<UniqueConstraint>,
-                }
+        let result = task::spawn_blocking(move || -> Result<_, StoreError> {
+            // CAS-retry loop: re-read all jobs on conflict and re-attempt
+            // the apply. Conflicts are rare in practice (the most common
+            // cause is a concurrent patch_job on a job being completed),
+            // so the cost of re-reading is amortised across normal runs.
+            loop {
+                let (prepared, not_found) =
+                    pre_read_completes(&ids, now, &ks, default_completed_retention_ms)?;
 
-                /// Pre-computed index keys for a non-zero-retention completion.
-                struct RetentionKeys {
-                    old_status: Vec<u8>,
-                    new_status: Vec<u8>,
-                    purge: Vec<u8>,
-                }
-
-                let mut not_found: Vec<String> = Vec::new();
-
-                loop {
-                    // ---- outside tx: pre-read and prepare ----
-                    let mut prepared: Vec<Prepared> = Vec::new();
-
-                    for id in &ids {
-                        let job_key = make_job_key(id);
-                        let pre_bytes = match ks.data.get(&job_key)? {
-                            Some(bytes) => bytes,
-                            None => {
-                                not_found.push(id.clone());
-                                continue;
-                            }
-                        };
-
-                        let mut job: Job = rmp_serde::from_slice(&pre_bytes)?;
-
-                        if job.status != JobStatus::InFlight as u8 {
-                            not_found.push(id.clone());
-                            continue;
-                        }
-
-                        let retention_ms = job
-                            .retention
-                            .as_ref()
-                            .and_then(|r| r.completed_ms)
-                            .unwrap_or(default_completed_retention_ms);
-
-                        if retention_ms == 0 {
-                            let del = prepare_job_deletion(&job, JobStatus::InFlight, &ks);
-                            prepared.push(Prepared {
-                                id: id.clone(),
-                                queue: job.queue.clone(),
-                                pre_bytes,
-                                priority: job.priority,
-                                updated_bytes: None,
-                                deletion: Some(del),
-                                index_keys: None,
-                                unique: None,
-                            });
-                        } else {
-                            let purge_at = now + retention_ms;
-                            let old_status_key = make_status_key(JobStatus::InFlight, id);
-                            let new_status_key = make_status_key(JobStatus::Completed, id);
-                            let purge_key = make_purge_key(purge_at, id);
-
-                            let unique = job.unique.clone();
-
-                            let queue = job.queue.clone();
-                            job.status = JobStatus::Completed.into();
-                            job.purge_at = Some(purge_at);
-                            job.completed_at = Some(now);
-
-                            let updated_slice: Slice = rmp_serde::to_vec_named(&job)?.into();
-
-                            prepared.push(Prepared {
-                                id: id.clone(),
-                                queue,
-                                pre_bytes,
-                                priority: job.priority,
-                                updated_bytes: Some(updated_slice),
-                                deletion: None,
-                                index_keys: Some(RetentionKeys {
-                                    old_status: old_status_key,
-                                    new_status: new_status_key,
-                                    purge: purge_key,
-                                }),
-                                unique,
-                            });
-                        }
-                    }
-
-                    if prepared.is_empty() {
-                        return Ok(BulkCompleteResult {
-                            completed: Vec::new(),
-                            not_found,
-                        });
-                    }
-
-                    // ---- inside tx ----
-                    let mut tx = ks.write_tx();
-                    let mut cas_conflict_detected = false;
-
-                    for p in &prepared {
-                        let job_key = make_job_key(&p.id);
-
-                        if let Some(ref del) = p.deletion {
-                            // Zero-retention: delete via CAS.
-                            let prev = tx.take(&ks.data, &job_key)?;
-                            if prev.as_deref() != Some(&*p.pre_bytes) {
-                                cas_conflict_detected = true;
-                                break;
-                            }
-                            apply_job_deletion(&mut tx, del, &ks);
-                        } else if let Some(ref updated) = p.updated_bytes {
-                            // Non-zero retention: update via CAS.
-                            let prev =
-                                tx.fetch_update(&ks.data, &job_key, |_| Some(updated.clone()))?;
-                            if prev.as_deref() != Some(&*p.pre_bytes) {
-                                cas_conflict_detected = true;
-                                break;
-                            }
-                            let keys = p.index_keys.as_ref().unwrap();
-                            tx.remove(&ks.index, &keys.old_status);
-                            tx.insert(&ks.index, &keys.new_status, b"");
-                            tx.insert(&ks.index, &keys.purge, b"");
-
-                            // Remove unique index for Queued or Active scope,
-                            // but only if it still belongs to this job.
-                            if let Some(ref uc) = p.unique {
-                                let scope = uc.unique_while();
-                                if scope == UniqueWhile::Queued || scope == UniqueWhile::Active {
-                                    let job_id = p.id.as_bytes();
-                                    tx.fetch_update(&ks.index, &make_unique_key(&uc.key), |v| {
-                                        match v {
-                                            Some(v) if v.as_ref() == job_id => None,
-                                            other => other.cloned(),
-                                        }
-                                    })?;
-                                }
-                            }
-                        }
-                    }
-
-                    if cas_conflict_detected {
-                        drop(tx);
-                        not_found.clear();
-                        continue; // Retry from pre-read.
-                    }
-
-                    ks.commit(tx, ks.default_commit_mode)?;
-
-                    // Update ready_index for all completed jobs.
-                    for p in &prepared {
-                        ready_index.remove(&p.queue, p.priority, &p.id);
-                    }
-
-                    let completed: Vec<String> = prepared.into_iter().map(|p| p.id).collect();
-
+                if prepared.is_empty() {
                     return Ok(BulkCompleteResult {
-                        completed,
+                        completed: Vec::new(),
                         not_found,
                     });
                 }
-            })
-            .await?;
+
+                let mut tx = ks.write_tx();
+                if !apply_complete_batch(&mut tx, &ks, &prepared)? {
+                    // CAS mismatch on at least one job — drop the tx
+                    // (rolls back any partial writes), then re-read
+                    // everything and try again.
+                    drop(tx);
+                    continue;
+                }
+
+                ks.commit(tx, ks.default_commit_mode)?;
+
+                // Update ready_index for all completed jobs (the
+                // status-transition path; ready_index entries for InFlight
+                // jobs were already removed at take time, but this is the
+                // canonical cleanup for any stragglers).
+                for p in &prepared {
+                    ready_index.remove(&p.queue, p.priority, &p.id);
+                }
+
+                let completed: Vec<String> = prepared.into_iter().map(|p| p.id).collect();
+
+                return Ok(BulkCompleteResult {
+                    completed,
+                    not_found,
+                });
+            }
+        })
+        .await?;
 
         let bulk_result = result?;
 
@@ -5000,7 +4872,7 @@ fn error_keys(ks: &Keyspaces, job_id: &str) -> impl Iterator<Item = Vec<u8>> {
 ///
 /// Built by `prepare_job_deletion` (no tx required), applied by
 /// `apply_job_deletion` (write-only inside an open tx).
-struct JobDeletion {
+pub(super) struct JobDeletion {
     id: String,
     status_key: Vec<u8>,
     queue_key: Vec<u8>,
@@ -5258,6 +5130,176 @@ pub(super) fn finalize_enqueue(
             }
         }
     }
+}
+
+/// A job that has been pre-read and prepared for completion. Built by
+/// `pre_read_completes` (no tx required), applied by
+/// `apply_complete_batch` inside a write transaction.
+///
+/// Carries the original `pre_bytes` for CAS verification at apply time.
+/// If the job's stored bytes changed between pre-read and tx, the apply
+/// reports a CAS conflict and the caller must retry the pre-read.
+pub(super) struct PreparedComplete {
+    pub id: String,
+    pub queue: String,
+    pub pre_bytes: Slice,
+    pub priority: u16,
+    /// `None` for zero-retention completions (which delete the job).
+    pub updated_bytes: Option<Slice>,
+    /// `Some` for zero-retention completions (delete-paths).
+    pub deletion: Option<JobDeletion>,
+    /// Pre-computed index key updates for non-zero-retention paths.
+    pub index_keys: Option<CompletionRetentionKeys>,
+    /// Unique constraint snapshot for cleaning up the unique index.
+    pub unique: Option<UniqueConstraint>,
+}
+
+/// Pre-computed index keys for a non-zero-retention completion.
+pub(super) struct CompletionRetentionKeys {
+    pub old_status: Vec<u8>,
+    pub new_status: Vec<u8>,
+    pub purge: Vec<u8>,
+}
+
+/// Pre-read the given job ids and build the list of `PreparedComplete`
+/// values for those that are still in `InFlight` state. Jobs that are
+/// missing or in a different status are pushed into `not_found`.
+///
+/// Does NOT open a transaction — reads go directly through the
+/// keyspace, so the returned `pre_bytes` may be invalidated by
+/// concurrent writers. `apply_complete_batch` verifies via CAS and
+/// surfaces conflicts to the caller.
+pub(super) fn pre_read_completes(
+    ids: &[String],
+    now: u64,
+    ks: &Keyspaces,
+    default_completed_retention_ms: u64,
+) -> Result<(Vec<PreparedComplete>, Vec<String>), StoreError> {
+    let mut prepared: Vec<PreparedComplete> = Vec::with_capacity(ids.len());
+    let mut not_found: Vec<String> = Vec::new();
+
+    for id in ids {
+        let job_key = make_job_key(id);
+        let pre_bytes = match ks.data.get(&job_key)? {
+            Some(bytes) => bytes,
+            None => {
+                not_found.push(id.clone());
+                continue;
+            }
+        };
+
+        let mut job: Job = rmp_serde::from_slice(&pre_bytes)?;
+
+        if job.status != JobStatus::InFlight as u8 {
+            not_found.push(id.clone());
+            continue;
+        }
+
+        let retention_ms = job
+            .retention
+            .as_ref()
+            .and_then(|r| r.completed_ms)
+            .unwrap_or(default_completed_retention_ms);
+
+        if retention_ms == 0 {
+            let del = prepare_job_deletion(&job, JobStatus::InFlight, ks);
+            prepared.push(PreparedComplete {
+                id: id.clone(),
+                queue: job.queue.clone(),
+                pre_bytes,
+                priority: job.priority,
+                updated_bytes: None,
+                deletion: Some(del),
+                index_keys: None,
+                unique: None,
+            });
+        } else {
+            let purge_at = now + retention_ms;
+            let old_status_key = make_status_key(JobStatus::InFlight, id);
+            let new_status_key = make_status_key(JobStatus::Completed, id);
+            let purge_key = make_purge_key(purge_at, id);
+
+            let unique = job.unique.clone();
+
+            let queue = job.queue.clone();
+            job.status = JobStatus::Completed.into();
+            job.purge_at = Some(purge_at);
+            job.completed_at = Some(now);
+
+            let updated_slice: Slice = rmp_serde::to_vec_named(&job)?.into();
+
+            prepared.push(PreparedComplete {
+                id: id.clone(),
+                queue,
+                pre_bytes,
+                priority: job.priority,
+                updated_bytes: Some(updated_slice),
+                deletion: None,
+                index_keys: Some(CompletionRetentionKeys {
+                    old_status: old_status_key,
+                    new_status: new_status_key,
+                    purge: purge_key,
+                }),
+                unique,
+            });
+        }
+    }
+
+    Ok((prepared, not_found))
+}
+
+/// Apply a batch of prepared completions to an open write transaction
+/// with optimistic-concurrency CAS verification.
+///
+/// On any CAS mismatch, returns `Ok(false)` immediately without writing
+/// further items. The caller must drop the tx and retry the
+/// pre-read+apply sequence — the returned tx is left in a stale state
+/// (some items may have been written before the conflict was detected).
+///
+/// On success, every item has been applied to the tx; caller commits.
+/// Does NOT commit the transaction.
+pub(super) fn apply_complete_batch(
+    tx: &mut fjall::SingleWriterWriteTx<'_>,
+    ks: &Keyspaces,
+    prepared: &[PreparedComplete],
+) -> Result<bool, StoreError> {
+    for p in prepared {
+        let job_key = make_job_key(&p.id);
+
+        if let Some(ref del) = p.deletion {
+            // Zero-retention: delete via CAS.
+            let prev = tx.take(&ks.data, &job_key)?;
+            if prev.as_deref() != Some(&*p.pre_bytes) {
+                return Ok(false);
+            }
+            apply_job_deletion(tx, del, ks);
+        } else if let Some(ref updated) = p.updated_bytes {
+            // Non-zero retention: update via CAS.
+            let prev = tx.fetch_update(&ks.data, &job_key, |_| Some(updated.clone()))?;
+            if prev.as_deref() != Some(&*p.pre_bytes) {
+                return Ok(false);
+            }
+            let keys = p.index_keys.as_ref().unwrap();
+            tx.remove(&ks.index, &keys.old_status);
+            tx.insert(&ks.index, &keys.new_status, b"");
+            tx.insert(&ks.index, &keys.purge, b"");
+
+            // Remove unique index for Queued or Active scope on
+            // completion, but only if it still belongs to this job.
+            if let Some(ref uc) = p.unique {
+                let scope = uc.unique_while();
+                if scope == UniqueWhile::Queued || scope == UniqueWhile::Active {
+                    let job_id = p.id.as_bytes();
+                    tx.fetch_update(&ks.index, &make_unique_key(&uc.key), |v| match v {
+                        Some(v) if v.as_ref() == job_id => None,
+                        other => other.cloned(),
+                    })?;
+                }
+            }
+        }
+    }
+
+    Ok(true)
 }
 
 /// Compute the backoff delay in milliseconds for a given attempt count.

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -39,6 +39,7 @@ use super::ready_index::ReadyIndex;
 use super::scheduled_index::ScheduledIndex;
 
 use super::cron::{CronEntry, CronGroup};
+use super::enqueue_batcher::EnqueueBatcher;
 use super::group_committer::GroupCommitter;
 use super::options::{
     BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
@@ -356,6 +357,13 @@ pub struct Store {
     /// or otherwise change state. Take handlers use this both to wake up
     /// when new work is available and to prune their in-flight tracking.
     event_tx: broadcast::Sender<StoreEvent>,
+
+    /// Server-side auto-batcher for concurrent single-job enqueues.
+    /// Owned in an `Arc` so spawn_blocking tasks can cheaply clone the
+    /// handle without holding a `&Store` borrow across the .await.
+    /// Shut down by dropping (the inner `SyncSender` closes, the worker
+    /// drains queued ops and exits).
+    enqueue_batcher: Arc<EnqueueBatcher>,
 }
 
 /// One-byte tag prefix for records in the `data` keyspace.
@@ -386,7 +394,7 @@ enum IndexKind {
 /// Groups the fjall database handle and all disk keyspaces into a single
 /// cheaply-cloneable unit. Wrapped in `Arc` inside `Store` so that every
 /// async method only bumps one reference count instead of three.
-struct Keyspaces {
+pub(super) struct Keyspaces {
     /// Connection to the underlying database.
     db: SingleWriterTxDatabase,
 
@@ -412,12 +420,12 @@ struct Keyspaces {
 
     /// Commit mode for enqueue operations (resolved at construction;
     /// inherits the default when not overridden).
-    enqueue_commit_mode: CommitMode,
+    pub(super) enqueue_commit_mode: CommitMode,
 }
 
 impl Keyspaces {
     /// Acquire the single-writer transaction lock.
-    fn write_tx(&self) -> fjall::SingleWriterWriteTx<'_> {
+    pub(super) fn write_tx(&self) -> fjall::SingleWriterWriteTx<'_> {
         self.db.write_tx()
     }
 
@@ -426,7 +434,7 @@ impl Keyspaces {
     /// Calls fjall's `tx.commit()` to buffer the write, then sends a sync
     /// request to the group committer and blocks until it completes.
     /// Since this is always called inside `spawn_blocking`, blocking is safe.
-    fn commit(
+    pub(super) fn commit(
         &self,
         tx: fjall::SingleWriterWriteTx<'_>,
         mode: CommitMode,
@@ -1207,6 +1215,13 @@ pub struct StorageConfig {
     /// enqueue inherits `default_commit_mode`.
     pub enqueue_commit_mode: Option<CommitMode>,
 
+    /// Maximum number of single-job enqueues coalesced into one write
+    /// transaction by the server-side auto-batcher. Also the bounded
+    /// channel capacity for in-flight enqueue requests, so it caps both
+    /// per-batch size and total in-flight load. Does NOT apply to
+    /// explicit `enqueue_bulk` calls, which run their own tx.
+    pub enqueue_batch_size: usize,
+
     /// After a bulk mutation affects at least this many records, force a
     /// full LSM compaction to reclaim tombstones. Without this, leveled
     /// compaction can leave large pockets of garbage in the upper levels
@@ -1253,6 +1268,10 @@ pub const DEFAULT_DEAD_RETENTION_MS: u64 = 604_800_000;
 /// compaction once they commit.
 pub const DEFAULT_AUTO_COMPACT_THRESHOLD: u64 = 10_000;
 
+/// Default maximum number of concurrent single-job enqueues coalesced
+/// into one auto-batched commit. Also the bounded channel capacity.
+pub const DEFAULT_ENQUEUE_BATCH_SIZE: usize = 1000;
+
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
@@ -1271,6 +1290,7 @@ impl Default for StorageConfig {
             },
             default_commit_mode: CommitMode::default(),
             enqueue_commit_mode: None,
+            enqueue_batch_size: DEFAULT_ENQUEUE_BATCH_SIZE,
             auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
         }
     }
@@ -1290,6 +1310,7 @@ impl StorageConfig {
     /// | `ZIZQ_L0_THRESHOLD`       | `l0_threshold`     |
     /// | `ZIZQ_DEFAULT_COMMIT_MODE` | `default_commit_mode` |
     /// | `ZIZQ_ENQUEUE_COMMIT_MODE` | `enqueue_commit_mode` |
+    /// | `ZIZQ_ENQUEUE_BATCH_SIZE` | `enqueue_batch_size` |
     /// | `ZIZQ_AUTO_COMPACT_THRESHOLD` | `auto_compact_threshold` |
     pub fn from_env() -> Result<Self, EnvConfigError> {
         let defaults = Self::default();
@@ -1326,6 +1347,8 @@ impl StorageConfig {
                     });
                 }
             },
+            enqueue_batch_size: env_parse("ZIZQ_ENQUEUE_BATCH_SIZE")?
+                .unwrap_or(defaults.enqueue_batch_size),
             auto_compact_threshold: env_parse("ZIZQ_AUTO_COMPACT_THRESHOLD")?
                 .unwrap_or(defaults.auto_compact_threshold),
         })
@@ -1423,18 +1446,35 @@ impl Store {
         // SyncSender closes, the thread drains and does a final SyncAll).
         let group_committer = GroupCommitter::start(db.clone(), path.to_path_buf());
 
+        let ks = Arc::new(Keyspaces {
+            db,
+            data,
+            index,
+            group_committer,
+            default_commit_mode,
+            enqueue_commit_mode,
+        });
+        let ready_index = Arc::new(ReadyIndex::new());
+        let scheduled_index = Arc::new(ScheduledIndex::new());
+
+        // Start the enqueue auto-batcher — a dedicated OS thread that
+        // coalesces concurrent single-job enqueues into one tx.commit().
+        // Shuts down when this Store (and any spawn_blocking clones of
+        // the Arc) drops — the inner SyncSender closes, the worker
+        // drains remaining ops and exits.
+        let enqueue_batcher = Arc::new(EnqueueBatcher::start(
+            ks.clone(),
+            ready_index.clone(),
+            scheduled_index.clone(),
+            event_tx.clone(),
+            config.enqueue_batch_size,
+        ));
+
         Ok(Self {
             config: config.clone(),
-            ks: Arc::new(Keyspaces {
-                db,
-                data,
-                index,
-                group_committer,
-                default_commit_mode,
-                enqueue_commit_mode,
-            }),
-            ready_index: Arc::new(ReadyIndex::new()),
-            scheduled_index: Arc::new(ScheduledIndex::new()),
+            ks,
+            ready_index,
+            scheduled_index,
             cron_index: Arc::new(CronScheduleIndex::new()),
             default_completed_retention_ms: config.default_completed_retention_ms,
             default_dead_retention_ms: config.default_dead_retention_ms,
@@ -1443,6 +1483,7 @@ impl Store {
             index_ready: Arc::new(AtomicBool::new(true)),
             in_flight_count: Arc::new(AtomicU64::new(0)),
             event_tx,
+            enqueue_batcher,
         })
     }
 
@@ -1460,28 +1501,28 @@ impl Store {
         now: u64,
         opts: EnqueueOptions,
     ) -> Result<EnqueueResult, StoreError> {
-        let ks = self.ks.clone();
-        let ready_index = self.ready_index.clone();
-        let scheduled_index = self.scheduled_index.clone();
-        let event_tx = self.event_tx.clone();
+        // Singleton enqueue is a Vec-of-1 trip through the same
+        // batcher path as `enqueue_bulk`. The batcher coalesces this
+        // with whatever else is in the channel at mutex-acquire time
+        // and commits the whole coalesced batch atomically.
+        let batcher = self.enqueue_batcher.clone();
 
-        task::spawn_blocking(move || -> Result<_, StoreError> {
+        let reply_rx = task::spawn_blocking(move || -> Result<_, StoreError> {
             let prepared = prepare_enqueue(opts, now)?;
-
-            let mut tx = ks.write_tx();
-            let result = apply_enqueue(&mut tx, &ks, &prepared)?;
-
-            if result.is_duplicate() {
-                drop(tx);
-            } else {
-                ks.commit(tx, ks.enqueue_commit_mode)?;
-            }
-
-            finalize_enqueue(&result, &ready_index, &scheduled_index, &event_tx);
-
-            Ok(result)
+            Ok(batcher.submit(vec![prepared]))
         })
-        .await?
+        .await??;
+
+        let mut results = reply_rx
+            .await
+            .map_err(|_| StoreError::Internal("enqueue auto-batcher channel closed".into()))??;
+
+        // Vec-of-1 contract — the batcher always returns the same number
+        // of results as the input length. `unwrap` is safe in
+        // principle, but we still guard against batcher-side bugs.
+        results.pop().ok_or_else(|| {
+            StoreError::Internal("enqueue auto-batcher returned empty result".into())
+        })
     }
 
     /// Enqueue multiple jobs in a single transaction.
@@ -1489,6 +1530,12 @@ impl Store {
     /// All jobs are serialized and inserted under one write transaction with
     /// a single commit. In-memory indexes are updated after commit succeeds.
     /// Events are broadcast after the sync completes.
+    ///
+    /// Bulk participates in the same auto-batcher as singular enqueue —
+    /// a bulk-of-N counts as one op in the batcher's op-count budget,
+    /// and may share a commit with other concurrent enqueue requests.
+    /// Atomicity is preserved at the commit boundary: if the coalesced
+    /// commit fails, every participating op fails together.
     pub async fn enqueue_bulk(
         &self,
         now: u64,
@@ -1498,28 +1545,20 @@ impl Store {
             return Ok(Vec::new());
         }
 
-        let ks = self.ks.clone();
-        let ready_index = self.ready_index.clone();
-        let scheduled_index = self.scheduled_index.clone();
-        let event_tx = self.event_tx.clone();
+        let batcher = self.enqueue_batcher.clone();
 
-        task::spawn_blocking(move || -> Result<_, StoreError> {
+        let reply_rx = task::spawn_blocking(move || -> Result<_, StoreError> {
             let prepared: Vec<PreparedEnqueue> = batch
                 .into_iter()
                 .map(|opts| prepare_enqueue(opts, now))
                 .collect::<Result<_, StoreError>>()?;
-
-            let mut tx = ks.write_tx();
-            let results = apply_enqueue_batch(&mut tx, &ks, &prepared)?;
-            ks.commit(tx, ks.enqueue_commit_mode)?;
-
-            for r in &results {
-                finalize_enqueue(r, &ready_index, &scheduled_index, &event_tx);
-            }
-
-            Ok(results)
+            Ok(batcher.submit(prepared))
         })
-        .await?
+        .await??;
+
+        reply_rx
+            .await
+            .map_err(|_| StoreError::Internal("enqueue auto-batcher channel closed".into()))?
     }
 
     /// Take the next job from the priority index.
@@ -5018,7 +5057,7 @@ fn apply_job_deletion(tx: &mut fjall::SingleWriterWriteTx<'_>, del: &JobDeletion
 /// `apply_enqueue` inside a write transaction. This separates the pure
 /// computation (serialization, key building) from the transactional writes,
 /// allowing callers to compose enqueue with other operations in the same tx.
-struct PreparedEnqueue {
+pub(super) struct PreparedEnqueue {
     job: Job,
     meta_bytes: Vec<u8>,
     payload_bytes: Vec<u8>,
@@ -5146,7 +5185,7 @@ fn apply_enqueue(
 ///
 /// Does NOT commit the transaction — the caller commits and runs
 /// `finalize_enqueue` per result post-commit.
-fn apply_enqueue_batch(
+pub(super) fn apply_enqueue_batch(
     tx: &mut fjall::SingleWriterWriteTx<'_>,
     ks: &Keyspaces,
     prepared: &[PreparedEnqueue],
@@ -5187,7 +5226,7 @@ fn apply_enqueue_batch(
 ///
 /// Call after the transaction has been committed. Updates the ready or
 /// scheduled index depending on the job's status.
-fn finalize_enqueue(
+pub(super) fn finalize_enqueue(
     result: &EnqueueResult,
     ready_index: &ReadyIndex,
     scheduled_index: &ScheduledIndex,


### PR DESCRIPTION
Enqueue Coalescing
---------------------

Like the `GroupCommitter` for fsyncs of the journal, we take multiple
enqueue requests and push them into a queue that is processed
sequentially. If while processing a single or a batch of enqueues more
fill up in the queue, those are processed in the next batch as a single
commit.

This should significantly reduce contention on the database in
high-throughput scenarios.

Acknowledgment Coalescing
-----------------------------

All official clients use `mark_completed_bulk` within their `Worker`
implementations so that under heavy throughput, many acks coalesce into
a single HTTP request all processed together. This is a notable
optimisation that reduces HTTP traffic and improves throughput (acks are
processed faster and therefore more jobs are prefetched sooner). This
works well when all concurrency is bounded to one client instance (i.e.
multi-threaded or async I/O based). When multiple processes are scaled
horizontally, however, those acks would not be coalesced across clients.

This commit implements the same logic server side. All acks go through a
mpsc channel and are drained in their entirety inside a single commit.

This means the client side coalescing benefits that individual client
(reduced HTTP requests) while the server side coalescing benefits all
clients (reduced DB commit wait time).
