### PR TITLE
Extract maintenance module from store + break down enqueue + complete.

### DIFF
--- a/src/store/complete/apply.rs
+++ b/src/store/complete/apply.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Write-tx phase of completion: apply pre-built `PreparedComplete`
+//! values to an open transaction, with optimistic-concurrency CAS
+//! verification per item. Zero-retention completions delete the job;
+//! non-zero retention updates the status/purge keys.
+
+use super::super::delete::apply_job_deletion;
+use super::super::keys::{make_job_key, make_unique_key};
+use super::super::store::Keyspaces;
+use super::super::types::{StoreError, UniqueWhile};
+use super::pre_read::PreparedComplete;
+
+/// Apply a batch of prepared completions to an open write transaction
+/// with optimistic-concurrency CAS verification.
+///
+/// On any CAS mismatch, returns `Ok(false)` immediately without writing
+/// further items. The caller must drop the tx and retry the
+/// pre-read+apply sequence — the returned tx is left in a stale state
+/// (some items may have been written before the conflict was detected).
+///
+/// On success, every item has been applied to the tx; caller commits.
+/// Does NOT commit the transaction.
+pub(super) fn apply_complete_batch(
+    tx: &mut fjall::SingleWriterWriteTx<'_>,
+    ks: &Keyspaces,
+    prepared: &[PreparedComplete],
+) -> Result<bool, StoreError> {
+    for p in prepared {
+        let job_key = make_job_key(&p.id);
+
+        if let Some(ref del) = p.deletion {
+            // Zero-retention: delete via CAS.
+            let prev = tx.take(&ks.data, &job_key)?;
+            if prev.as_deref() != Some(&*p.pre_bytes) {
+                return Ok(false);
+            }
+            apply_job_deletion(tx, del, ks);
+        } else if let Some(ref updated) = p.updated_bytes {
+            // Non-zero retention: update via CAS.
+            let prev = tx.fetch_update(&ks.data, &job_key, |_| Some(updated.clone()))?;
+            if prev.as_deref() != Some(&*p.pre_bytes) {
+                return Ok(false);
+            }
+            let keys = p.index_keys.as_ref().unwrap();
+            tx.remove(&ks.index, &keys.old_status);
+            tx.insert(&ks.index, &keys.new_status, b"");
+            tx.insert(&ks.index, &keys.purge, b"");
+
+            // Remove unique index for Queued or Active scope on
+            // completion, but only if it still belongs to this job.
+            if let Some(ref uc) = p.unique {
+                let scope = uc.unique_while();
+                if scope == UniqueWhile::Queued || scope == UniqueWhile::Active {
+                    let job_id = p.id.as_bytes();
+                    tx.fetch_update(&ks.index, &make_unique_key(&uc.key), |v| match v {
+                        Some(v) if v.as_ref() == job_id => None,
+                        other => other.cloned(),
+                    })?;
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}

--- a/src/store/complete/batcher.rs
+++ b/src/store/complete/batcher.rs
@@ -50,7 +50,8 @@ use super::super::ready_index::ReadyIndex;
 use super::super::results::BulkCompleteResult;
 use super::super::store::{Keyspaces, StoreEvent};
 use super::super::types::StoreError;
-use super::{apply_complete_batch, pre_read_completes};
+use super::apply::apply_complete_batch;
+use super::pre_read::pre_read_completes;
 
 /// A single completion request in flight: ids to ack, the caller's
 /// `now` timestamp, and a oneshot for the per-op `BulkCompleteResult`.

--- a/src/store/complete/mod.rs
+++ b/src/store/complete/mod.rs
@@ -6,23 +6,21 @@
 //! Both the singular `mark_completed` and bulk `mark_completed_bulk` entry
 //! points funnel into the server-side `CompleteBatcher`, which coalesces
 //! concurrent acks across many connections into a single fjall transaction.
-//! The actual disk work (CAS retry, ready-index update, in-flight count
-//! decrement, `JobCompleted` broadcast) lives in `batcher.rs`; the
-//! methods here are thin async wrappers that hand off through
-//! `spawn_blocking`.
+//! The disk work splits across the pre-read → apply pair in sibling
+//! submodules; the methods here are thin async wrappers that hand off
+//! through `spawn_blocking`.
 
+mod apply;
 mod batcher;
+mod pre_read;
 
 pub(super) use batcher::CompleteBatcher;
 
-use fjall::Slice;
 use tokio::task;
 
-use super::delete::{JobDeletion, apply_job_deletion, prepare_job_deletion};
-use super::keys::{make_job_key, make_purge_key, make_status_key, make_unique_key};
 use super::results::BulkCompleteResult;
-use super::store::{Keyspaces, Store};
-use super::types::{Job, JobStatus, StoreError, UniqueConstraint, UniqueWhile};
+use super::store::Store;
+use super::types::StoreError;
 
 impl Store {
     /// Mark a job as successfully completed.
@@ -70,177 +68,6 @@ impl Store {
             .map_err(|_| StoreError::Internal("complete auto-batcher channel closed".into()))?
     }
 }
-
-/// A job that has been pre-read and prepared for completion. Built by
-/// `pre_read_completes` (no tx required), applied by
-/// `apply_complete_batch` inside a write transaction.
-///
-/// Carries the original `pre_bytes` for CAS verification at apply time.
-/// If the job's stored bytes changed between pre-read and tx, the apply
-/// reports a CAS conflict and the caller must retry the pre-read.
-pub(super) struct PreparedComplete {
-    pub id: String,
-    pub queue: String,
-    pub pre_bytes: Slice,
-    pub priority: u16,
-    /// `None` for zero-retention completions (which delete the job).
-    pub updated_bytes: Option<Slice>,
-    /// `Some` for zero-retention completions (delete-paths).
-    pub deletion: Option<JobDeletion>,
-    /// Pre-computed index key updates for non-zero-retention paths.
-    pub index_keys: Option<CompletionRetentionKeys>,
-    /// Unique constraint snapshot for cleaning up the unique index.
-    pub unique: Option<UniqueConstraint>,
-}
-
-/// Pre-computed index keys for a non-zero-retention completion.
-pub(super) struct CompletionRetentionKeys {
-    pub old_status: Vec<u8>,
-    pub new_status: Vec<u8>,
-    pub purge: Vec<u8>,
-}
-
-/// Pre-read the given job ids and build the list of `PreparedComplete`
-/// values for those that are still in `InFlight` state. Jobs that are
-/// missing or in a different status are pushed into `not_found`.
-///
-/// Does NOT open a transaction — reads go directly through the
-/// keyspace, so the returned `pre_bytes` may be invalidated by
-/// concurrent writers. `apply_complete_batch` verifies via CAS and
-/// surfaces conflicts to the caller.
-pub(super) fn pre_read_completes(
-    ids: &[String],
-    now: u64,
-    ks: &Keyspaces,
-    default_completed_retention_ms: u64,
-) -> Result<(Vec<PreparedComplete>, Vec<String>), StoreError> {
-    let mut prepared: Vec<PreparedComplete> = Vec::with_capacity(ids.len());
-    let mut not_found: Vec<String> = Vec::new();
-
-    for id in ids {
-        let job_key = make_job_key(id);
-        let pre_bytes = match ks.data.get(&job_key)? {
-            Some(bytes) => bytes,
-            None => {
-                not_found.push(id.clone());
-                continue;
-            }
-        };
-
-        let mut job: Job = rmp_serde::from_slice(&pre_bytes)?;
-
-        if job.status != JobStatus::InFlight as u8 {
-            not_found.push(id.clone());
-            continue;
-        }
-
-        let retention_ms = job
-            .retention
-            .as_ref()
-            .and_then(|r| r.completed_ms)
-            .unwrap_or(default_completed_retention_ms);
-
-        if retention_ms == 0 {
-            let del = prepare_job_deletion(&job, JobStatus::InFlight, ks);
-            prepared.push(PreparedComplete {
-                id: id.clone(),
-                queue: job.queue.clone(),
-                pre_bytes,
-                priority: job.priority,
-                updated_bytes: None,
-                deletion: Some(del),
-                index_keys: None,
-                unique: None,
-            });
-        } else {
-            let purge_at = now + retention_ms;
-            let old_status_key = make_status_key(JobStatus::InFlight, id);
-            let new_status_key = make_status_key(JobStatus::Completed, id);
-            let purge_key = make_purge_key(purge_at, id);
-
-            let unique = job.unique.clone();
-
-            let queue = job.queue.clone();
-            job.status = JobStatus::Completed.into();
-            job.purge_at = Some(purge_at);
-            job.completed_at = Some(now);
-
-            let updated_slice: Slice = rmp_serde::to_vec_named(&job)?.into();
-
-            prepared.push(PreparedComplete {
-                id: id.clone(),
-                queue,
-                pre_bytes,
-                priority: job.priority,
-                updated_bytes: Some(updated_slice),
-                deletion: None,
-                index_keys: Some(CompletionRetentionKeys {
-                    old_status: old_status_key,
-                    new_status: new_status_key,
-                    purge: purge_key,
-                }),
-                unique,
-            });
-        }
-    }
-
-    Ok((prepared, not_found))
-}
-
-/// Apply a batch of prepared completions to an open write transaction
-/// with optimistic-concurrency CAS verification.
-///
-/// On any CAS mismatch, returns `Ok(false)` immediately without writing
-/// further items. The caller must drop the tx and retry the
-/// pre-read+apply sequence — the returned tx is left in a stale state
-/// (some items may have been written before the conflict was detected).
-///
-/// On success, every item has been applied to the tx; caller commits.
-/// Does NOT commit the transaction.
-pub(super) fn apply_complete_batch(
-    tx: &mut fjall::SingleWriterWriteTx<'_>,
-    ks: &Keyspaces,
-    prepared: &[PreparedComplete],
-) -> Result<bool, StoreError> {
-    for p in prepared {
-        let job_key = make_job_key(&p.id);
-
-        if let Some(ref del) = p.deletion {
-            // Zero-retention: delete via CAS.
-            let prev = tx.take(&ks.data, &job_key)?;
-            if prev.as_deref() != Some(&*p.pre_bytes) {
-                return Ok(false);
-            }
-            apply_job_deletion(tx, del, ks);
-        } else if let Some(ref updated) = p.updated_bytes {
-            // Non-zero retention: update via CAS.
-            let prev = tx.fetch_update(&ks.data, &job_key, |_| Some(updated.clone()))?;
-            if prev.as_deref() != Some(&*p.pre_bytes) {
-                return Ok(false);
-            }
-            let keys = p.index_keys.as_ref().unwrap();
-            tx.remove(&ks.index, &keys.old_status);
-            tx.insert(&ks.index, &keys.new_status, b"");
-            tx.insert(&ks.index, &keys.purge, b"");
-
-            // Remove unique index for Queued or Active scope on
-            // completion, but only if it still belongs to this job.
-            if let Some(ref uc) = p.unique {
-                let scope = uc.unique_while();
-                if scope == UniqueWhile::Queued || scope == UniqueWhile::Active {
-                    let job_id = p.id.as_bytes();
-                    tx.fetch_update(&ks.index, &make_unique_key(&uc.key), |v| match v {
-                        Some(v) if v.as_ref() == job_id => None,
-                        other => other.cloned(),
-                    })?;
-                }
-            }
-        }
-    }
-
-    Ok(true)
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/src/store/complete/pre_read.rs
+++ b/src/store/complete/pre_read.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Pre-tx phase of completion: read each candidate job from the data
+//! keyspace, classify it (zero-retention → delete, non-zero → status
+//! update + purge), and build a `PreparedComplete` for the apply phase.
+
+use fjall::Slice;
+
+use super::super::delete::{JobDeletion, prepare_job_deletion};
+use super::super::keys::{make_job_key, make_purge_key, make_status_key};
+use super::super::store::Keyspaces;
+use super::super::types::{Job, JobStatus, StoreError, UniqueConstraint};
+
+/// A job that has been pre-read and prepared for completion. Built by
+/// `pre_read_completes` (no tx required), applied by
+/// `apply_complete_batch` inside a write transaction.
+///
+/// Carries the original `pre_bytes` for CAS verification at apply time.
+/// If the job's stored bytes changed between pre-read and tx, the apply
+/// reports a CAS conflict and the caller must retry the pre-read.
+pub(super) struct PreparedComplete {
+    pub(super) id: String,
+    pub(super) queue: String,
+    pub(super) pre_bytes: Slice,
+    pub(super) priority: u16,
+    /// `None` for zero-retention completions (which delete the job).
+    pub(super) updated_bytes: Option<Slice>,
+    /// `Some` for zero-retention completions (delete-paths).
+    pub(super) deletion: Option<JobDeletion>,
+    /// Pre-computed index key updates for non-zero-retention paths.
+    pub(super) index_keys: Option<CompletionRetentionKeys>,
+    /// Unique constraint snapshot for cleaning up the unique index.
+    pub(super) unique: Option<UniqueConstraint>,
+}
+
+/// Pre-computed index keys for a non-zero-retention completion.
+pub(super) struct CompletionRetentionKeys {
+    pub(super) old_status: Vec<u8>,
+    pub(super) new_status: Vec<u8>,
+    pub(super) purge: Vec<u8>,
+}
+
+/// Pre-read the given job ids and build the list of `PreparedComplete`
+/// values for those that are still in `InFlight` state. Jobs that are
+/// missing or in a different status are pushed into `not_found`.
+///
+/// Does NOT open a transaction — reads go directly through the
+/// keyspace, so the returned `pre_bytes` may be invalidated by
+/// concurrent writers. `apply_complete_batch` verifies via CAS and
+/// surfaces conflicts to the caller.
+pub(super) fn pre_read_completes(
+    ids: &[String],
+    now: u64,
+    ks: &Keyspaces,
+    default_completed_retention_ms: u64,
+) -> Result<(Vec<PreparedComplete>, Vec<String>), StoreError> {
+    let mut prepared: Vec<PreparedComplete> = Vec::with_capacity(ids.len());
+    let mut not_found: Vec<String> = Vec::new();
+
+    for id in ids {
+        let job_key = make_job_key(id);
+        let pre_bytes = match ks.data.get(&job_key)? {
+            Some(bytes) => bytes,
+            None => {
+                not_found.push(id.clone());
+                continue;
+            }
+        };
+
+        let mut job: Job = rmp_serde::from_slice(&pre_bytes)?;
+
+        if job.status != JobStatus::InFlight as u8 {
+            not_found.push(id.clone());
+            continue;
+        }
+
+        let retention_ms = job
+            .retention
+            .as_ref()
+            .and_then(|r| r.completed_ms)
+            .unwrap_or(default_completed_retention_ms);
+
+        if retention_ms == 0 {
+            let del = prepare_job_deletion(&job, JobStatus::InFlight, ks);
+            prepared.push(PreparedComplete {
+                id: id.clone(),
+                queue: job.queue.clone(),
+                pre_bytes,
+                priority: job.priority,
+                updated_bytes: None,
+                deletion: Some(del),
+                index_keys: None,
+                unique: None,
+            });
+        } else {
+            let purge_at = now + retention_ms;
+            let old_status_key = make_status_key(JobStatus::InFlight, id);
+            let new_status_key = make_status_key(JobStatus::Completed, id);
+            let purge_key = make_purge_key(purge_at, id);
+
+            let unique = job.unique.clone();
+
+            let queue = job.queue.clone();
+            job.status = JobStatus::Completed.into();
+            job.purge_at = Some(purge_at);
+            job.completed_at = Some(now);
+
+            let updated_slice: Slice = rmp_serde::to_vec_named(&job)?.into();
+
+            prepared.push(PreparedComplete {
+                id: id.clone(),
+                queue,
+                pre_bytes,
+                priority: job.priority,
+                updated_bytes: Some(updated_slice),
+                deletion: None,
+                index_keys: Some(CompletionRetentionKeys {
+                    old_status: old_status_key,
+                    new_status: new_status_key,
+                    purge: purge_key,
+                }),
+                unique,
+            });
+        }
+    }
+
+    Ok((prepared, not_found))
+}

--- a/src/store/enqueue/apply.rs
+++ b/src/store/enqueue/apply.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Write-tx phase of enqueue: apply pre-built `PreparedEnqueue` values to
+//! an open transaction, with unique-conflict detection (cross-batch via
+//! the index, intra-batch via a `HashMap`).
+
+use std::collections::HashMap;
+
+use super::super::keys::make_job_key;
+use super::super::results::EnqueueResult;
+use super::super::store::Keyspaces;
+use super::super::types::{Job, JobStatus, StoreError};
+use super::prepare::PreparedEnqueue;
+
+/// Insert a prepared enqueue into an open write transaction.
+///
+/// Checks for unique constraint conflicts first. Returns `Duplicate` if a
+/// conflict is found (nothing is written), `Created` otherwise.
+///
+/// Does NOT commit the transaction — the caller is responsible for
+/// committing (possibly after adding other writes to the same tx).
+pub(in crate::store) fn apply_enqueue(
+    tx: &mut fjall::SingleWriterWriteTx<'_>,
+    ks: &Keyspaces,
+    p: &PreparedEnqueue,
+) -> Result<EnqueueResult, StoreError> {
+    // Check for a unique conflict.
+    if let Some(ref uc) = p.job.unique {
+        let scope = uc.unique_while();
+        let idx_key = p.unique_idx_key.as_ref().unwrap();
+
+        if let Some(existing_id_bytes) = ks.index.get(idx_key)? {
+            let existing_id = std::str::from_utf8(&existing_id_bytes).map_err(|e| {
+                StoreError::Corruption(format!("unique index value is not valid UTF-8: {e}"))
+            })?;
+
+            if let Some(existing_meta_bytes) = ks.data.get(&make_job_key(existing_id))? {
+                let existing_meta: Job = rmp_serde::from_slice(&existing_meta_bytes)?;
+                if let Ok(existing_status) = JobStatus::try_from(existing_meta.status) {
+                    if scope.conflicts_with(existing_status) {
+                        return Ok(EnqueueResult::Duplicate(existing_meta));
+                    }
+                }
+            }
+        }
+    }
+
+    tx.insert(&ks.data, &p.job_key, &p.meta_bytes);
+    tx.insert(&ks.data, &p.payload_key, &p.payload_bytes);
+    tx.insert(&ks.index, &p.queue_key, b"");
+    tx.insert(&ks.index, &p.status_key, b"");
+    tx.insert(&ks.index, &p.type_key, b"");
+
+    if let Some(ref idx_key) = p.unique_idx_key {
+        tx.insert(&ks.index, idx_key, p.job.id.as_bytes());
+    }
+
+    Ok(EnqueueResult::Created(p.job.clone()))
+}
+
+/// Apply a batch of prepared enqueues to an open write transaction with
+/// intra-batch unique-key dedup.
+///
+/// When two prepared jobs in the same batch share a `unique` key, the
+/// second one returns `EnqueueResult::Duplicate(...)` referring to the
+/// first without performing a tx insert. Cross-batch dedup against
+/// already-committed jobs is handled by `apply_enqueue` itself.
+///
+/// Does NOT commit the transaction — the caller commits and runs
+/// `finalize_enqueue` per result post-commit.
+pub(super) fn apply_enqueue_batch(
+    tx: &mut fjall::SingleWriterWriteTx<'_>,
+    ks: &Keyspaces,
+    prepared: &[PreparedEnqueue],
+) -> Result<Vec<EnqueueResult>, StoreError> {
+    // Maps unique_key -> index in `results` for intra-batch conflicts.
+    let mut batch_unique_keys: HashMap<String, usize> = HashMap::new();
+    let mut results: Vec<EnqueueResult> = Vec::with_capacity(prepared.len());
+
+    for p in prepared {
+        // Intra-batch unique conflict check (no DB read needed).
+        if let Some(ref uc) = p.job.unique {
+            if let Some(&existing_idx) = batch_unique_keys.get(&uc.key) {
+                results.push(EnqueueResult::Duplicate(
+                    results[existing_idx].job().clone(),
+                ));
+                continue;
+            }
+        }
+
+        let result = apply_enqueue(tx, ks, p)?;
+
+        // Track unique keys for intra-batch dedup.
+        if let EnqueueResult::Created(ref job) = result {
+            if let Some(ref uc) = job.unique {
+                batch_unique_keys.insert(uc.key.clone(), results.len());
+            }
+        }
+
+        results.push(result);
+    }
+
+    Ok(results)
+}

--- a/src/store/enqueue/batcher.rs
+++ b/src/store/enqueue/batcher.rs
@@ -60,7 +60,9 @@ use super::super::results::EnqueueResult;
 use super::super::scheduled_index::ScheduledIndex;
 use super::super::store::{Keyspaces, StoreEvent};
 use super::super::types::StoreError;
-use super::{PreparedEnqueue, apply_enqueue_batch, finalize_enqueue};
+use super::apply::apply_enqueue_batch;
+use super::finalize::finalize_enqueue;
+use super::prepare::PreparedEnqueue;
 
 /// A single enqueue request in flight: the prepared jobs plus a
 /// oneshot slot for the per-request results. `prepared.len() == 1`

--- a/src/store/enqueue/finalize.rs
+++ b/src/store/enqueue/finalize.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Post-commit phase of enqueue: update the in-memory ready/scheduled
+//! index and broadcast the corresponding `JobCreated` / `JobScheduled`
+//! event. Called by the auto-batcher after a successful commit, and by
+//! `cron::promote_cron_entry` for the cron-driven enqueue path.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use tokio::sync::broadcast;
+
+use super::super::ready_index::ReadyIndex;
+use super::super::results::EnqueueResult;
+use super::super::scheduled_index::ScheduledIndex;
+use super::super::store::StoreEvent;
+use super::super::types::JobStatus;
+
+/// Update in-memory indexes for a successfully enqueued job.
+///
+/// Call after the transaction has been committed. Updates the ready or
+/// scheduled index depending on the job's status.
+pub(in crate::store) fn finalize_enqueue(
+    result: &EnqueueResult,
+    ready_index: &ReadyIndex,
+    scheduled_index: &ScheduledIndex,
+    event_tx: &broadcast::Sender<StoreEvent>,
+) {
+    if let EnqueueResult::Created(job) = result {
+        match JobStatus::try_from(job.status) {
+            Ok(JobStatus::Ready) => {
+                ready_index.insert(&job.queue, job.priority, job.id.clone());
+                let _ = event_tx.send(StoreEvent::JobCreated {
+                    id: job.id.clone(),
+                    queue: job.queue.clone(),
+                    token: Arc::new(AtomicBool::new(false)),
+                });
+            }
+            Ok(JobStatus::Scheduled) => {
+                scheduled_index.insert(job.ready_at, job.id.clone());
+                let _ = event_tx.send(StoreEvent::JobScheduled {
+                    id: job.id.clone(),
+                    ready_at: job.ready_at,
+                });
+            }
+            _ => {
+                tracing::warn!(
+                    job_id = %job.id,
+                    status = job.status,
+                    "enqueue produced unexpected status"
+                );
+            }
+        }
+    }
+}

--- a/src/store/enqueue/mod.rs
+++ b/src/store/enqueue/mod.rs
@@ -5,30 +5,26 @@
 //!
 //! Both entry points funnel into the server-side `EnqueueBatcher` which
 //! coalesces concurrent enqueues across many connections into a single
-//! fjall transaction. The disk work (unique-conflict check, key writes,
-//! in-memory index update, event broadcast) lives in the prepare → apply
-//! → finalize trio below; the methods here are thin async wrappers that
-//! hand off through `spawn_blocking`.
+//! fjall transaction. The disk work splits across the prepare → apply →
+//! finalize trio in sibling submodules; the methods here are thin async
+//! wrappers that hand off through `spawn_blocking`.
 
+mod apply;
 mod batcher;
+mod finalize;
+mod prepare;
 
+pub(in crate::store) use apply::apply_enqueue;
 pub(super) use batcher::EnqueueBatcher;
+pub(in crate::store) use finalize::finalize_enqueue;
+pub(in crate::store) use prepare::{PreparedEnqueue, prepare_enqueue};
 
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-
-use tokio::sync::broadcast;
 use tokio::task;
 
-use super::keys::{
-    make_job_key, make_payload_key, make_queue_key, make_status_key, make_type_key, make_unique_key,
-};
 use super::options::EnqueueOptions;
-use super::ready_index::ReadyIndex;
 use super::results::EnqueueResult;
-use super::scheduled_index::ScheduledIndex;
-use super::store::{Keyspaces, Store, StoreEvent};
-use super::types::{Job, JobStatus, StoreError, UniqueConstraint, UniqueWhile};
+use super::store::Store;
+use super::types::StoreError;
 
 impl Store {
     /// Enqueue a new job.
@@ -105,219 +101,6 @@ impl Store {
             .map_err(|_| StoreError::Internal("enqueue auto-batcher channel closed".into()))?
     }
 }
-
-/// Pre-computed data for inserting a job into the store.
-///
-/// Built by `prepare_enqueue` from `EnqueueOptions`, consumed by
-/// `apply_enqueue` inside a write transaction. This separates the pure
-/// computation (serialization, key building) from the transactional writes,
-/// allowing callers to compose enqueue with other operations in the same tx.
-pub(super) struct PreparedEnqueue {
-    job: Job,
-    meta_bytes: Vec<u8>,
-    payload_bytes: Vec<u8>,
-    job_key: Vec<u8>,
-    payload_key: Vec<u8>,
-    queue_key: Vec<u8>,
-    status_key: Vec<u8>,
-    type_key: Vec<u8>,
-    unique_idx_key: Option<Vec<u8>>,
-}
-
-/// Build a `PreparedEnqueue` from `EnqueueOptions` and the current time.
-///
-/// Pure computation — no IO, no transaction needed.
-pub(super) fn prepare_enqueue(
-    opts: EnqueueOptions,
-    now: u64,
-) -> Result<PreparedEnqueue, StoreError> {
-    let unique_while_scope = match (opts.unique_key.as_ref(), opts.unique_while) {
-        (Some(_), Some(scope)) => Some(scope),
-        (Some(_), None) => Some(UniqueWhile::Queued),
-        _ => None,
-    };
-
-    let id = scru128::new_string();
-    let ready_at = opts.ready_at.unwrap_or(now);
-    let scheduled = ready_at > now;
-    let status = if scheduled {
-        JobStatus::Scheduled
-    } else {
-        JobStatus::Ready
-    };
-
-    let payload_bytes = rmp_serde::to_vec_named(&opts.payload)?;
-
-    let job = Job {
-        id: id.clone(),
-        job_type: opts.job_type,
-        queue: opts.queue,
-        priority: opts.priority,
-        payload: Some(opts.payload),
-        status: status.into(),
-        ready_at,
-        attempts: 0,
-        retry_limit: opts.retry_limit,
-        backoff: opts.backoff,
-        dequeued_at: None,
-        failed_at: None,
-        retention: opts.retention,
-        purge_at: None,
-        completed_at: None,
-        unique: opts.unique_key.map(|k| UniqueConstraint {
-            key: k,
-            scope: unique_while_scope.unwrap_or(UniqueWhile::Queued) as u8,
-        }),
-    };
-
-    let mut meta = job.clone();
-    meta.payload = None;
-    let meta_bytes = rmp_serde::to_vec_named(&meta)?;
-
-    Ok(PreparedEnqueue {
-        job_key: make_job_key(&id),
-        payload_key: make_payload_key(&id),
-        queue_key: make_queue_key(&job.queue, &id),
-        status_key: make_status_key(status, &id),
-        type_key: make_type_key(&job.job_type, &id),
-        unique_idx_key: job.unique.as_ref().map(|uc| make_unique_key(&uc.key)),
-        job,
-        meta_bytes,
-        payload_bytes,
-    })
-}
-
-/// Insert a prepared enqueue into an open write transaction.
-///
-/// Checks for unique constraint conflicts first. Returns `Duplicate` if a
-/// conflict is found (nothing is written), `Created` otherwise.
-///
-/// Does NOT commit the transaction — the caller is responsible for
-/// committing (possibly after adding other writes to the same tx).
-pub(super) fn apply_enqueue(
-    tx: &mut fjall::SingleWriterWriteTx<'_>,
-    ks: &Keyspaces,
-    p: &PreparedEnqueue,
-) -> Result<EnqueueResult, StoreError> {
-    // Check for a unique conflict.
-    if let Some(ref uc) = p.job.unique {
-        let scope = uc.unique_while();
-        let idx_key = p.unique_idx_key.as_ref().unwrap();
-
-        if let Some(existing_id_bytes) = ks.index.get(idx_key)? {
-            let existing_id = std::str::from_utf8(&existing_id_bytes).map_err(|e| {
-                StoreError::Corruption(format!("unique index value is not valid UTF-8: {e}"))
-            })?;
-
-            if let Some(existing_meta_bytes) = ks.data.get(&make_job_key(existing_id))? {
-                let existing_meta: Job = rmp_serde::from_slice(&existing_meta_bytes)?;
-                if let Ok(existing_status) = JobStatus::try_from(existing_meta.status) {
-                    if scope.conflicts_with(existing_status) {
-                        return Ok(EnqueueResult::Duplicate(existing_meta));
-                    }
-                }
-            }
-        }
-    }
-
-    tx.insert(&ks.data, &p.job_key, &p.meta_bytes);
-    tx.insert(&ks.data, &p.payload_key, &p.payload_bytes);
-    tx.insert(&ks.index, &p.queue_key, b"");
-    tx.insert(&ks.index, &p.status_key, b"");
-    tx.insert(&ks.index, &p.type_key, b"");
-
-    if let Some(ref idx_key) = p.unique_idx_key {
-        tx.insert(&ks.index, idx_key, p.job.id.as_bytes());
-    }
-
-    Ok(EnqueueResult::Created(p.job.clone()))
-}
-
-/// Apply a batch of prepared enqueues to an open write transaction with
-/// intra-batch unique-key dedup.
-///
-/// When two prepared jobs in the same batch share a `unique` key, the
-/// second one returns `EnqueueResult::Duplicate(...)` referring to the
-/// first without performing a tx insert. Cross-batch dedup against
-/// already-committed jobs is handled by `apply_enqueue` itself.
-///
-/// Does NOT commit the transaction — the caller commits and runs
-/// `finalize_enqueue` per result post-commit.
-pub(super) fn apply_enqueue_batch(
-    tx: &mut fjall::SingleWriterWriteTx<'_>,
-    ks: &Keyspaces,
-    prepared: &[PreparedEnqueue],
-) -> Result<Vec<EnqueueResult>, StoreError> {
-    use std::collections::HashMap;
-
-    // Maps unique_key -> index in `results` for intra-batch conflicts.
-    let mut batch_unique_keys: HashMap<String, usize> = HashMap::new();
-    let mut results: Vec<EnqueueResult> = Vec::with_capacity(prepared.len());
-
-    for p in prepared {
-        // Intra-batch unique conflict check (no DB read needed).
-        if let Some(ref uc) = p.job.unique {
-            if let Some(&existing_idx) = batch_unique_keys.get(&uc.key) {
-                results.push(EnqueueResult::Duplicate(
-                    results[existing_idx].job().clone(),
-                ));
-                continue;
-            }
-        }
-
-        let result = apply_enqueue(tx, ks, p)?;
-
-        // Track unique keys for intra-batch dedup.
-        if let EnqueueResult::Created(ref job) = result {
-            if let Some(ref uc) = job.unique {
-                batch_unique_keys.insert(uc.key.clone(), results.len());
-            }
-        }
-
-        results.push(result);
-    }
-
-    Ok(results)
-}
-
-/// Update in-memory indexes for a successfully enqueued job.
-///
-/// Call after the transaction has been committed. Updates the ready or
-/// scheduled index depending on the job's status.
-pub(super) fn finalize_enqueue(
-    result: &EnqueueResult,
-    ready_index: &ReadyIndex,
-    scheduled_index: &ScheduledIndex,
-    event_tx: &broadcast::Sender<StoreEvent>,
-) {
-    if let EnqueueResult::Created(job) = result {
-        match JobStatus::try_from(job.status) {
-            Ok(JobStatus::Ready) => {
-                ready_index.insert(&job.queue, job.priority, job.id.clone());
-                let _ = event_tx.send(StoreEvent::JobCreated {
-                    id: job.id.clone(),
-                    queue: job.queue.clone(),
-                    token: Arc::new(AtomicBool::new(false)),
-                });
-            }
-            Ok(JobStatus::Scheduled) => {
-                scheduled_index.insert(job.ready_at, job.id.clone());
-                let _ = event_tx.send(StoreEvent::JobScheduled {
-                    id: job.id.clone(),
-                    ready_at: job.ready_at,
-                });
-            }
-            _ => {
-                tracing::warn!(
-                    job_id = %job.id,
-                    status = job.status,
-                    "enqueue produced unexpected status"
-                );
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Pure-computation phase of enqueue: assemble a `PreparedEnqueue` from
+//! `EnqueueOptions` without touching the database. Used both by the
+//! enqueue auto-batcher and by `cron::promote_cron_entry`.
+
+use super::super::keys::{
+    make_job_key, make_payload_key, make_queue_key, make_status_key, make_type_key, make_unique_key,
+};
+use super::super::options::EnqueueOptions;
+use super::super::types::{Job, JobStatus, StoreError, UniqueConstraint, UniqueWhile};
+
+/// Pre-computed data for inserting a job into the store.
+///
+/// Built by `prepare_enqueue` from `EnqueueOptions`, consumed by
+/// `apply_enqueue` inside a write transaction. This separates the pure
+/// computation (serialization, key building) from the transactional writes,
+/// allowing callers to compose enqueue with other operations in the same tx.
+pub(in crate::store) struct PreparedEnqueue {
+    pub(super) job: Job,
+    pub(super) meta_bytes: Vec<u8>,
+    pub(super) payload_bytes: Vec<u8>,
+    pub(super) job_key: Vec<u8>,
+    pub(super) payload_key: Vec<u8>,
+    pub(super) queue_key: Vec<u8>,
+    pub(super) status_key: Vec<u8>,
+    pub(super) type_key: Vec<u8>,
+    pub(super) unique_idx_key: Option<Vec<u8>>,
+}
+
+/// Build a `PreparedEnqueue` from `EnqueueOptions` and the current time.
+///
+/// Pure computation — no IO, no transaction needed.
+pub(in crate::store) fn prepare_enqueue(
+    opts: EnqueueOptions,
+    now: u64,
+) -> Result<PreparedEnqueue, StoreError> {
+    let unique_while_scope = match (opts.unique_key.as_ref(), opts.unique_while) {
+        (Some(_), Some(scope)) => Some(scope),
+        (Some(_), None) => Some(UniqueWhile::Queued),
+        _ => None,
+    };
+
+    let id = scru128::new_string();
+    let ready_at = opts.ready_at.unwrap_or(now);
+    let scheduled = ready_at > now;
+    let status = if scheduled {
+        JobStatus::Scheduled
+    } else {
+        JobStatus::Ready
+    };
+
+    let payload_bytes = rmp_serde::to_vec_named(&opts.payload)?;
+
+    let job = Job {
+        id: id.clone(),
+        job_type: opts.job_type,
+        queue: opts.queue,
+        priority: opts.priority,
+        payload: Some(opts.payload),
+        status: status.into(),
+        ready_at,
+        attempts: 0,
+        retry_limit: opts.retry_limit,
+        backoff: opts.backoff,
+        dequeued_at: None,
+        failed_at: None,
+        retention: opts.retention,
+        purge_at: None,
+        completed_at: None,
+        unique: opts.unique_key.map(|k| UniqueConstraint {
+            key: k,
+            scope: unique_while_scope.unwrap_or(UniqueWhile::Queued) as u8,
+        }),
+    };
+
+    let mut meta = job.clone();
+    meta.payload = None;
+    let meta_bytes = rmp_serde::to_vec_named(&meta)?;
+
+    Ok(PreparedEnqueue {
+        job_key: make_job_key(&id),
+        payload_key: make_payload_key(&id),
+        queue_key: make_queue_key(&job.queue, &id),
+        status_key: make_status_key(status, &id),
+        type_key: make_type_key(&job.job_type, &id),
+        unique_idx_key: job.unique.as_ref().map(|uc| make_unique_key(&uc.key)),
+        job,
+        meta_bytes,
+        payload_bytes,
+    })
+}

--- a/src/store/fail.rs
+++ b/src/store/fail.rs
@@ -11,8 +11,8 @@ use tokio::task;
 use super::delete::{apply_job_deletion, prepare_job_deletion};
 use super::keys::{make_error_key, make_job_key, make_purge_key, make_status_key, make_unique_key};
 use super::options::FailureOptions;
-use super::store::{Store, StoreEvent, compute_backoff};
-use super::types::{ErrorRecord, Job, JobStatus, StoreError, UniqueWhile};
+use super::store::{Store, StoreEvent};
+use super::types::{BackoffConfig, ErrorRecord, Job, JobStatus, StoreError, UniqueWhile};
 
 impl Store {
     /// Record a job failure and either schedule a retry or kill the job
@@ -248,6 +248,27 @@ impl Store {
     }
 }
 
+/// Compute the backoff delay in milliseconds for a given attempt count.
+///
+/// Formula: `delay_ms = attempts^exponent + base_ms + rand(0..jitter_ms) * (attempts + 1)`
+///
+/// The jitter component scales linearly with the attempt count so that
+/// later retries spread further apart, reducing collision likelihood when
+/// many jobs fail at similar times.
+fn compute_backoff(attempts: u32, backoff: &BackoffConfig) -> u64 {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+
+    let base_delay = (attempts as f32).powf(backoff.exponent) + backoff.base_ms as f32;
+
+    // Cheap random value using the same approach as rand_id() in http.rs.
+    let rand_frac = (RandomState::new().build_hasher().finish() as f64) / (u64::MAX as f64); // 0.0..1.0
+
+    let jitter = rand_frac * backoff.jitter_ms as f64 * (attempts as f64 + 1.0);
+
+    (base_delay as f64 + jitter) as u64
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -258,8 +279,66 @@ mod tests {
     use super::super::test_support::{
         enqueue_and_take, test_failure_opts, test_store, test_store_with_retry_limit,
     };
-    use super::super::types::{ErrorRecord, JobStatus};
+    use super::super::types::{BackoffConfig, ErrorRecord, JobStatus};
+    use super::compute_backoff;
     use crate::time::now_millis;
+
+    // --- compute_backoff tests ---
+
+    #[test]
+    fn compute_backoff_zero_jitter_is_deterministic() {
+        let backoff = BackoffConfig {
+            exponent: 2.0,
+            base_ms: 100,
+            jitter_ms: 0,
+        };
+
+        // attempts=1: 1^2 + 100 = 101
+        assert_eq!(compute_backoff(1, &backoff), 101);
+        // attempts=2: 2^2 + 100 = 104
+        assert_eq!(compute_backoff(2, &backoff), 104);
+        // attempts=3: 3^2 + 100 = 109
+        assert_eq!(compute_backoff(3, &backoff), 109);
+    }
+
+    #[test]
+    fn compute_backoff_with_jitter_stays_in_range() {
+        let backoff = BackoffConfig {
+            exponent: 2.0,
+            base_ms: 100,
+            jitter_ms: 50,
+        };
+
+        // Run many times to exercise randomness.
+        for attempts in 1..=10 {
+            let delay = compute_backoff(attempts, &backoff);
+            let base = (attempts as f64).powf(2.0) + 100.0;
+            let max_jitter = 50.0 * (attempts as f64 + 1.0);
+            assert!(
+                delay >= base as u64,
+                "delay {delay} below base {base} for attempt {attempts}"
+            );
+            assert!(
+                delay <= (base + max_jitter) as u64,
+                "delay {delay} above max {} for attempt {attempts}",
+                base + max_jitter
+            );
+        }
+    }
+
+    #[test]
+    fn compute_backoff_zero_attempts() {
+        let backoff = BackoffConfig {
+            exponent: 2.0,
+            base_ms: 100,
+            jitter_ms: 0,
+        };
+
+        // attempts=0: 0^2 + 100 = 100
+        assert_eq!(compute_backoff(0, &backoff), 100);
+    }
+
+    // --- record_failure tests ---
 
     #[tokio::test]
     async fn record_failure_retries_under_limit() {

--- a/src/store/maintenance.rs
+++ b/src/store/maintenance.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Maintenance ops that don't fit any single job-lifecycle pass:
+//!
+//! - `compact_all`: force a full LSM major compaction across both
+//!   keyspaces to reclaim tombstones leveled compaction would otherwise
+//!   leave in upper levels.
+//! - `backup_snapshot`: take a consistent point-in-time copy of the
+//!   database to a new directory.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use fjall::Readable;
+use fjall::config::{FilterPolicy, PinningPolicy};
+use tokio::task;
+
+use super::store::Store;
+use super::types::StoreError;
+
+impl Store {
+    /// Force a full LSM compaction of both keyspaces, reclaiming tombstones
+    /// that leveled compaction has left in upper levels.
+    ///
+    /// Leveled compaction triggers on level-size ratios, so after a large
+    /// bulk delete (or any operation that produces many tombstones without
+    /// matching live writes) the upper levels can sit on garbage for a long
+    /// time on a quiet database. A full compaction merges every level down
+    /// and drops tombstones whose seqnos are safe to GC.
+    ///
+    /// Runs on a blocking thread and may take seconds for large keyspaces.
+    /// Excludes other (background leveled) compactions while running, but
+    /// reads and writes at the LSM level proceed normally — they don't
+    /// touch the compaction lock. Concurrent zizq transactions also aren't
+    /// serialized against this since we bypass the txn writer lock.
+    //
+    // `major_compact` is `#[doc(hidden)]` in fjall 3.0.x / 3.1.x. It works
+    // and is the intended escape hatch for this use case, but the API is
+    // not formally stable yet; recheck on each fjall upgrade.
+    pub async fn compact_all(&self) -> Result<(), StoreError> {
+        let ks = self.ks.clone();
+        task::spawn_blocking(move || -> Result<(), StoreError> {
+            ks.data.inner().major_compact()?;
+            ks.index.inner().major_compact()?;
+            Ok(())
+        })
+        .await?
+    }
+
+    /// Create a consistent backup of the database at the given path.
+    ///
+    /// Takes a read snapshot of the live database and copies all key/value
+    /// pairs from both keyspaces into a new database at `dest`. The new
+    /// database is created with the same `StorageConfig` as the live one.
+    ///
+    /// This runs entirely from a point-in-time snapshot, so it does not
+    /// block or lock the live database.
+    pub async fn backup_snapshot(
+        &self,
+        dest: impl AsRef<Path> + Send + 'static,
+    ) -> Result<(), StoreError> {
+        let ks = self.ks.clone();
+        let config = self.config.clone();
+
+        task::spawn_blocking(move || {
+            let snapshot = ks.db.read_tx();
+            let dest = dest.as_ref();
+
+            // Open a new database with matching settings.
+            let backup_db = fjall::Database::builder(dest)
+                .cache_size(config.cache_size)
+                .max_journaling_size(config.journal_size)
+                .open()
+                .map_err(|e| {
+                    StoreError::Internal(format!("failed to open backup database: {e}"))
+                })?;
+
+            let data_compaction = Arc::new(
+                fjall::compaction::Leveled::default()
+                    .with_l0_threshold(config.l0_threshold)
+                    .with_table_target_size(config.data_table_size),
+            );
+            let index_compaction = Arc::new(
+                fjall::compaction::Leveled::default()
+                    .with_l0_threshold(config.l0_threshold)
+                    .with_table_target_size(config.index_table_size),
+            );
+
+            let backup_data = backup_db
+                .keyspace("data", || {
+                    fjall::KeyspaceCreateOptions::default()
+                        .compaction_strategy(data_compaction)
+                        .max_memtable_size(config.data_table_size)
+                        .filter_block_pinning_policy(PinningPolicy::all(true))
+                        .index_block_pinning_policy(PinningPolicy::all(true))
+                })
+                .map_err(|e| {
+                    StoreError::Internal(format!("failed to create backup data keyspace: {e}"))
+                })?;
+
+            let backup_index = backup_db
+                .keyspace("index", || {
+                    fjall::KeyspaceCreateOptions::default()
+                        .compaction_strategy(index_compaction)
+                        .max_memtable_size(config.index_table_size)
+                        .filter_policy(FilterPolicy::disabled())
+                        .index_block_pinning_policy(PinningPolicy::all(true))
+                })
+                .map_err(|e| {
+                    StoreError::Internal(format!("failed to create backup index keyspace: {e}"))
+                })?;
+
+            // Copy all data keyspace entries.
+            for entry in snapshot.range::<Vec<u8>, _>(&ks.data, ..) {
+                let (key, value) = entry.into_inner()?;
+                backup_data
+                    .insert(&*key, &*value)
+                    .map_err(|e| StoreError::Internal(format!("backup data write failed: {e}")))?;
+            }
+
+            // Copy all index keyspace entries.
+            for entry in snapshot.range::<Vec<u8>, _>(&ks.index, ..) {
+                let (key, value) = entry.into_inner()?;
+                backup_index
+                    .insert(&*key, &*value)
+                    .map_err(|e| StoreError::Internal(format!("backup index write failed: {e}")))?;
+            }
+
+            // Flush and close cleanly.
+            backup_db
+                .persist(fjall::PersistMode::SyncAll)
+                .map_err(|e| StoreError::Internal(format!("backup flush failed: {e}")))?;
+
+            drop(backup_db);
+            Ok(())
+        })
+        .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::options::{BulkDeleteOptions, EnqueueOptions, ListJobsOptions};
+    use super::super::store::Store;
+    use super::super::test_support::test_store;
+    use crate::time::now_millis;
+
+    #[tokio::test]
+    async fn compact_all_succeeds_on_empty_store() {
+        let store = test_store();
+        store.compact_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn compact_all_succeeds_after_writes_and_deletes() {
+        let store = test_store();
+        let now = now_millis();
+
+        for _ in 0..50 {
+            store
+                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(null)))
+                .await
+                .unwrap();
+        }
+        let count = store.delete_jobs(BulkDeleteOptions::new()).await.unwrap();
+        assert_eq!(count, 50);
+
+        store.compact_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backup_snapshot_copies_all_data() {
+        let store = test_store();
+        let now = now_millis();
+
+        // Enqueue some jobs across different queues.
+        for i in 0..5 {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("test", &format!("q{i}"), serde_json::json!({"i": i})),
+                )
+                .await
+                .unwrap();
+        }
+
+        // Create the backup.
+        let backup_dir = tempfile::tempdir().unwrap();
+        let backup_path = backup_dir.path().join("data");
+        store.backup_snapshot(backup_path.clone()).await.unwrap();
+
+        // Open the backup as a new store and verify the data.
+        let restored = Store::open(&backup_path, Default::default()).unwrap();
+        let opts = ListJobsOptions::new().limit(100).now(now);
+        let page = restored.list_jobs(opts).await.unwrap();
+        assert_eq!(page.jobs.len(), 5);
+
+        let queues = restored.list_queues().await.unwrap();
+        assert_eq!(queues, vec!["q0", "q1", "q2", "q3", "q4"]);
+    }
+
+    #[tokio::test]
+    async fn backup_snapshot_is_point_in_time() {
+        let store = test_store();
+        let now = now_millis();
+
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("test", "q", serde_json::json!("before")),
+            )
+            .await
+            .unwrap();
+
+        // Take the backup.
+        let backup_dir = tempfile::tempdir().unwrap();
+        let backup_path = backup_dir.path().join("data");
+        store.backup_snapshot(backup_path.clone()).await.unwrap();
+
+        // Enqueue more after the backup.
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("test", "q", serde_json::json!("after")),
+            )
+            .await
+            .unwrap();
+
+        // The backup should only contain the job from before.
+        let restored = Store::open(&backup_path, Default::default()).unwrap();
+        let opts = ListJobsOptions::new().limit(100).now(now);
+        let page = restored.list_jobs(opts).await.unwrap();
+        assert_eq!(page.jobs.len(), 1);
+        assert_eq!(page.jobs[0].payload, Some(serde_json::json!("before")));
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,6 +8,7 @@ mod enqueue;
 mod fail;
 mod group_committer;
 mod keys;
+mod maintenance;
 mod options;
 mod patch;
 mod read;

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -20,14 +20,12 @@
 //! types coexist without collision. Combined filters (e.g. queue + status)
 //! use sorted stream intersection across the tag-prefixed ranges.
 
-use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use fjall::config::{FilterPolicy, PinningPolicy};
-use fjall::{Readable, SingleWriterTxDatabase, SingleWriterTxKeyspace};
+use fjall::{SingleWriterTxDatabase, SingleWriterTxKeyspace};
 use tokio::sync::broadcast;
-use tokio::task;
 
 use super::complete::CompleteBatcher;
 use super::cron::CronScheduleIndex;
@@ -391,145 +389,6 @@ impl Store {
     pub fn scheduled_count(&self) -> usize {
         self.scheduled_index.len()
     }
-
-    /// Force a full LSM compaction of both keyspaces, reclaiming tombstones
-    /// that leveled compaction has left in upper levels.
-    ///
-    /// Leveled compaction triggers on level-size ratios, so after a large
-    /// bulk delete (or any operation that produces many tombstones without
-    /// matching live writes) the upper levels can sit on garbage for a long
-    /// time on a quiet database. A full compaction merges every level down
-    /// and drops tombstones whose seqnos are safe to GC.
-    ///
-    /// Runs on a blocking thread and may take seconds for large keyspaces.
-    /// Excludes other (background leveled) compactions while running, but
-    /// reads and writes at the LSM level proceed normally — they don't
-    /// touch the compaction lock. Concurrent zizq transactions also aren't
-    /// serialized against this since we bypass the txn writer lock.
-    //
-    // `major_compact` is `#[doc(hidden)]` in fjall 3.0.x / 3.1.x. It works
-    // and is the intended escape hatch for this use case, but the API is
-    // not formally stable yet; recheck on each fjall upgrade.
-    pub async fn compact_all(&self) -> Result<(), StoreError> {
-        let ks = self.ks.clone();
-        task::spawn_blocking(move || -> Result<(), StoreError> {
-            ks.data.inner().major_compact()?;
-            ks.index.inner().major_compact()?;
-            Ok(())
-        })
-        .await?
-    }
-
-    /// Create a consistent backup of the database at the given path.
-    ///
-    /// Takes a read snapshot of the live database and copies all key/value
-    /// pairs from both keyspaces into a new database at `dest`. The new
-    /// database is created with the same `StorageConfig` as the live one.
-    ///
-    /// This runs entirely from a point-in-time snapshot, so it does not
-    /// block or lock the live database.
-    pub async fn backup_snapshot(
-        &self,
-        dest: impl AsRef<Path> + Send + 'static,
-    ) -> Result<(), StoreError> {
-        let ks = self.ks.clone();
-        let config = self.config.clone();
-
-        task::spawn_blocking(move || {
-            let snapshot = ks.db.read_tx();
-            let dest = dest.as_ref();
-
-            // Open a new database with matching settings.
-            let backup_db = fjall::Database::builder(dest)
-                .cache_size(config.cache_size)
-                .max_journaling_size(config.journal_size)
-                .open()
-                .map_err(|e| {
-                    StoreError::Internal(format!("failed to open backup database: {e}"))
-                })?;
-
-            let data_compaction = Arc::new(
-                fjall::compaction::Leveled::default()
-                    .with_l0_threshold(config.l0_threshold)
-                    .with_table_target_size(config.data_table_size),
-            );
-            let index_compaction = Arc::new(
-                fjall::compaction::Leveled::default()
-                    .with_l0_threshold(config.l0_threshold)
-                    .with_table_target_size(config.index_table_size),
-            );
-
-            let backup_data = backup_db
-                .keyspace("data", || {
-                    fjall::KeyspaceCreateOptions::default()
-                        .compaction_strategy(data_compaction)
-                        .max_memtable_size(config.data_table_size)
-                        .filter_block_pinning_policy(PinningPolicy::all(true))
-                        .index_block_pinning_policy(PinningPolicy::all(true))
-                })
-                .map_err(|e| {
-                    StoreError::Internal(format!("failed to create backup data keyspace: {e}"))
-                })?;
-
-            let backup_index = backup_db
-                .keyspace("index", || {
-                    fjall::KeyspaceCreateOptions::default()
-                        .compaction_strategy(index_compaction)
-                        .max_memtable_size(config.index_table_size)
-                        .filter_policy(FilterPolicy::disabled())
-                        .index_block_pinning_policy(PinningPolicy::all(true))
-                })
-                .map_err(|e| {
-                    StoreError::Internal(format!("failed to create backup index keyspace: {e}"))
-                })?;
-
-            // Copy all data keyspace entries.
-            for entry in snapshot.range::<Vec<u8>, _>(&ks.data, ..) {
-                let (key, value) = entry.into_inner()?;
-                backup_data
-                    .insert(&*key, &*value)
-                    .map_err(|e| StoreError::Internal(format!("backup data write failed: {e}")))?;
-            }
-
-            // Copy all index keyspace entries.
-            for entry in snapshot.range::<Vec<u8>, _>(&ks.index, ..) {
-                let (key, value) = entry.into_inner()?;
-                backup_index
-                    .insert(&*key, &*value)
-                    .map_err(|e| StoreError::Internal(format!("backup index write failed: {e}")))?;
-            }
-
-            // Flush and close cleanly.
-            backup_db
-                .persist(fjall::PersistMode::SyncAll)
-                .map_err(|e| StoreError::Internal(format!("backup flush failed: {e}")))?;
-
-            drop(backup_db);
-            Ok(())
-        })
-        .await?
-    }
-}
-
-/// Compute the backoff delay in milliseconds for a given attempt count.
-///
-/// Formula: `delay_ms = attempts^exponent + base_ms + rand(0..jitter_ms) * (attempts + 1)`
-///
-/// The jitter component scales linearly with the attempt count so that
-/// later retries spread further apart, reducing collision likelihood when
-/// many jobs fail at similar times.
-pub(super) fn compute_backoff(attempts: u32, backoff: &BackoffConfig) -> u64 {
-    use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hasher};
-
-    let base_delay = (attempts as f32).powf(backoff.exponent) + backoff.base_ms as f32;
-
-    // Cheap random value using the same approach as rand_id() in http.rs.
-    let rand_frac = (RandomState::new().build_hasher().finish() as f64) / (u64::MAX as f64); // 0.0..1.0
-
-    let jitter = rand_frac * backoff.jitter_ms as f64 * (attempts as f64 + 1.0);
-
-    (base_delay as f64 + jitter) as u64
 }
 
 #[cfg(test)]
@@ -537,66 +396,11 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    use crate::store::options::{BulkDeleteOptions, EnqueueOptions, ListJobsOptions};
+    use crate::store::options::EnqueueOptions;
     use crate::store::storage_config::StorageConfig;
     use crate::store::test_support::test_store;
     use crate::store::types::JobStatus;
     use crate::time::now_millis;
-
-    // --- compute_backoff tests ---
-
-    #[test]
-    fn compute_backoff_zero_jitter_is_deterministic() {
-        let backoff = BackoffConfig {
-            exponent: 2.0,
-            base_ms: 100,
-            jitter_ms: 0,
-        };
-
-        // attempts=1: 1^2 + 100 = 101
-        assert_eq!(compute_backoff(1, &backoff), 101);
-        // attempts=2: 2^2 + 100 = 104
-        assert_eq!(compute_backoff(2, &backoff), 104);
-        // attempts=3: 3^2 + 100 = 109
-        assert_eq!(compute_backoff(3, &backoff), 109);
-    }
-
-    #[test]
-    fn compute_backoff_with_jitter_stays_in_range() {
-        let backoff = BackoffConfig {
-            exponent: 2.0,
-            base_ms: 100,
-            jitter_ms: 50,
-        };
-
-        // Run many times to exercise randomness.
-        for attempts in 1..=10 {
-            let delay = compute_backoff(attempts, &backoff);
-            let base = (attempts as f64).powf(2.0) + 100.0;
-            let max_jitter = 50.0 * (attempts as f64 + 1.0);
-            assert!(
-                delay >= base as u64,
-                "delay {delay} below base {base} for attempt {attempts}"
-            );
-            assert!(
-                delay <= (base + max_jitter) as u64,
-                "delay {delay} above max {} for attempt {attempts}",
-                base + max_jitter
-            );
-        }
-    }
-
-    #[test]
-    fn compute_backoff_zero_attempts() {
-        let backoff = BackoffConfig {
-            exponent: 2.0,
-            base_ms: 100,
-            jitter_ms: 0,
-        };
-
-        // attempts=0: 0^2 + 100 = 100
-        assert_eq!(compute_backoff(0, &backoff), 100);
-    }
 
     #[tokio::test]
     async fn fsync_commit_mode_smoke_test() {
@@ -755,96 +559,5 @@ mod tests {
             .into_job();
 
         assert_eq!(store.scheduled_count(), 1);
-    }
-
-    // --- compact_all + auto-compact ---
-
-    #[tokio::test]
-    async fn compact_all_succeeds_on_empty_store() {
-        let store = test_store();
-        store.compact_all().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn compact_all_succeeds_after_writes_and_deletes() {
-        let store = test_store();
-        let now = now_millis();
-
-        for _ in 0..50 {
-            store
-                .enqueue(now, EnqueueOptions::new("t", "q", serde_json::json!(null)))
-                .await
-                .unwrap();
-        }
-        let count = store.delete_jobs(BulkDeleteOptions::new()).await.unwrap();
-        assert_eq!(count, 50);
-
-        store.compact_all().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn backup_snapshot_copies_all_data() {
-        let store = test_store();
-        let now = now_millis();
-
-        // Enqueue some jobs across different queues.
-        for i in 0..5 {
-            store
-                .enqueue(
-                    now,
-                    EnqueueOptions::new("test", &format!("q{i}"), serde_json::json!({"i": i})),
-                )
-                .await
-                .unwrap();
-        }
-
-        // Create the backup.
-        let backup_dir = tempfile::tempdir().unwrap();
-        let backup_path = backup_dir.path().join("data");
-        store.backup_snapshot(backup_path.clone()).await.unwrap();
-
-        // Open the backup as a new store and verify the data.
-        let restored = Store::open(&backup_path, Default::default()).unwrap();
-        let opts = ListJobsOptions::new().limit(100).now(now);
-        let page = restored.list_jobs(opts).await.unwrap();
-        assert_eq!(page.jobs.len(), 5);
-
-        let queues = restored.list_queues().await.unwrap();
-        assert_eq!(queues, vec!["q0", "q1", "q2", "q3", "q4"]);
-    }
-
-    #[tokio::test]
-    async fn backup_snapshot_is_point_in_time() {
-        let store = test_store();
-        let now = now_millis();
-
-        store
-            .enqueue(
-                now,
-                EnqueueOptions::new("test", "q", serde_json::json!("before")),
-            )
-            .await
-            .unwrap();
-
-        // Take the backup.
-        let backup_dir = tempfile::tempdir().unwrap();
-        let backup_path = backup_dir.path().join("data");
-        store.backup_snapshot(backup_path.clone()).await.unwrap();
-
-        // Enqueue more after the backup.
-        store
-            .enqueue(
-                now,
-                EnqueueOptions::new("test", "q", serde_json::json!("after")),
-            )
-            .await
-            .unwrap();
-
-        // The backup should only contain the job from before.
-        let restored = Store::open(&backup_path, Default::default()).unwrap();
-        let opts = ListJobsOptions::new().limit(100).now(now);
-        let page = restored.list_jobs(opts).await.unwrap();
-        assert_eq!(page.jobs.len(), 1);
-        assert_eq!(page.jobs[0].payload, Some(serde_json::json!("before")));
     }
 }


### PR DESCRIPTION
This is the final commit in a series of commits in which we've been breaking down the massive `store` module into smaller modules. What was over 13K lines of code is now spread across many modules with < 1K each. `store.rs` itself is now well under 1K lines.

In this commit, `maintenance.rs` is extracted, which includes the compaction and backup functionality, and the `enqueue` and `complete` modules have their `mod.rs` broken into smaller modules by functionality area.

No further work is on the immediate agenda for breaking down the store.