### PR TITLE
Implement Integer Range Support for Query Params.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -37,7 +37,7 @@ use super::types::{
     CronGroupResponse, DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse,
     FailureRequest, HealthResponse, Job, JobStatus, ListCronGroupsResponse, ListErrorsPages,
     ListErrorsParams, ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse,
-    ListQueuesResponse, Order, PatchCronGroupRequest, PatchJobBody, PatchJobsParams,
+    ListQueuesResponse, Order, PatchCronGroupRequest, PatchJobBody, PatchJobsParams, RangeQuery,
     ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse, VersionResponse,
     parse_unique_while,
 };
@@ -1165,6 +1165,8 @@ async fn bulk_delete_jobs(
     if !params.job_type.is_empty() {
         opts.types = params.job_type.0;
     }
+    opts.priority = params.priority.0;
+    opts.ready_at = params.ready_at.0;
     opts.filter = filter;
 
     match state.store.delete_jobs(opts).await {
@@ -1333,6 +1335,8 @@ async fn bulk_patch_jobs(
         } else {
             params.job_type.0
         },
+        priority: params.priority.0,
+        ready_at: params.ready_at.0,
         filter,
         patch,
     };
@@ -1425,6 +1429,8 @@ async fn list_jobs(
         }
         opts = opts.ids(params.id.0.clone());
     }
+    opts = opts.priority(params.priority.0.clone());
+    opts = opts.ready_at(params.ready_at.0.clone());
     if let Some(ref expr) = params.filter {
         match PayloadFilter::compile(expr) {
             Ok(f) => opts.filter = Some(std::sync::Arc::new(f)),
@@ -1451,6 +1457,8 @@ async fn list_jobs(
                 &params.queue,
                 &params.job_type,
                 &params.id,
+                &params.priority,
+                &params.ready_at,
                 filter_expr,
             );
             let next = page.next.map(|o| {
@@ -1462,6 +1470,8 @@ async fn list_jobs(
                     &params.queue,
                     &params.job_type,
                     &params.id,
+                    &params.priority,
+                    &params.ready_at,
                     filter_expr,
                 )
             });
@@ -1474,6 +1484,8 @@ async fn list_jobs(
                     &params.queue,
                     &params.job_type,
                     &params.id,
+                    &params.priority,
+                    &params.ready_at,
                     filter_expr,
                 )
             });
