### PR TITLE
Fix Bug with `DELETE /jobs/{id}` and 204 w/ `()` Body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.4.2
 
+- Fixed `DELETE /jobs/{id}`: the 204 No Content response was
+  accidentally including a serialized empty-body payload (JSON `null`
+  or its msgpack equivalent). HTTP/1.1 clients silently tolerated the
+  spec violation and ignored the body, but HTTP/2 strictly enforces
+  RFC 7230 § 3.3.3's "204 MUST NOT have a body" — any DATA frame
+  after a 204 HEADERS frame triggers `NGHTTP2_PROTOCOL_ERROR` and
+  closes the stream. Only affected clients negotiating h2 (TLS or
+  h2c); h1.1 clients were unaffected. Other 204 sites in the codebase
+  were already correct.
 - Added server-side opportunistic batching for enqueue requests.
   Singular `enqueue` and bulk `enqueue_bulk` now route through one
   shared channel; a dedicated background thread coalesces whatever

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -1070,7 +1070,14 @@ async fn delete_job(
     Path(id): Path<String>,
 ) -> Response {
     match state.store.delete_job(&id).await {
-        Ok(true) => respond(fmt, StatusCode::NO_CONTENT, &()),
+        // RFC 7230 § 3.3.3: a 204 No Content response MUST NOT have a
+        // message body. `respond()` would serialize `()` to a JSON
+        // `null` (or msgpack equivalent) and attach it as the body,
+        // which HTTP/1.1 clients silently tolerate but HTTP/2 rejects
+        // with NGHTTP2_PROTOCOL_ERROR (any DATA frame after a 204
+        // HEADERS frame is a protocol violation). Use the bodyless
+        // `no_content()` helper instead.
+        Ok(true) => no_content(),
         Ok(false) => respond(
             fmt,
             StatusCode::NOT_FOUND,
@@ -6731,6 +6738,17 @@ mod tests {
         let req = empty_request("DELETE", &format!("/jobs/{}", job.id));
         let res = app.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        // RFC 7230 § 3.3.3: a 204 must have no body. HTTP/2 enforces
+        // this strictly — a DATA frame after a 204's HEADERS frame
+        // triggers NGHTTP2_PROTOCOL_ERROR on the client side.
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            body.is_empty(),
+            "204 No Content must have an empty body, got {body:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Uncovered an issue surfacing over h2c in the Node.js client, specifically on this endpoint. `NGHTTP2_PROTOCOL_ERROR` was being returned and it turns out it's because we're responding `204 No Content`, but are using `()` for the body, which gets encoded as *something* (`null` or `{}`) and therefore makes the body present when it shouldn't be. Confirmed this fixes the issue.