### PR TITLE
Extract `JobFilter` struct to avoid repetition across endpoints.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -1150,24 +1150,24 @@ async fn bulk_delete_jobs(
 
     let mut opts = store::BulkDeleteOptions::new();
     if !params.id.is_empty() {
-        opts.ids = params.id.0;
+        opts.filter.ids = params.id.0;
     }
     if !params.status.is_empty() {
-        opts.statuses = params
+        opts.filter.statuses = params
             .status
             .iter()
             .map(|s| store::JobStatus::from(*s))
             .collect();
     }
     if !params.queue.is_empty() {
-        opts.queues = params.queue.0;
+        opts.filter.queues = params.queue.0;
     }
     if !params.job_type.is_empty() {
-        opts.types = params.job_type.0;
+        opts.filter.types = params.job_type.0;
     }
-    opts.priority = params.priority.0;
-    opts.ready_at = params.ready_at.0;
-    opts.filter = filter;
+    opts.filter.priority = params.priority.0;
+    opts.filter.ready_at = params.ready_at.0;
+    opts.filter.payload_filter = filter;
 
     match state.store.delete_jobs(opts).await {
         Ok(count) => {
@@ -1311,33 +1311,35 @@ async fn bulk_patch_jobs(
     }
 
     let opts = store::BulkPatchOptions {
-        ids: if params.id.is_empty() {
-            HashSet::new()
-        } else {
-            params.id.0
+        filter: store::JobFilter {
+            ids: if params.id.is_empty() {
+                HashSet::new()
+            } else {
+                params.id.0
+            },
+            statuses: if params.status.is_empty() {
+                HashSet::new()
+            } else {
+                params
+                    .status
+                    .iter()
+                    .map(|s| store::JobStatus::from(*s))
+                    .collect()
+            },
+            queues: if params.queue.is_empty() {
+                HashSet::new()
+            } else {
+                params.queue.0
+            },
+            types: if params.job_type.is_empty() {
+                HashSet::new()
+            } else {
+                params.job_type.0
+            },
+            priority: params.priority.0,
+            ready_at: params.ready_at.0,
+            payload_filter: filter,
         },
-        statuses: if params.status.is_empty() {
-            HashSet::new()
-        } else {
-            params
-                .status
-                .iter()
-                .map(|s| store::JobStatus::from(*s))
-                .collect()
-        },
-        queues: if params.queue.is_empty() {
-            HashSet::new()
-        } else {
-            params.queue.0
-        },
-        types: if params.job_type.is_empty() {
-            HashSet::new()
-        } else {
-            params.job_type.0
-        },
-        priority: params.priority.0,
-        ready_at: params.ready_at.0,
-        filter,
         patch,
     };
 
@@ -1433,7 +1435,7 @@ async fn list_jobs(
     opts = opts.ready_at(params.ready_at.0.clone());
     if let Some(ref expr) = params.filter {
         match PayloadFilter::compile(expr) {
-            Ok(f) => opts.filter = Some(std::sync::Arc::new(f)),
+            Ok(f) => opts.filter.payload_filter = Some(std::sync::Arc::new(f)),
             Err(e) => {
                 return respond(
                     fmt,
@@ -1638,7 +1640,7 @@ async fn count_jobs(
     opts = opts.ready_at(params.ready_at.0.clone());
     if let Some(ref expr) = params.filter {
         match PayloadFilter::compile(expr) {
-            Ok(f) => opts.filter = Some(std::sync::Arc::new(f)),
+            Ok(f) => opts.filter.payload_filter = Some(std::sync::Arc::new(f)),
             Err(e) => {
                 return respond(
                     fmt,

--- a/src/store/delete.rs
+++ b/src/store/delete.rs
@@ -10,7 +10,6 @@
 //!   events so workers can release capacity for in-flight jobs deleted
 //!   out from under them.
 
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use tokio::task;
@@ -20,7 +19,7 @@ use super::keys::{
     make_type_key, make_unique_key,
 };
 use super::options::BulkDeleteOptions;
-use super::scan::{JobStream, PayloadFilteredIter, RangeFilteredIter, build_id_stream};
+use super::scan::{JobStream, apply_filters, build_id_stream, filter_needs_payload};
 use super::store::{Keyspaces, Store, StoreEvent};
 use super::types::{Job, JobStatus, ScanDirection, StoreError};
 
@@ -117,60 +116,34 @@ impl Store {
             let mut tx = ks.write_tx();
             let snapshot = ks.db.read_tx();
 
-            let has_payload_filter = opts.filter.is_some();
+            let needs_payload = filter_needs_payload(&opts.filter);
 
             // Build the job stream: filtered by indexes, or full scan.
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if let Some((id_stream, source, _)) = build_id_stream(
-                    &snapshot,
-                    &ks,
-                    &opts.ids,
-                    &opts.statuses,
-                    &opts.queues,
-                    &opts.types,
-                    &None,
-                    ScanDirection::Asc,
-                ) {
-                    let stream = JobStream::by_id(
-                        id_stream,
-                        &snapshot,
-                        &ks.data,
-                        None,               // no expiry filtering for deletion
-                        has_payload_filter, // only hydrate if filter needs it
-                        source,
-                    );
-                    Box::new(stream) as Box<dyn Iterator<Item = Result<Job, StoreError>> + '_>
-                } else {
-                    let stream = JobStream::full_scan(
-                        &snapshot,
-                        &ks,
-                        &None,
-                        ScanDirection::Asc,
-                        None,
-                        has_payload_filter,
-                    );
-                    Box::new(stream) as Box<dyn Iterator<Item = Result<Job, StoreError>> + '_>
-                };
-
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if opts.priority.is_some() || opts.ready_at.is_some() {
-                    Box::new(RangeFilteredIter {
-                        inner: jobs,
-                        priority: opts.priority.clone(),
-                        ready_at: opts.ready_at.clone(),
-                    })
-                } else {
-                    jobs
-                };
-
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if let Some(ref filter) = opts.filter {
-                    Box::new(PayloadFilteredIter {
-                        inner: jobs,
-                        filter: Arc::clone(filter),
-                    })
-                } else {
-                    jobs
+            // Then apply range and payload filters as post-hydration checks.
+            let jobs =
+                match build_id_stream(&snapshot, &ks, &opts.filter, &None, ScanDirection::Asc) {
+                    Some((id_stream, source, _)) => apply_filters(
+                        JobStream::by_id(
+                            id_stream,
+                            &snapshot,
+                            &ks.data,
+                            None, // no expiry filtering for deletion
+                            needs_payload,
+                            source,
+                        ),
+                        &opts.filter,
+                    ),
+                    None => apply_filters(
+                        JobStream::full_scan(
+                            &snapshot,
+                            &ks,
+                            &None,
+                            ScanDirection::Asc,
+                            None,
+                            needs_payload,
+                        ),
+                        &opts.filter,
+                    ),
                 };
 
             // Track deleted jobs for post-commit cleanup.
@@ -538,7 +511,7 @@ mod tests {
         store.mark_completed(now, &taken.id).await.unwrap();
 
         let mut opts = BulkDeleteOptions::new();
-        opts.statuses = [JobStatus::Ready].into();
+        opts.filter.statuses = [JobStatus::Ready].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 2);
 
@@ -579,7 +552,7 @@ mod tests {
             .unwrap();
 
         let mut opts = BulkDeleteOptions::new();
-        opts.queues = ["delete_me".into()].into();
+        opts.filter.queues = ["delete_me".into()].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 2);
 
@@ -613,7 +586,7 @@ mod tests {
             .into_job();
 
         let mut opts = BulkDeleteOptions::new();
-        opts.ids = [j1.id.clone(), j3.id.clone()].into();
+        opts.filter.ids = [j1.id.clone(), j3.id.clone()].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 2);
 
@@ -653,7 +626,7 @@ mod tests {
             .unwrap();
 
         let mut opts = BulkDeleteOptions::new();
-        opts.filter = Some(Arc::new(PayloadFilter::compile(".x > 1").unwrap()));
+        opts.filter.payload_filter = Some(Arc::new(PayloadFilter::compile(".x > 1").unwrap()));
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 2);
 
@@ -716,8 +689,8 @@ mod tests {
 
         // Delete ready jobs in queue "a" only.
         let mut opts = BulkDeleteOptions::new();
-        opts.queues = ["a".into()].into();
-        opts.statuses = [JobStatus::Ready].into();
+        opts.filter.queues = ["a".into()].into();
+        opts.filter.statuses = [JobStatus::Ready].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 1);
 
@@ -760,7 +733,7 @@ mod tests {
     async fn delete_jobs_returns_zero_for_no_matches() {
         let store = test_store();
         let mut opts = BulkDeleteOptions::new();
-        opts.queues = ["nonexistent".into()].into();
+        opts.filter.queues = ["nonexistent".into()].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 0);
     }
@@ -777,7 +750,7 @@ mod tests {
             .into_job();
 
         let mut opts = BulkDeleteOptions::new();
-        opts.ids = [j1.id, "0000000000000000000000000".into()].into();
+        opts.filter.ids = [j1.id, "0000000000000000000000000".into()].into();
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 1);
     }
@@ -841,7 +814,7 @@ mod tests {
         }
 
         let mut opts = BulkDeleteOptions::new();
-        opts.priority = Some(5..=100);
+        opts.filter.priority = Some(5..=100);
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 2);
 
@@ -883,8 +856,8 @@ mod tests {
             .unwrap();
 
         let mut opts = BulkDeleteOptions::new();
-        opts.queues = ["a".into()].into();
-        opts.ready_at = Some((now + 5_000)..=(now + 20_000));
+        opts.filter.queues = ["a".into()].into();
+        opts.filter.ready_at = Some((now + 5_000)..=(now + 20_000));
         let count = store.delete_jobs(opts).await.unwrap();
         assert_eq!(count, 1);
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -29,7 +29,7 @@ mod test_support;
 
 pub use options::{
     BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
-    ListErrorsOptions, ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
+    JobFilter, ListErrorsOptions, ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
     RetentionConfigPatch,
 };
 

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -16,38 +16,32 @@ use crate::filter::PayloadFilter;
 
 use super::types::{BackoffConfig, JobStatus, RetentionConfig, ScanDirection, UniqueWhile};
 
-/// Options for listing jobs with cursor-based pagination in `Store::list_jobs`.
-#[derive(Debug, Clone)]
-pub struct ListJobsOptions {
-    /// Cursor: start after this job ID (exclusive). `None` means start from
-    /// the beginning (asc) or end (desc).
-    pub from: Option<String>,
-
-    /// Scan direction.
-    pub direction: ScanDirection,
-
-    /// Maximum number of jobs to return.
-    pub limit: usize,
-
+/// Predicate that selects which jobs an operation acts on.
+///
+/// Every store operation that narrows a job set (list, count, bulk delete,
+/// bulk patch) accepts a `JobFilter`. Adding a new way to match jobs means
+/// adding one field here — the scan machinery, the iterator chain, and
+/// every operation that takes a filter pick it up automatically. This
+/// also makes the API hard to use wrong: a new filter is impossible to
+/// "forget to add" to an endpoint, because there is no per-endpoint copy.
+///
+/// All fields are `AND`-ed together. Set-shaped fields (`ids`, `statuses`,
+/// etc.) treat an empty set as "match anything"; range fields treat
+/// `None` the same way.
+#[derive(Debug, Default, Clone)]
+pub struct JobFilter {
     /// Optional ID filter. When non-empty, only jobs with one of these
     /// IDs are returned. Intersected with other filters when combined.
     pub ids: HashSet<String>,
 
-    /// Optional status filter. When non-empty, only jobs with one of these
-    /// statuses are returned, using the status index for efficient lookup.
+    /// Optional status filter, served by the status index.
     pub statuses: HashSet<JobStatus>,
 
-    /// Optional queue filter. When non-empty, only jobs belonging to one of
-    /// these queues are returned, using the queue index.
+    /// Optional queue filter, served by the queue index.
     pub queues: HashSet<String>,
 
-    /// Optional type filter. When non-empty, only jobs with one of these
-    /// types are returned, using the type index.
+    /// Optional type filter, served by the type index.
     pub types: HashSet<String>,
-
-    /// Current time for filtering out expired jobs (purge_at <= now).
-    /// When `Some`, jobs past their purge_at are skipped.
-    pub now: Option<u64>,
 
     /// Optional priority range filter (inclusive on both ends).
     /// Applied as a post-hydration check on each candidate job.
@@ -61,9 +55,79 @@ pub struct ListJobsOptions {
     /// payload matches the filter are returned. Payloads are hydrated and
     /// checked after the index scan narrows the candidate set.
     ///
-    /// Wrapped in `Arc` because `ListJobsOptions` must be `Clone` for
+    /// Wrapped in `Arc` because options structs must be `Clone` for
     /// pagination, but `PayloadFilter` contains compiled state.
-    pub filter: Option<Arc<PayloadFilter>>,
+    pub payload_filter: Option<Arc<PayloadFilter>>,
+}
+
+impl JobFilter {
+    /// Create an empty filter (matches every job).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by job IDs and return `self`.
+    pub fn ids(mut self, ids: HashSet<String>) -> Self {
+        self.ids = ids;
+        self
+    }
+
+    /// Filter by job status and return `self`.
+    pub fn statuses(mut self, statuses: HashSet<JobStatus>) -> Self {
+        self.statuses = statuses;
+        self
+    }
+
+    /// Filter by queue membership and return `self`.
+    pub fn queues(mut self, queues: HashSet<String>) -> Self {
+        self.queues = queues;
+        self
+    }
+
+    /// Filter by job type and return `self`.
+    pub fn types(mut self, types: HashSet<String>) -> Self {
+        self.types = types;
+        self
+    }
+
+    /// Filter by priority range (inclusive) and return `self`.
+    pub fn priority(mut self, range: impl Into<Option<RangeInclusive<u16>>>) -> Self {
+        self.priority = range.into();
+        self
+    }
+
+    /// Filter by `ready_at` range (inclusive, ms since epoch) and return `self`.
+    pub fn ready_at(mut self, range: impl Into<Option<RangeInclusive<u64>>>) -> Self {
+        self.ready_at = range.into();
+        self
+    }
+
+    /// Set the jq payload filter and return `self`.
+    pub fn payload_filter(mut self, filter: impl Into<Option<Arc<PayloadFilter>>>) -> Self {
+        self.payload_filter = filter.into();
+        self
+    }
+}
+
+/// Options for listing jobs with cursor-based pagination in `Store::list_jobs`.
+#[derive(Debug, Clone)]
+pub struct ListJobsOptions {
+    /// Cursor: start after this job ID (exclusive). `None` means start from
+    /// the beginning (asc) or end (desc).
+    pub from: Option<String>,
+
+    /// Scan direction.
+    pub direction: ScanDirection,
+
+    /// Maximum number of jobs to return.
+    pub limit: usize,
+
+    /// Current time for filtering out expired jobs (purge_at <= now).
+    /// When `Some`, jobs past their purge_at are skipped.
+    pub now: Option<u64>,
+
+    /// Predicate selecting which jobs are returned.
+    pub filter: JobFilter,
 }
 
 impl ListJobsOptions {
@@ -73,14 +137,8 @@ impl ListJobsOptions {
             from: None,
             direction: ScanDirection::Asc,
             limit: 50,
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: HashSet::new(),
-            types: HashSet::new(),
             now: None,
-            priority: None,
-            ready_at: None,
-            filter: None,
+            filter: JobFilter::new(),
         }
     }
 
@@ -102,128 +160,81 @@ impl ListJobsOptions {
         self
     }
 
-    /// Filter by job IDs and return `self`.
-    ///
-    /// An empty set means "all jobs". When combined with other filters,
-    /// the result is the intersection.
-    pub fn ids(mut self, ids: HashSet<String>) -> Self {
-        self.ids = ids;
-        self
-    }
-
-    /// Filter by job status and return `self`.
-    ///
-    /// An empty set means "all statuses".
-    pub fn statuses(mut self, statuses: HashSet<JobStatus>) -> Self {
-        self.statuses = statuses;
-        self
-    }
-
-    /// Filter by queue membership and return `self`.
-    ///
-    /// An empty set means "all queues".
-    pub fn queues(mut self, queues: HashSet<String>) -> Self {
-        self.queues = queues;
-        self
-    }
-
-    /// Filter by job type and return `self`.
-    ///
-    /// An empty set means "all types".
-    pub fn types(mut self, types: HashSet<String>) -> Self {
-        self.types = types;
-        self
-    }
-
     /// Set the current time for filtering expired jobs and return `self`.
     pub fn now(mut self, now: impl Into<Option<u64>>) -> Self {
         self.now = now.into();
         self
     }
 
+    /// Set the underlying job filter and return `self`.
+    pub fn filter(mut self, filter: JobFilter) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    // --- Delegating builders for the inner JobFilter ---
+
+    /// Filter by job IDs and return `self`.
+    pub fn ids(mut self, ids: HashSet<String>) -> Self {
+        self.filter.ids = ids;
+        self
+    }
+
+    /// Filter by job status and return `self`.
+    pub fn statuses(mut self, statuses: HashSet<JobStatus>) -> Self {
+        self.filter.statuses = statuses;
+        self
+    }
+
+    /// Filter by queue membership and return `self`.
+    pub fn queues(mut self, queues: HashSet<String>) -> Self {
+        self.filter.queues = queues;
+        self
+    }
+
+    /// Filter by job type and return `self`.
+    pub fn types(mut self, types: HashSet<String>) -> Self {
+        self.filter.types = types;
+        self
+    }
+
     /// Filter by priority range (inclusive) and return `self`.
     pub fn priority(mut self, range: impl Into<Option<RangeInclusive<u16>>>) -> Self {
-        self.priority = range.into();
+        self.filter.priority = range.into();
         self
     }
 
-    /// Filter by `ready_at` range (inclusive, ms since epoch) and return `self`.
+    /// Filter by `ready_at` range (inclusive) and return `self`.
     pub fn ready_at(mut self, range: impl Into<Option<RangeInclusive<u64>>>) -> Self {
-        self.ready_at = range.into();
+        self.filter.ready_at = range.into();
         self
     }
 
-    /// Set the payload filter and return `self`.
-    pub fn filter(mut self, filter: impl Into<Option<Arc<PayloadFilter>>>) -> Self {
-        self.filter = filter.into();
+    /// Set the jq payload filter and return `self`.
+    pub fn payload_filter(mut self, filter: impl Into<Option<Arc<PayloadFilter>>>) -> Self {
+        self.filter.payload_filter = filter.into();
         self
     }
 }
 
 /// Options for bulk-deleting jobs in `Store::delete_jobs`.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BulkDeleteOptions {
-    /// Optional ID filter. When non-empty, only these IDs are candidates.
-    pub ids: HashSet<String>,
-
-    /// Optional status filter.
-    pub statuses: HashSet<JobStatus>,
-
-    /// Optional queue filter.
-    pub queues: HashSet<String>,
-
-    /// Optional type filter.
-    pub types: HashSet<String>,
-
-    /// Optional priority range (inclusive on both ends).
-    pub priority: Option<RangeInclusive<u16>>,
-
-    /// Optional `ready_at` range (inclusive on both ends, ms since epoch).
-    pub ready_at: Option<RangeInclusive<u64>>,
-
-    /// Optional jq payload filter.
-    pub filter: Option<Arc<PayloadFilter>>,
+    /// Predicate selecting which jobs are deleted.
+    pub filter: JobFilter,
 }
 
 impl BulkDeleteOptions {
     pub fn new() -> Self {
-        Self {
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: HashSet::new(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: None,
-            filter: None,
-        }
+        Self::default()
     }
 }
 
 /// Options for bulk-patching jobs matching a set of filters.
-///
-/// Combines the same filter fields as `BulkDeleteOptions` with the
-/// patch fields from `PatchJobOptions`.
+#[derive(Debug, Default)]
 pub struct BulkPatchOptions {
-    /// Optional ID filter. When non-empty, only these IDs are candidates.
-    pub ids: HashSet<String>,
-
-    /// Optional status filter.
-    pub statuses: HashSet<JobStatus>,
-
-    /// Optional queue filter.
-    pub queues: HashSet<String>,
-
-    /// Optional type filter.
-    pub types: HashSet<String>,
-
-    /// Optional priority range (inclusive on both ends).
-    pub priority: Option<RangeInclusive<u16>>,
-
-    /// Optional `ready_at` range (inclusive on both ends, ms since epoch).
-    pub ready_at: Option<RangeInclusive<u64>>,
-
-    /// Optional jq payload filter.
-    pub filter: Option<Arc<PayloadFilter>>,
+    /// Predicate selecting which jobs are patched.
+    pub filter: JobFilter,
 
     /// The patch to apply to each matching job.
     pub patch: PatchJobOptions,

--- a/src/store/patch.rs
+++ b/src/store/patch.rs
@@ -18,7 +18,7 @@ use tokio::task;
 use super::keys::{make_job_key, make_queue_key, make_status_key};
 use super::options::{BulkPatchOptions, PatchJobOptions};
 use super::ready_index::ReadyIndex;
-use super::scan::{JobStream, PayloadFilteredIter, RangeFilteredIter, build_id_stream};
+use super::scan::{JobStream, apply_filters, build_id_stream, filter_needs_payload};
 use super::scheduled_index::ScheduledIndex;
 use super::store::{Keyspaces, Store, StoreEvent};
 use super::types::{Job, JobStatus, ScanDirection, StoreError};
@@ -315,58 +315,33 @@ impl Store {
             let mut tx = ks.write_tx();
             let snapshot = ks.db.read_tx();
 
-            let has_payload_filter = opts.filter.is_some();
+            let needs_payload = filter_needs_payload(&opts.filter);
             let now = crate::time::now_millis();
 
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if let Some((id_stream, source, _)) = build_id_stream(
-                    &snapshot,
-                    &ks,
-                    &opts.ids,
-                    &opts.statuses,
-                    &opts.queues,
-                    &opts.types,
-                    &None,
-                    ScanDirection::Asc,
-                ) {
-                    Box::new(JobStream::by_id(
-                        id_stream,
-                        &snapshot,
-                        &ks.data,
-                        None,
-                        has_payload_filter,
-                        source,
-                    ))
-                } else {
-                    Box::new(JobStream::full_scan(
-                        &snapshot,
-                        &ks,
-                        &None,
-                        ScanDirection::Asc,
-                        None,
-                        has_payload_filter,
-                    ))
-                };
-
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if opts.priority.is_some() || opts.ready_at.is_some() {
-                    Box::new(RangeFilteredIter {
-                        inner: jobs,
-                        priority: opts.priority.clone(),
-                        ready_at: opts.ready_at.clone(),
-                    })
-                } else {
-                    jobs
-                };
-
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if let Some(ref filter) = opts.filter {
-                    Box::new(PayloadFilteredIter {
-                        inner: jobs,
-                        filter: Arc::clone(filter),
-                    })
-                } else {
-                    jobs
+            let jobs =
+                match build_id_stream(&snapshot, &ks, &opts.filter, &None, ScanDirection::Asc) {
+                    Some((id_stream, source, _)) => apply_filters(
+                        JobStream::by_id(
+                            id_stream,
+                            &snapshot,
+                            &ks.data,
+                            None,
+                            needs_payload,
+                            source,
+                        ),
+                        &opts.filter,
+                    ),
+                    None => apply_filters(
+                        JobStream::full_scan(
+                            &snapshot,
+                            &ks,
+                            &None,
+                            ScanDirection::Asc,
+                            None,
+                            needs_payload,
+                        ),
+                        &opts.filter,
+                    ),
                 };
 
             let mut diffs: Vec<PatchDiff> = Vec::new();
@@ -428,7 +403,8 @@ mod tests {
     use std::collections::HashSet;
 
     use super::super::options::{
-        BulkPatchOptions, EnqueueOptions, ListJobsOptions, PatchJobOptions, RetentionConfigPatch,
+        BulkPatchOptions, EnqueueOptions, JobFilter, ListJobsOptions, PatchJobOptions,
+        RetentionConfigPatch,
     };
     use super::super::store::StoreEvent;
     use super::super::test_support::{test_store, test_store_with_retention};
@@ -1217,13 +1193,10 @@ mod tests {
         }
 
         let opts = BulkPatchOptions {
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: ["q1".into()].into(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: None,
-            filter: None,
+            filter: JobFilter {
+                queues: ["q1".into()].into(),
+                ..Default::default()
+            },
             patch: PatchJobOptions {
                 queue: Some("q2".into()),
                 ..Default::default()
@@ -1260,13 +1233,10 @@ mod tests {
         store.mark_completed(now, &job.id).await.unwrap();
 
         let opts = BulkPatchOptions {
-            ids: [job.id.clone()].into(),
-            statuses: HashSet::new(),
-            queues: HashSet::new(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: None,
-            filter: None,
+            filter: JobFilter {
+                ids: [job.id.clone()].into(),
+                ..Default::default()
+            },
             patch: PatchJobOptions {
                 priority: Some(99),
                 ..Default::default()
@@ -1293,13 +1263,7 @@ mod tests {
 
         // Patch them all to scheduled.
         let opts = BulkPatchOptions {
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: HashSet::new(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: None,
-            filter: None,
+            filter: JobFilter::default(),
             patch: PatchJobOptions {
                 ready_at: Some(Some(future)),
                 ..Default::default()
@@ -1337,13 +1301,10 @@ mod tests {
 
         // Only patch job_a.
         let opts = BulkPatchOptions {
-            ids: [job_a.id.clone()].into(),
-            statuses: HashSet::new(),
-            queues: HashSet::new(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: None,
-            filter: None,
+            filter: JobFilter {
+                ids: [job_a.id.clone()].into(),
+                ..Default::default()
+            },
             patch: PatchJobOptions {
                 priority: Some(99),
                 ..Default::default()
@@ -1362,13 +1323,10 @@ mod tests {
         let store = test_store();
 
         let opts = BulkPatchOptions {
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: ["nonexistent".into()].into(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: None,
-            filter: None,
+            filter: JobFilter {
+                queues: ["nonexistent".into()].into(),
+                ..Default::default()
+            },
             patch: PatchJobOptions {
                 priority: Some(99),
                 ..Default::default()
@@ -1395,13 +1353,10 @@ mod tests {
         }
 
         let opts = BulkPatchOptions {
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: HashSet::new(),
-            types: HashSet::new(),
-            priority: Some(5..=100),
-            ready_at: None,
-            filter: None,
+            filter: JobFilter {
+                priority: Some(5..=100),
+                ..Default::default()
+            },
             patch: PatchJobOptions {
                 priority: Some(7),
                 ..Default::default()
@@ -1447,13 +1402,11 @@ mod tests {
             .into_job();
 
         let opts = BulkPatchOptions {
-            ids: HashSet::new(),
-            statuses: HashSet::new(),
-            queues: ["a".into()].into(),
-            types: HashSet::new(),
-            priority: None,
-            ready_at: Some((now + 5_000)..=(now + 20_000)),
-            filter: None,
+            filter: JobFilter {
+                queues: ["a".into()].into(),
+                ready_at: Some((now + 5_000)..=(now + 20_000)),
+                ..Default::default()
+            },
             patch: PatchJobOptions {
                 priority: Some(42),
                 ..Default::default()

--- a/src/store/read.rs
+++ b/src/store/read.rs
@@ -18,7 +18,7 @@ use tokio::task;
 use super::keys::{IndexKind, RecordKind, make_error_key, make_job_key, make_payload_key};
 use super::options::{ListErrorsOptions, ListJobsOptions};
 use super::results::{ListErrorsPage, ListJobsPage};
-use super::scan::{JobStream, PayloadFilteredIter, RangeFilteredIter, build_id_stream};
+use super::scan::{JobStream, apply_filters, build_id_stream, filter_needs_payload};
 use super::store::Store;
 use super::types::{ErrorRecord, Job, ScanDirection, StoreError};
 
@@ -67,16 +67,8 @@ impl Store {
             let snapshot = ks.db.read_tx();
             let fetch = opts.limit.saturating_add(1);
 
-            let id_stream_opt = build_id_stream(
-                &snapshot,
-                &ks,
-                &opts.ids,
-                &opts.statuses,
-                &opts.queues,
-                &opts.types,
-                &opts.from,
-                opts.direction,
-            );
+            let id_stream_opt =
+                build_id_stream(&snapshot, &ks, &opts.filter, &opts.from, opts.direction);
 
             let job_stream = match id_stream_opt {
                 Some((ids, source, _has_id_filter)) => {
@@ -87,27 +79,7 @@ impl Store {
                 }
             };
 
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if opts.priority.is_some() || opts.ready_at.is_some() {
-                    Box::new(RangeFilteredIter {
-                        inner: job_stream,
-                        priority: opts.priority.clone(),
-                        ready_at: opts.ready_at.clone(),
-                    })
-                } else {
-                    Box::new(job_stream)
-                };
-
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if let Some(filter) = opts.filter.clone() {
-                    Box::new(PayloadFilteredIter {
-                        inner: jobs,
-                        filter,
-                    })
-                } else {
-                    jobs
-                };
-
+            let jobs = apply_filters(job_stream, &opts.filter);
             let mut rows: Vec<Job> = jobs.take(fetch).collect::<Result<Vec<_>, _>>()?;
 
             // If we got more rows than the requested limit, we know there's a
@@ -123,13 +95,7 @@ impl Store {
                     .from(cursor.to_string())
                     .direction(direction)
                     .limit(opts.limit)
-                    .ids(opts.ids.clone())
-                    .statuses(opts.statuses.clone())
-                    .queues(opts.queues.clone())
-                    .types(opts.types.clone())
                     .now(opts.now)
-                    .priority(opts.priority.clone())
-                    .ready_at(opts.ready_at.clone())
                     .filter(opts.filter.clone())
             };
 
@@ -173,15 +139,12 @@ impl Store {
             let id_stream_opt = build_id_stream(
                 &snapshot,
                 &ks,
-                &opts.ids,
-                &opts.statuses,
-                &opts.queues,
-                &opts.types,
+                &opts.filter,
                 &None,              // no cursor for count
                 ScanDirection::Asc, // direction doesn't matter for count
             );
 
-            let needs_payload = opts.filter.is_some();
+            let needs_payload = filter_needs_payload(&opts.filter);
 
             let job_stream = match id_stream_opt {
                 Some((ids, source, _has_id_filter)) => {
@@ -197,28 +160,8 @@ impl Store {
                 ),
             };
 
-            let jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if opts.priority.is_some() || opts.ready_at.is_some() {
-                    Box::new(RangeFilteredIter {
-                        inner: job_stream,
-                        priority: opts.priority.clone(),
-                        ready_at: opts.ready_at.clone(),
-                    })
-                } else {
-                    Box::new(job_stream)
-                };
-
-            let mut jobs: Box<dyn Iterator<Item = Result<Job, StoreError>> + '_> =
-                if let Some(filter) = opts.filter.clone() {
-                    Box::new(PayloadFilteredIter {
-                        inner: jobs,
-                        filter,
-                    })
-                } else {
-                    jobs
-                };
-
-            let count = jobs.try_fold(0, |acc, r| r.map(|_| acc + 1))?;
+            let count =
+                apply_filters(job_stream, &opts.filter).try_fold(0, |acc, r| r.map(|_| acc + 1))?;
 
             Ok(count)
         })
@@ -1855,8 +1798,8 @@ mod tests {
 
         // Follow next — should preserve both queue and status filters.
         let next = page.next.unwrap();
-        assert!(!next.queues.is_empty());
-        assert!(!next.statuses.is_empty());
+        assert!(!next.filter.queues.is_empty());
+        assert!(!next.filter.statuses.is_empty());
 
         let page2 = store.list_jobs(next).await.unwrap();
         assert_eq!(page2.jobs.len(), 1);
@@ -2944,7 +2887,11 @@ mod tests {
 
         let filter = crate::filter::PayloadFilter::compile(".score > 20").unwrap();
         let count = store
-            .count_jobs(ListJobsOptions::new().now(now).filter(Arc::new(filter)))
+            .count_jobs(
+                ListJobsOptions::new()
+                    .now(now)
+                    .payload_filter(Arc::new(filter)),
+            )
             .await
             .unwrap();
         assert_eq!(count, 2);
@@ -3109,7 +3056,12 @@ mod tests {
         let ids: HashSet<String> = [j1.id.clone(), j2.id.clone()].into();
         let filter = Arc::new(PayloadFilter::compile(".x == 1").unwrap());
         let page = store
-            .list_jobs(ListJobsOptions::new().ids(ids).filter(filter).now(now))
+            .list_jobs(
+                ListJobsOptions::new()
+                    .ids(ids)
+                    .payload_filter(filter)
+                    .now(now),
+            )
             .await
             .unwrap();
 
@@ -3137,7 +3089,12 @@ mod tests {
         .into();
         let filter = Arc::new(PayloadFilter::compile(".").unwrap());
         let page = store
-            .list_jobs(ListJobsOptions::new().ids(ids).filter(filter).now(now))
+            .list_jobs(
+                ListJobsOptions::new()
+                    .ids(ids)
+                    .payload_filter(filter)
+                    .now(now),
+            )
             .await
             .unwrap();
 
@@ -3346,7 +3303,11 @@ mod tests {
 
         let filter = Arc::new(PayloadFilter::compile(".u == 1").unwrap());
         let page = store
-            .list_jobs(ListJobsOptions::new().priority(40..=100).filter(filter))
+            .list_jobs(
+                ListJobsOptions::new()
+                    .priority(40..=100)
+                    .payload_filter(filter),
+            )
             .await
             .unwrap();
 

--- a/src/store/scan.rs
+++ b/src/store/scan.rs
@@ -34,6 +34,7 @@ use super::keys::{
     IndexKind, RecordKind, make_job_key, make_payload_key, make_queue_key, make_status_key,
     make_type_key,
 };
+use super::options::JobFilter;
 use super::store::Keyspaces;
 use super::types::{Job, JobStatus, ScanDirection, StoreError};
 
@@ -712,57 +713,57 @@ impl<I: Iterator<Item = Result<Job, StoreError>>> Iterator for PayloadFilteredIt
     }
 }
 
-/// Build an `IdStream` from index filters and/or ID filters.
+/// Build an `IdStream` from a `JobFilter`'s index-backed fields.
 ///
-/// Returns `None` when no index filters are active (caller should use a
-/// full-scan `JobStream` instead). Returns `Some((stream, source, has_ids))`
-/// when at least one filter is active.
+/// Returns `None` when no index-backed filter is active (caller should use
+/// a full-scan `JobStream` instead). Returns `Some((stream, source,
+/// has_ids))` when at least one filter is active.
+///
+/// Range and payload fields are NOT consulted here — they are applied as
+/// post-hydration filters by [`apply_filters`].
 pub(super) fn build_id_stream<'a>(
     snapshot: &'a impl Readable,
     ks: &'a Keyspaces,
-    ids: &HashSet<String>,
-    statuses: &HashSet<JobStatus>,
-    queues: &HashSet<String>,
-    types: &HashSet<String>,
+    filter: &JobFilter,
     from: &Option<String>,
     direction: ScanDirection,
 ) -> Option<(IdStream<'a>, String, bool)> {
     let mut filters: Vec<(&str, IdStream<'a>)> = Vec::new();
 
-    if !queues.is_empty() {
+    if !filter.queues.is_empty() {
         filters.push((
             "jobs_by_queue",
             merge_sources(
-                queue_scan_sources(snapshot, ks, queues, from, direction),
+                queue_scan_sources(snapshot, ks, &filter.queues, from, direction),
                 direction,
             ),
         ));
     }
 
-    if !statuses.is_empty() {
+    if !filter.statuses.is_empty() {
         filters.push((
             "jobs_by_status",
             merge_sources(
-                status_scan_sources(snapshot, ks, statuses, from, direction),
+                status_scan_sources(snapshot, ks, &filter.statuses, from, direction),
                 direction,
             ),
         ));
     }
 
-    if !types.is_empty() {
+    if !filter.types.is_empty() {
         filters.push((
             "jobs_by_type",
             merge_sources(
-                type_scan_sources(snapshot, ks, types, from, direction),
+                type_scan_sources(snapshot, ks, &filter.types, from, direction),
                 direction,
             ),
         ));
     }
 
-    let has_id_filter = !ids.is_empty();
+    let has_id_filter = !filter.ids.is_empty();
 
     if has_id_filter {
-        filters.push(("jobs_by_id", id_stream(ids, from, direction)));
+        filters.push(("jobs_by_id", id_stream(&filter.ids, from, direction)));
     }
 
     if filters.is_empty() {
@@ -781,4 +782,43 @@ pub(super) fn build_id_stream<'a>(
     let combined = iter.fold(first, |acc, s| intersect_streams(acc, s, direction));
 
     Some((combined, source_desc, has_id_filter))
+}
+
+/// Wrap a `JobStream` with the post-hydration filters from a `JobFilter`
+/// (range, then payload) and return as a boxed iterator.
+///
+/// Range checks are O(1) integer comparisons, so they run first to
+/// short-circuit the more expensive jq payload evaluation. Range checks
+/// don't need a hydrated payload — only the payload filter does.
+pub(super) fn apply_filters<'a, R: Readable + 'a>(
+    inner: JobStream<'a, R>,
+    filter: &JobFilter,
+) -> Box<dyn Iterator<Item = Result<Job, StoreError>> + 'a> {
+    let stream: Box<dyn Iterator<Item = Result<Job, StoreError>> + 'a> =
+        if filter.priority.is_some() || filter.ready_at.is_some() {
+            Box::new(RangeFilteredIter {
+                inner,
+                priority: filter.priority.clone(),
+                ready_at: filter.ready_at.clone(),
+            })
+        } else {
+            Box::new(inner)
+        };
+
+    if let Some(payload_filter) = &filter.payload_filter {
+        Box::new(PayloadFilteredIter {
+            inner: stream,
+            filter: Arc::clone(payload_filter),
+        })
+    } else {
+        stream
+    }
+}
+
+/// Does `filter` need each candidate job's payload hydrated?
+///
+/// Range filters operate on top-level `Job` fields, so they don't require
+/// payload hydration. Only a jq payload filter does.
+pub(super) fn filter_needs_payload(filter: &JobFilter) -> bool {
+    filter.payload_filter.is_some()
 }

--- a/src/store/take.rs
+++ b/src/store/take.rs
@@ -1035,7 +1035,7 @@ mod tests {
             .unwrap();
 
         let mut delete_opts = BulkDeleteOptions::new();
-        delete_opts.queues = ["myqueue".to_string()].into();
+        delete_opts.filter.queues = ["myqueue".to_string()].into();
         let deleted = store.delete_jobs(delete_opts).await.unwrap();
         assert_eq!(deleted, 1);
 


### PR DESCRIPTION
All endpoints that deal with collections of jobs (list, count, delete, patch) take the same scan/filtering options, but previously they all just duplicated those options which triggers many callsite changes when adding new options. This extract those common "filter" parameters into a shared `JobFilter` struct to avoid all that repetition.