@@ -1527,6 +1539,8 @@ fn build_page_url(
     queues: &CommaSet<String>,
     types: &CommaSet<String>,
     ids: &CommaSet<String>,
+    priority: &RangeQuery<u16>,
+    ready_at: &RangeQuery<u64>,
     filter: Option<&str>,
 ) -> String {
     let mut url = String::from("/jobs?");
@@ -1546,6 +1560,12 @@ fn build_page_url(
     }
     if !ids.is_empty() {
         url.push_str(&format!("&id={ids}"));
+    }
+    if !priority.is_empty() {
+        url.push_str(&format!("&priority={priority}"));
+    }
+    if !ready_at.is_empty() {
+        url.push_str(&format!("&ready_at={ready_at}"));
     }
     if let Some(expr) = filter {
         url.push_str(&format!("&filter={}", urlencoding::encode(expr)));
@@ -1614,6 +1634,8 @@ async fn count_jobs(
         }
         opts = opts.ids(params.id.0.clone());
     }
+    opts = opts.priority(params.priority.0.clone());
+    opts = opts.ready_at(params.ready_at.0.clone());
     if let Some(ref expr) = params.filter {
         match PayloadFilter::compile(expr) {
             Ok(f) => opts.filter = Some(std::sync::Arc::new(f)),
@@ -7318,6 +7340,283 @@ mod tests {
         let text = response_body(res).await;
         let body: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(body["patched"], 0);
+    }
+
+    // --- range filter tests (priority + ready_at) ---
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_priority_range() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for p in [0u16, 5, 50, 100, 200] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let req = empty_request("GET", "/jobs?priority=5..100");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let priorities: Vec<u64> = body["jobs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|j| j["priority"].as_u64().unwrap())
+            .collect();
+        assert_eq!(priorities, vec![5, 50, 100]);
+    }
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_unbounded_upper_priority() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for p in [0u16, 50, 100] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let req = empty_request("GET", "/jobs?priority=50..");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let jobs = body["jobs"].as_array().unwrap();
+        assert_eq!(jobs.len(), 2);
+        assert!(jobs.iter().all(|j| j["priority"].as_u64().unwrap() >= 50));
+    }
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_ready_at_range() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for offset_secs in [10u64, 30, 60, 120] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null))
+                        .ready_at(now + offset_secs * 1_000),
+                )
+                .await
+                .unwrap();
+        }
+
+        let lo = now + 30_000;
+        let hi = now + 90_000;
+        let req = empty_request("GET", &format!("/jobs?ready_at={lo}..{hi}"));
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let jobs = body["jobs"].as_array().unwrap();
+        assert_eq!(jobs.len(), 2);
+        for j in jobs {
+            let ra = j["ready_at"].as_u64().unwrap();
+            assert!(ra >= lo && ra <= hi);
+        }
+    }
+
+    #[tokio::test]
+    async fn list_jobs_priority_filter_preserves_in_pagination() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        // Three matches at priority 50, plus noise outside the range.
+        for p in [50u16, 50, 50, 0, 200] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let req = empty_request("GET", "/jobs?priority=50&limit=2");
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["jobs"].as_array().unwrap().len(), 2);
+
+        // The next URL must carry the priority parameter forward.
+        let next_url = body["pages"]["next"].as_str().unwrap();
+        assert!(next_url.contains("priority=50"), "next_url: {next_url}");
+
+        let req = empty_request("GET", next_url);
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let jobs = body["jobs"].as_array().unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["priority"], 50);
+    }
+
+    #[tokio::test]
+    async fn list_jobs_ready_at_range_preserves_in_pagination() {
+        // A bounded ready_at range like "1000..2000" must survive the
+        // Display/Deserialize round-trip on the next-page URL.
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for offset_secs in [30u64, 40, 50, 5, 1000] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null))
+                        .ready_at(now + offset_secs * 1_000),
+                )
+                .await
+                .unwrap();
+        }
+
+        let lo = now + 20_000;
+        let hi = now + 60_000;
+        let req = empty_request("GET", &format!("/jobs?ready_at={lo}..{hi}&limit=2"));
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["jobs"].as_array().unwrap().len(), 2);
+
+        let next_url = body["pages"]["next"].as_str().unwrap();
+        assert!(
+            next_url.contains(&format!("ready_at={lo}..{hi}")),
+            "next_url: {next_url}"
+        );
+
+        let req = empty_request("GET", next_url);
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let jobs = body["jobs"].as_array().unwrap();
+        assert_eq!(jobs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_jobs_rejects_lo_greater_than_hi() {
+        let req = empty_request("GET", "/jobs?priority=200..100");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(body["error"].as_str().unwrap().contains("invalid query"));
+    }
+
+    #[tokio::test]
+    async fn list_jobs_rejects_non_numeric_priority() {
+        let req = empty_request("GET", "/jobs?priority=abc");
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn bulk_delete_by_priority_range() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for p in [0u16, 5, 50, 200] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let req = empty_request("DELETE", "/jobs?priority=5..100");
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["deleted"], 2);
+
+        let req = empty_request("GET", "/jobs");
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let priorities: Vec<u64> = body["jobs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|j| j["priority"].as_u64().unwrap())
+            .collect();
+        assert_eq!(priorities, vec![0, 200]);
+    }
+
+    #[tokio::test]
+    async fn bulk_patch_by_priority_range() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for p in [0u16, 5, 50, 200] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let req = json_request(
+            "PATCH",
+            "/jobs?priority=5..100",
+            &serde_json::json!({"priority": 7}),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["patched"], 2);
+
+        let req = empty_request("GET", "/jobs");
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let mut priorities: Vec<u64> = body["jobs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|j| j["priority"].as_u64().unwrap())
+            .collect();
+        priorities.sort();
+        assert_eq!(priorities, vec![0, 7, 7, 200]);
+    }
+
+    #[tokio::test]
+    async fn count_jobs_by_priority_range() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        for p in [0u16, 5, 50, 100, 200] {
+            state
+                .store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let req = empty_request("GET", "/jobs/count?priority=5..100");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 3);
     }
 
     #[tokio::test]

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -10,6 +10,7 @@
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
+use std::ops::RangeInclusive;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -148,6 +149,112 @@ where
             set.insert(value);
         }
         Ok(Self(set))
+    }
+}
+
+// --- RangeQuery ---
+
+/// Min/max bounds used to fill in an unbounded side of a range query.
+///
+/// Implemented for the unsigned integer types that range-filterable
+/// job fields use (`priority: u16`, `ready_at: u64`).
+pub trait QueryBounded: Sized {
+    const MIN: Self;
+    const MAX: Self;
+}
+
+impl QueryBounded for u16 {
+    const MIN: Self = u16::MIN;
+    const MAX: Self = u16::MAX;
+}
+
+impl QueryBounded for u64 {
+    const MIN: Self = u64::MIN;
+    const MAX: Self = u64::MAX;
+}
+
+/// A range deserialized from a query parameter, with **inclusive** bounds
+/// on both sides.
+///
+/// Four accepted shapes:
+///
+/// - `"100"` → `100..=100` (single value)
+/// - `"100..200"` → `100..=200`
+/// - `"..200"` → `T::MIN..=200`
+/// - `"100.."` → `100..=T::MAX`
+///
+/// An absent or empty parameter deserializes as `None` (no range filter).
+/// A range where the lower bound exceeds the upper bound is a deserialize
+/// error.
+#[derive(Debug, Clone, Default)]
+pub struct RangeQuery<T>(pub Option<RangeInclusive<T>>);
+
+impl<T> RangeQuery<T> {
+    /// Return `true` when no range is set (treated as "match anything").
+    pub fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+impl<T> fmt::Display for RangeQuery<T>
+where
+    T: fmt::Display + PartialEq + QueryBounded,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Some(range) = &self.0 else {
+            return Ok(());
+        };
+        let (lo, hi) = (range.start(), range.end());
+        if lo == hi {
+            write!(f, "{lo}")
+        } else if *lo == T::MIN {
+            write!(f, "..{hi}")
+        } else if *hi == T::MAX {
+            write!(f, "{lo}..")
+        } else {
+            write!(f, "{lo}..{hi}")
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for RangeQuery<T>
+where
+    T: FromStr + Ord + Clone + QueryBounded,
+    T::Err: fmt::Display,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.is_empty() {
+            return Ok(Self(None));
+        }
+
+        let (lo, hi) = if let Some((lo_str, hi_str)) = s.split_once("..") {
+            let lo = if lo_str.is_empty() {
+                T::MIN
+            } else {
+                lo_str.parse().map_err(serde::de::Error::custom)?
+            };
+            let hi = if hi_str.is_empty() {
+                T::MAX
+            } else {
+                hi_str.parse().map_err(serde::de::Error::custom)?
+            };
+            (lo, hi)
+        } else {
+            let v: T = s.parse().map_err(serde::de::Error::custom)?;
+            (v.clone(), v)
+        };
+
+        if lo > hi {
+            return Err(serde::de::Error::custom(
+                "range lower bound exceeds upper bound",
+            ));
+        }
+
+        Ok(Self(Some(lo..=hi)))
     }
 }
 
@@ -566,6 +673,14 @@ pub struct ListJobsParams {
     #[serde(default)]
     pub id: CommaSet<String>,
 
+    /// Priority range (inclusive). Accepts `N`, `A..B`, `..B`, or `A..`.
+    #[serde(default)]
+    pub priority: RangeQuery<u16>,
+
+    /// `ready_at` range (inclusive, ms since epoch). Same syntax as `priority`.
+    #[serde(default)]
+    pub ready_at: RangeQuery<u64>,
+
     /// jq expression to filter jobs by payload (e.g. ".user_id == 42").
     pub filter: Option<String>,
 }
@@ -589,6 +704,14 @@ pub struct CountJobsParams {
     /// Type filter, comma-delimited.
     #[serde(default, rename = "type")]
     pub job_type: CommaSet<String>,
+
+    /// Priority range (inclusive). Accepts `N`, `A..B`, `..B`, or `A..`.
+    #[serde(default)]
+    pub priority: RangeQuery<u16>,
+
+    /// `ready_at` range (inclusive, ms since epoch). Same syntax as `priority`.
+    #[serde(default)]
+    pub ready_at: RangeQuery<u64>,
 
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
@@ -614,6 +737,14 @@ pub struct DeleteJobsParams {
     #[serde(default, rename = "type")]
     pub job_type: CommaSet<String>,
 
+    /// Priority range (inclusive). Accepts `N`, `A..B`, `..B`, or `A..`.
+    #[serde(default)]
+    pub priority: RangeQuery<u16>,
+
+    /// `ready_at` range (inclusive, ms since epoch). Same syntax as `priority`.
+    #[serde(default)]
+    pub ready_at: RangeQuery<u64>,
+
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
 }
@@ -637,6 +768,14 @@ pub struct PatchJobsParams {
     /// Type filter, comma-delimited.
     #[serde(default, rename = "type")]
     pub job_type: CommaSet<String>,
+
+    /// Priority range (inclusive). Accepts `N`, `A..B`, `..B`, or `A..`.
+    #[serde(default)]
+    pub priority: RangeQuery<u16>,
+
+    /// `ready_at` range (inclusive, ms since epoch). Same syntax as `priority`.
+    #[serde(default)]
+    pub ready_at: RangeQuery<u64>,
 
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
@@ -1001,5 +1140,103 @@ impl CronEntryResponse {
             next_enqueue_at: entry.next_enqueue_at,
             last_enqueue_at: entry.last_enqueue_at,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The RangeQuery Deserialize impl reads a string, so we can exercise it
+    // by deserializing a JSON string literal. This avoids pulling in a URL
+    // parser just for tests.
+    fn parse_u16(s: &str) -> Result<RangeQuery<u16>, String> {
+        let json = serde_json::to_string(s).unwrap();
+        serde_json::from_str::<RangeQuery<u16>>(&json).map_err(|e| e.to_string())
+    }
+
+    fn parse_u64(s: &str) -> Result<RangeQuery<u64>, String> {
+        let json = serde_json::to_string(s).unwrap();
+        serde_json::from_str::<RangeQuery<u64>>(&json).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn range_query_single_value() {
+        let r = parse_u16("42").unwrap();
+        assert_eq!(r.0, Some(42..=42));
+    }
+
+    #[test]
+    fn range_query_bounded_both_sides() {
+        let r = parse_u16("10..200").unwrap();
+        assert_eq!(r.0, Some(10..=200));
+    }
+
+    #[test]
+    fn range_query_unbounded_lower() {
+        let r = parse_u16("..200").unwrap();
+        assert_eq!(r.0, Some(0..=200));
+    }
+
+    #[test]
+    fn range_query_unbounded_upper() {
+        let r = parse_u16("100..").unwrap();
+        assert_eq!(r.0, Some(100..=u16::MAX));
+    }
+
+    #[test]
+    fn range_query_unbounded_both_sides() {
+        let r = parse_u16("..").unwrap();
+        assert_eq!(r.0, Some(0..=u16::MAX));
+    }
+
+    #[test]
+    fn range_query_empty_string_is_none() {
+        let r = parse_u16("").unwrap();
+        assert_eq!(r.0, None);
+    }
+
+    #[test]
+    fn range_query_rejects_lo_greater_than_hi() {
+        let err = parse_u16("200..100").unwrap_err();
+        assert!(err.contains("lower bound exceeds"), "got: {err}");
+    }
+
+    #[test]
+    fn range_query_rejects_non_numeric() {
+        let err = parse_u16("abc").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn range_query_rejects_negative() {
+        let err = parse_u16("-5..10").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn range_query_u64_full_range() {
+        let r = parse_u64("1700000000000..1800000000000").unwrap();
+        assert_eq!(r.0, Some(1_700_000_000_000..=1_800_000_000_000));
+    }
+
+    #[test]
+    fn range_query_display_round_trip() {
+        // Each shape must format back to a string the deserializer accepts.
+        for input in ["42", "10..200", "..200", "100..", ".."] {
+            let parsed = parse_u16(input).unwrap();
+            let rendered = parsed.to_string();
+            let reparsed = parse_u16(&rendered).unwrap();
+            assert_eq!(
+                parsed.0, reparsed.0,
+                "round-trip failed: {input} -> {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn range_query_display_empty_is_blank() {
+        let r: RangeQuery<u16> = RangeQuery::default();
+        assert_eq!(r.to_string(), "");
     }
 }

--- a/src/store/delete.rs
+++ b/src/store/delete.rs
@@ -20,7 +20,7 @@ use super::keys::{
     make_type_key, make_unique_key,
 };
 use super::options::BulkDeleteOptions;
-use super::scan::{JobStream, PayloadFilteredIter, build_id_stream};
+use super::scan::{JobStream, PayloadFilteredIter, RangeFilteredIter, build_id_stream};
 use super::store::{Keyspaces, Store, StoreEvent};
 use super::types::{Job, JobStatus, ScanDirection, StoreError};
 
@@ -150,6 +150,17 @@ impl Store {
                         has_payload_filter,
                     );
                     Box::new(stream) as Box<dyn Iterator<Item = Result<Job, StoreError>> + '_>
+                };
+
+            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
+                if opts.priority.is_some() || opts.ready_at.is_some() {
+                    Box::new(RangeFilteredIter {
+                        inner: jobs,
+                        priority: opts.priority.clone(),
+                        ready_at: opts.ready_at.clone(),
+                    })
+                } else {
+                    jobs
                 };
 
             let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
@@ -812,5 +823,75 @@ mod tests {
         }
         let count = store.delete_jobs(BulkDeleteOptions::new()).await.unwrap();
         assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn delete_jobs_by_priority_range() {
+        let store = test_store();
+        let now = now_millis();
+
+        for p in [0u16, 5, 50, 200] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut opts = BulkDeleteOptions::new();
+        opts.priority = Some(5..=100);
+        let count = store.delete_jobs(opts).await.unwrap();
+        assert_eq!(count, 2);
+
+        let page = store
+            .list_jobs(ListJobsOptions::new().now(now))
+            .await
+            .unwrap();
+        let remaining: Vec<u16> = page.jobs.iter().map(|j| j.priority).collect();
+        assert_eq!(remaining, vec![0, 200]);
+    }
+
+    #[tokio::test]
+    async fn delete_jobs_by_ready_at_range_intersected_with_queue() {
+        let store = test_store();
+        let now = now_millis();
+
+        // Queue "a" — two scheduled, one in range.
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "a", serde_json::json!(null)).ready_at(now + 10_000),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "a", serde_json::json!(null)).ready_at(now + 60_000),
+            )
+            .await
+            .unwrap();
+        // Queue "b" — one scheduled in range, must not be deleted.
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "b", serde_json::json!(null)).ready_at(now + 10_000),
+            )
+            .await
+            .unwrap();
+
+        let mut opts = BulkDeleteOptions::new();
+        opts.queues = ["a".into()].into();
+        opts.ready_at = Some((now + 5_000)..=(now + 20_000));
+        let count = store.delete_jobs(opts).await.unwrap();
+        assert_eq!(count, 1);
+
+        let page = store
+            .list_jobs(ListJobsOptions::new().now(now))
+            .await
+            .unwrap();
+        assert_eq!(page.jobs.len(), 2);
     }
 }

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -7,6 +7,7 @@
 //! queries, enqueue operations, patches, and failure handling.
 
 use std::collections::HashSet;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -48,6 +49,14 @@ pub struct ListJobsOptions {
     /// When `Some`, jobs past their purge_at are skipped.
     pub now: Option<u64>,
 
+    /// Optional priority range filter (inclusive on both ends).
+    /// Applied as a post-hydration check on each candidate job.
+    pub priority: Option<RangeInclusive<u16>>,
+
+    /// Optional `ready_at` range filter (inclusive on both ends, ms since
+    /// epoch). Applied as a post-hydration check on each candidate job.
+    pub ready_at: Option<RangeInclusive<u64>>,
+
     /// Optional jq-style payload filter. When provided, only jobs whose
     /// payload matches the filter are returned. Payloads are hydrated and
     /// checked after the index scan narrows the candidate set.
@@ -69,6 +78,8 @@ impl ListJobsOptions {
             queues: HashSet::new(),
             types: HashSet::new(),
             now: None,
+            priority: None,
+            ready_at: None,
             filter: None,
         }
     }
@@ -130,6 +141,18 @@ impl ListJobsOptions {
         self
     }
 
+    /// Filter by priority range (inclusive) and return `self`.
+    pub fn priority(mut self, range: impl Into<Option<RangeInclusive<u16>>>) -> Self {
+        self.priority = range.into();
+        self
+    }
+
+    /// Filter by `ready_at` range (inclusive, ms since epoch) and return `self`.
+    pub fn ready_at(mut self, range: impl Into<Option<RangeInclusive<u64>>>) -> Self {
+        self.ready_at = range.into();
+        self
+    }
+
     /// Set the payload filter and return `self`.
     pub fn filter(mut self, filter: impl Into<Option<Arc<PayloadFilter>>>) -> Self {
         self.filter = filter.into();
@@ -152,6 +175,12 @@ pub struct BulkDeleteOptions {
     /// Optional type filter.
     pub types: HashSet<String>,
 
+    /// Optional priority range (inclusive on both ends).
+    pub priority: Option<RangeInclusive<u16>>,
+
+    /// Optional `ready_at` range (inclusive on both ends, ms since epoch).
+    pub ready_at: Option<RangeInclusive<u64>>,
+
     /// Optional jq payload filter.
     pub filter: Option<Arc<PayloadFilter>>,
 }
@@ -163,6 +192,8 @@ impl BulkDeleteOptions {
             statuses: HashSet::new(),
             queues: HashSet::new(),
             types: HashSet::new(),
+            priority: None,
+            ready_at: None,
             filter: None,
         }
     }
@@ -184,6 +215,12 @@ pub struct BulkPatchOptions {
 
     /// Optional type filter.
     pub types: HashSet<String>,
+
+    /// Optional priority range (inclusive on both ends).
+    pub priority: Option<RangeInclusive<u16>>,
+
+    /// Optional `ready_at` range (inclusive on both ends, ms since epoch).
+    pub ready_at: Option<RangeInclusive<u64>>,
 
     /// Optional jq payload filter.
     pub filter: Option<Arc<PayloadFilter>>,

--- a/src/store/patch.rs
+++ b/src/store/patch.rs
@@ -18,7 +18,7 @@ use tokio::task;
 use super::keys::{make_job_key, make_queue_key, make_status_key};
 use super::options::{BulkPatchOptions, PatchJobOptions};
 use super::ready_index::ReadyIndex;
-use super::scan::{JobStream, PayloadFilteredIter, build_id_stream};
+use super::scan::{JobStream, PayloadFilteredIter, RangeFilteredIter, build_id_stream};
 use super::scheduled_index::ScheduledIndex;
 use super::store::{Keyspaces, Store, StoreEvent};
 use super::types::{Job, JobStatus, ScanDirection, StoreError};
@@ -346,6 +346,17 @@ impl Store {
                         None,
                         has_payload_filter,
                     ))
+                };
+
+            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
+                if opts.priority.is_some() || opts.ready_at.is_some() {
+                    Box::new(RangeFilteredIter {
+                        inner: jobs,
+                        priority: opts.priority.clone(),
+                        ready_at: opts.ready_at.clone(),
+                    })
+                } else {
+                    jobs
                 };
 
             let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
@@ -1210,6 +1221,8 @@ mod tests {
             statuses: HashSet::new(),
             queues: ["q1".into()].into(),
             types: HashSet::new(),
+            priority: None,
+            ready_at: None,
             filter: None,
             patch: PatchJobOptions {
                 queue: Some("q2".into()),
@@ -1251,6 +1264,8 @@ mod tests {
             statuses: HashSet::new(),
             queues: HashSet::new(),
             types: HashSet::new(),
+            priority: None,
+            ready_at: None,
             filter: None,
             patch: PatchJobOptions {
                 priority: Some(99),
@@ -1282,6 +1297,8 @@ mod tests {
             statuses: HashSet::new(),
             queues: HashSet::new(),
             types: HashSet::new(),
+            priority: None,
+            ready_at: None,
             filter: None,
             patch: PatchJobOptions {
                 ready_at: Some(Some(future)),
@@ -1324,6 +1341,8 @@ mod tests {
             statuses: HashSet::new(),
             queues: HashSet::new(),
             types: HashSet::new(),
+            priority: None,
+            ready_at: None,
             filter: None,
             patch: PatchJobOptions {
                 priority: Some(99),
@@ -1347,6 +1366,8 @@ mod tests {
             statuses: HashSet::new(),
             queues: ["nonexistent".into()].into(),
             types: HashSet::new(),
+            priority: None,
+            ready_at: None,
             filter: None,
             patch: PatchJobOptions {
                 priority: Some(99),
@@ -1356,5 +1377,92 @@ mod tests {
 
         let count = store.patch_jobs(opts).await.unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn patch_jobs_by_priority_range() {
+        let store = test_store();
+        let now = now_millis();
+
+        for p in [0u16, 5, 50, 200] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let opts = BulkPatchOptions {
+            ids: HashSet::new(),
+            statuses: HashSet::new(),
+            queues: HashSet::new(),
+            types: HashSet::new(),
+            priority: Some(5..=100),
+            ready_at: None,
+            filter: None,
+            patch: PatchJobOptions {
+                priority: Some(7),
+                ..Default::default()
+            },
+        };
+        let count = store.patch_jobs(opts).await.unwrap();
+        assert_eq!(count, 2);
+
+        let page = store.list_jobs(ListJobsOptions::new()).await.unwrap();
+        let mut got: Vec<u16> = page.jobs.iter().map(|j| j.priority).collect();
+        got.sort();
+        assert_eq!(got, vec![0, 7, 7, 200]);
+    }
+
+    #[tokio::test]
+    async fn patch_jobs_by_ready_at_range_intersected_with_queue() {
+        let store = test_store();
+        let now = now_millis();
+
+        // Queue "a" — two scheduled jobs, one inside the window.
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "a", serde_json::json!(null)).ready_at(now + 10_000),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "a", serde_json::json!(null)).ready_at(now + 60_000),
+            )
+            .await
+            .unwrap();
+        // Queue "b" — one scheduled job in the window, must not be touched.
+        let untouched = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "b", serde_json::json!(null)).ready_at(now + 10_000),
+            )
+            .await
+            .unwrap()
+            .into_job();
+
+        let opts = BulkPatchOptions {
+            ids: HashSet::new(),
+            statuses: HashSet::new(),
+            queues: ["a".into()].into(),
+            types: HashSet::new(),
+            priority: None,
+            ready_at: Some((now + 5_000)..=(now + 20_000)),
+            filter: None,
+            patch: PatchJobOptions {
+                priority: Some(42),
+                ..Default::default()
+            },
+        };
+        let count = store.patch_jobs(opts).await.unwrap();
+        assert_eq!(count, 1);
+
+        let untouched_after = store.get_job(now, &untouched.id).await.unwrap().unwrap();
+        assert_eq!(untouched_after.priority, 0);
     }
 }

--- a/src/store/read.rs
+++ b/src/store/read.rs
@@ -18,7 +18,7 @@ use tokio::task;
 use super::keys::{IndexKind, RecordKind, make_error_key, make_job_key, make_payload_key};
 use super::options::{ListErrorsOptions, ListJobsOptions};
 use super::results::{ListErrorsPage, ListJobsPage};
-use super::scan::{JobStream, PayloadFilteredIter, build_id_stream};
+use super::scan::{JobStream, PayloadFilteredIter, RangeFilteredIter, build_id_stream};
 use super::store::Store;
 use super::types::{ErrorRecord, Job, ScanDirection, StoreError};
 
@@ -87,16 +87,28 @@ impl Store {
                 }
             };
 
-            let mut rows: Vec<Job> = if let Some(filter) = opts.filter.clone() {
-                PayloadFilteredIter {
-                    inner: job_stream,
-                    filter,
-                }
-                .take(fetch)
-                .collect::<Result<Vec<_>, _>>()?
-            } else {
-                job_stream.take(fetch).collect::<Result<Vec<_>, _>>()?
-            };
+            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
+                if opts.priority.is_some() || opts.ready_at.is_some() {
+                    Box::new(RangeFilteredIter {
+                        inner: job_stream,
+                        priority: opts.priority.clone(),
+                        ready_at: opts.ready_at.clone(),
+                    })
+                } else {
+                    Box::new(job_stream)
+                };
+
+            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
+                if let Some(filter) = opts.filter.clone() {
+                    Box::new(PayloadFilteredIter {
+                        inner: jobs,
+                        filter,
+                    })
+                } else {
+                    jobs
+                };
+
+            let mut rows: Vec<Job> = jobs.take(fetch).collect::<Result<Vec<_>, _>>()?;
 
             // If we got more rows than the requested limit, we know there's a
             // next page, and we can just discard that extra row now.
@@ -116,6 +128,8 @@ impl Store {
                     .queues(opts.queues.clone())
                     .types(opts.types.clone())
                     .now(opts.now)
+                    .priority(opts.priority.clone())
+                    .ready_at(opts.ready_at.clone())
                     .filter(opts.filter.clone())
             };
 
@@ -169,7 +183,7 @@ impl Store {
 
             let needs_payload = opts.filter.is_some();
 
-            let mut job_stream = match id_stream_opt {
+            let job_stream = match id_stream_opt {
                 Some((ids, source, _has_id_filter)) => {
                     JobStream::by_id(ids, &snapshot, &ks.data, opts.now, needs_payload, source)
                 }
@@ -183,15 +197,28 @@ impl Store {
                 ),
             };
 
-            let count = if let Some(filter) = opts.filter.clone() {
-                PayloadFilteredIter {
-                    inner: job_stream,
-                    filter,
-                }
-                .try_fold(0, |acc, r| r.map(|_| acc + 1))?
-            } else {
-                job_stream.try_fold(0, |acc, r| r.map(|_| acc + 1))?
-            };
+            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
+                if opts.priority.is_some() || opts.ready_at.is_some() {
+                    Box::new(RangeFilteredIter {
+                        inner: job_stream,
+                        priority: opts.priority.clone(),
+                        ready_at: opts.ready_at.clone(),
+                    })
+                } else {
+                    Box::new(job_stream)
+                };
+
+            let mut jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
+                if let Some(filter) = opts.filter.clone() {
+                    Box::new(PayloadFilteredIter {
+                        inner: jobs,
+                        filter,
+                    })
+                } else {
+                    jobs
+                };
+
+            let count = jobs.try_fold(0, |acc, r| r.map(|_| acc + 1))?;
 
             Ok(count)
         })
@@ -3186,5 +3213,208 @@ mod tests {
         let store = test_store();
         let queues = store.list_queues().await.unwrap();
         assert!(queues.is_empty());
+    }
+
+    // --- list_jobs / count_jobs range filter tests ---
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_priority_range_inclusive() {
+        let store = test_store();
+        let now = now_millis();
+
+        let mut by_priority: Vec<(u16, String)> = Vec::new();
+        for p in [0u16, 5, 10, 50, 100, 200] {
+            let id = store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap()
+                .into_job()
+                .id;
+            by_priority.push((p, id));
+        }
+
+        let page = store
+            .list_jobs(ListJobsOptions::new().priority(5..=100))
+            .await
+            .unwrap();
+
+        let got: HashSet<u16> = page.jobs.iter().map(|j| j.priority).collect();
+        assert_eq!(got, HashSet::from([5, 10, 50, 100]));
+    }
+
+    #[tokio::test]
+    async fn list_jobs_priority_range_with_single_value() {
+        let store = test_store();
+        let now = now_millis();
+
+        for p in [0u16, 7, 7, 9] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let page = store
+            .list_jobs(ListJobsOptions::new().priority(7..=7))
+            .await
+            .unwrap();
+
+        assert_eq!(page.jobs.len(), 2);
+        assert!(page.jobs.iter().all(|j| j.priority == 7));
+    }
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_ready_at_range() {
+        let store = test_store();
+        let now = now_millis();
+
+        for offset_secs in [10u64, 30, 60, 120, 300] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null))
+                        .ready_at(now + offset_secs * 1_000),
+                )
+                .await
+                .unwrap();
+        }
+
+        let lo = now + 30_000;
+        let hi = now + 120_000;
+        let page = store
+            .list_jobs(ListJobsOptions::new().ready_at(lo..=hi))
+            .await
+            .unwrap();
+
+        assert_eq!(page.jobs.len(), 3);
+        assert!(
+            page.jobs
+                .iter()
+                .all(|j| j.ready_at >= lo && j.ready_at <= hi)
+        );
+    }
+
+    #[tokio::test]
+    async fn list_jobs_priority_range_intersects_with_queue_filter() {
+        let store = test_store();
+        let now = now_millis();
+
+        for (queue, p) in [("a", 5u16), ("a", 50), ("b", 5), ("b", 50)] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", queue, serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let page = store
+            .list_jobs(
+                ListJobsOptions::new()
+                    .queues(["a".into()].into())
+                    .priority(40..=100),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(page.jobs.len(), 1);
+        assert_eq!(page.jobs[0].queue, "a");
+        assert_eq!(page.jobs[0].priority, 50);
+    }
+
+    #[tokio::test]
+    async fn list_jobs_priority_range_combines_with_payload_filter() {
+        let store = test_store();
+        let now = now_millis();
+
+        for (p, uid) in [(5u16, 1), (50, 1), (5, 2), (50, 2)] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!({ "u": uid })).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let filter = Arc::new(PayloadFilter::compile(".u == 1").unwrap());
+        let page = store
+            .list_jobs(ListJobsOptions::new().priority(40..=100).filter(filter))
+            .await
+            .unwrap();
+
+        assert_eq!(page.jobs.len(), 1);
+        assert_eq!(page.jobs[0].priority, 50);
+        assert_eq!(page.jobs[0].payload, Some(serde_json::json!({"u": 1})));
+    }
+
+    #[tokio::test]
+    async fn list_jobs_paginates_across_skipped_priority_rows() {
+        let store = test_store();
+        let now = now_millis();
+
+        // Interleave matching (priority 10) and non-matching (priority 200)
+        // jobs. The cursor must advance across the skipped 200s when
+        // collecting a page of matches. 5 matches with limit 2 → 3 pages.
+        for p in [10u16, 200, 10, 200, 10, 200, 10, 200, 10] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let page1 = store
+            .list_jobs(ListJobsOptions::new().priority(10..=10).limit(2))
+            .await
+            .unwrap();
+        assert_eq!(page1.jobs.len(), 2);
+        assert!(page1.jobs.iter().all(|j| j.priority == 10));
+
+        let page2 = store
+            .list_jobs(page1.next.expect("expected page 2"))
+            .await
+            .unwrap();
+        assert_eq!(page2.jobs.len(), 2);
+        assert!(page2.jobs.iter().all(|j| j.priority == 10));
+
+        let page3 = store
+            .list_jobs(page2.next.expect("expected page 3"))
+            .await
+            .unwrap();
+        assert_eq!(page3.jobs.len(), 1);
+        assert_eq!(page3.jobs[0].priority, 10);
+        assert!(page3.next.is_none());
+    }
+
+    #[tokio::test]
+    async fn count_jobs_filters_by_priority_range() {
+        let store = test_store();
+        let now = now_millis();
+
+        for p in [0u16, 5, 50, 100, 200] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(null)).priority(p),
+                )
+                .await
+                .unwrap();
+        }
+
+        let count = store
+            .count_jobs(ListJobsOptions::new().priority(5..=100))
+            .await
+            .unwrap();
+        assert_eq!(count, 3);
     }
 }

--- a/src/store/scan.rs
+++ b/src/store/scan.rs
@@ -23,7 +23,7 @@
 
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashSet};
-use std::ops::Bound;
+use std::ops::{Bound, RangeInclusive};
 use std::sync::Arc;
 
 use fjall::{Readable, SingleWriterTxKeyspace};
@@ -643,6 +643,45 @@ impl<'a, R: Readable> Iterator for JobStream<'a, R> {
 
                 return Some(Ok(job));
             },
+        }
+    }
+}
+
+/// Wraps a job iterator and skips jobs whose `priority` or `ready_at`
+/// falls outside the supplied inclusive range(s).
+///
+/// Both bounds are checked off the already-hydrated `Job` record, so no
+/// extra disk reads are required. Cheap integer comparisons — chain this
+/// before `PayloadFilteredIter` so the payload filter only runs for rows
+/// that already passed the range check.
+pub(super) struct RangeFilteredIter<I> {
+    pub(super) inner: I,
+    pub(super) priority: Option<RangeInclusive<u16>>,
+    pub(super) ready_at: Option<RangeInclusive<u64>>,
+}
+
+impl<I: Iterator<Item = Result<Job, StoreError>>> Iterator for RangeFilteredIter<I> {
+    type Item = Result<Job, StoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let job = match self.inner.next()? {
+                Ok(j) => j,
+                Err(e) => return Some(Err(e)),
+            };
+
+            if let Some(range) = &self.priority {
+                if !range.contains(&job.priority) {
+                    continue;
+                }
+            }
+            if let Some(range) = &self.ready_at {
+                if !range.contains(&job.ready_at) {
+                    continue;
+                }
+            }
+
+            return Some(Ok(job));
         }
     }
 }


### PR DESCRIPTION
Adds "x", "x..y", "..y" and "x.." range syntaxes query parameters to filter jobs by `priority` and `ready_at`. Will extend with more parameters in a follow-up.