### PR TITLE
Support filtering jobs by number of attempts.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -1167,6 +1167,7 @@ async fn bulk_delete_jobs(
     }
     opts.filter.priority = params.priority.0;
     opts.filter.ready_at = params.ready_at.0;
+    opts.filter.attempts = params.attempts.0;
     opts.filter.payload_filter = filter;
 
     match state.store.delete_jobs(opts).await {
@@ -1338,6 +1339,7 @@ async fn bulk_patch_jobs(
             },
             priority: params.priority.0,
             ready_at: params.ready_at.0,
+            attempts: params.attempts.0,
             payload_filter: filter,
         },
         patch,
@@ -1433,6 +1435,7 @@ async fn list_jobs(
     }
     opts = opts.priority(params.priority.0.clone());
     opts = opts.ready_at(params.ready_at.0.clone());
+    opts = opts.attempts(params.attempts.0.clone());
     if let Some(ref expr) = params.filter {
         match PayloadFilter::compile(expr) {
             Ok(f) => opts.filter.payload_filter = Some(std::sync::Arc::new(f)),
@@ -1461,6 +1464,7 @@ async fn list_jobs(
                 &params.id,
                 &params.priority,
                 &params.ready_at,
+                &params.attempts,
                 filter_expr,
             );
             let next = page.next.map(|o| {
@@ -1474,6 +1478,7 @@ async fn list_jobs(
                     &params.id,
                     &params.priority,
                     &params.ready_at,
+                    &params.attempts,
                     filter_expr,
                 )
             });
@@ -1488,6 +1493,7 @@ async fn list_jobs(
                     &params.id,
                     &params.priority,
                     &params.ready_at,
+                    &params.attempts,
                     filter_expr,
                 )
             });
@@ -1543,6 +1549,7 @@ fn build_page_url(
     ids: &CommaSet<String>,
     priority: &RangeQuery<u16>,
     ready_at: &RangeQuery<u64>,
+    attempts: &RangeQuery<u32>,
     filter: Option<&str>,
 ) -> String {
     let mut url = String::from("/jobs?");
@@ -1568,6 +1575,9 @@ fn build_page_url(
     }
     if !ready_at.is_empty() {
         url.push_str(&format!("&ready_at={ready_at}"));
+    }
+    if !attempts.is_empty() {
+        url.push_str(&format!("&attempts={attempts}"));
     }
     if let Some(expr) = filter {
         url.push_str(&format!("&filter={}", urlencoding::encode(expr)));
@@ -1638,6 +1648,7 @@ async fn count_jobs(
     }
     opts = opts.priority(params.priority.0.clone());
     opts = opts.ready_at(params.ready_at.0.clone());
+    opts = opts.attempts(params.attempts.0.clone());
     if let Some(ref expr) = params.filter {
         match PayloadFilter::compile(expr) {
             Ok(f) => opts.filter.payload_filter = Some(std::sync::Arc::new(f)),
@@ -7619,6 +7630,57 @@ mod tests {
         assert_eq!(res.status(), StatusCode::OK);
         let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
         assert_eq!(body["count"], 3);
+    }
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_attempts_range() {
+        let (state, app) = test_state_and_app();
+        let now = crate::time::now_millis();
+
+        // Three jobs on separate queues so we can fail them selectively.
+        let mut ids: Vec<String> = Vec::new();
+        for q in ["a", "b", "c"] {
+            let id = state
+                .store
+                .enqueue(now, EnqueueOptions::new("t", q, serde_json::json!(null)))
+                .await
+                .unwrap()
+                .into_job()
+                .id;
+            ids.push(id);
+        }
+
+        // Fail queue "a" once → attempts=1.
+        let taken = state
+            .store
+            .take_next_job(now, &["a".into()].into())
+            .await
+            .unwrap()
+            .expect("ready job");
+        state
+            .store
+            .record_failure(
+                now,
+                &taken.id,
+                store::FailureOptions {
+                    message: "boom".into(),
+                    error_type: None,
+                    backtrace: None,
+                    retry_at: None,
+                    kill: false,
+                },
+            )
+            .await
+            .unwrap();
+
+        let req = empty_request("GET", "/jobs?attempts=1..");
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let jobs = body["jobs"].as_array().unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["attempts"], 1);
+        assert_eq!(jobs[0]["queue"], "a");
     }
 
     #[tokio::test]

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -168,6 +168,11 @@ impl QueryBounded for u16 {
     const MAX: Self = u16::MAX;
 }
 
+impl QueryBounded for u32 {
+    const MIN: Self = u32::MIN;
+    const MAX: Self = u32::MAX;
+}
+
 impl QueryBounded for u64 {
     const MIN: Self = u64::MIN;
     const MAX: Self = u64::MAX;
@@ -681,6 +686,10 @@ pub struct ListJobsParams {
     #[serde(default)]
     pub ready_at: RangeQuery<u64>,
 
+    /// `attempts` range (inclusive). Same syntax as `priority`.
+    #[serde(default)]
+    pub attempts: RangeQuery<u32>,
+
     /// jq expression to filter jobs by payload (e.g. ".user_id == 42").
     pub filter: Option<String>,
 }
@@ -712,6 +721,10 @@ pub struct CountJobsParams {
     /// `ready_at` range (inclusive, ms since epoch). Same syntax as `priority`.
     #[serde(default)]
     pub ready_at: RangeQuery<u64>,
+
+    /// `attempts` range (inclusive). Same syntax as `priority`.
+    #[serde(default)]
+    pub attempts: RangeQuery<u32>,
 
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
@@ -745,6 +758,10 @@ pub struct DeleteJobsParams {
     #[serde(default)]
     pub ready_at: RangeQuery<u64>,
 
+    /// `attempts` range (inclusive). Same syntax as `priority`.
+    #[serde(default)]
+    pub attempts: RangeQuery<u32>,
+
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
 }
@@ -776,6 +793,10 @@ pub struct PatchJobsParams {
     /// `ready_at` range (inclusive, ms since epoch). Same syntax as `priority`.
     #[serde(default)]
     pub ready_at: RangeQuery<u64>,
+
+    /// `attempts` range (inclusive). Same syntax as `priority`.
+    #[serde(default)]
+    pub attempts: RangeQuery<u32>,
 
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -51,6 +51,12 @@ pub struct JobFilter {
     /// epoch). Applied as a post-hydration check on each candidate job.
     pub ready_at: Option<RangeInclusive<u64>>,
 
+    /// Optional `attempts` range filter (inclusive on both ends). Counts
+    /// the number of failures so far — `0..=0` selects jobs that have
+    /// never failed, `1..` selects anything that has failed at least once.
+    /// Applied as a post-hydration check on each candidate job.
+    pub attempts: Option<RangeInclusive<u32>>,
+
     /// Optional jq-style payload filter. When provided, only jobs whose
     /// payload matches the filter are returned. Payloads are hydrated and
     /// checked after the index scan narrows the candidate set.
@@ -99,6 +105,12 @@ impl JobFilter {
     /// Filter by `ready_at` range (inclusive, ms since epoch) and return `self`.
     pub fn ready_at(mut self, range: impl Into<Option<RangeInclusive<u64>>>) -> Self {
         self.ready_at = range.into();
+        self
+    }
+
+    /// Filter by `attempts` range (inclusive) and return `self`.
+    pub fn attempts(mut self, range: impl Into<Option<RangeInclusive<u32>>>) -> Self {
+        self.attempts = range.into();
         self
     }
 
@@ -207,6 +219,12 @@ impl ListJobsOptions {
     /// Filter by `ready_at` range (inclusive) and return `self`.
     pub fn ready_at(mut self, range: impl Into<Option<RangeInclusive<u64>>>) -> Self {
         self.filter.ready_at = range.into();
+        self
+    }
+
+    /// Filter by `attempts` range (inclusive) and return `self`.
+    pub fn attempts(mut self, range: impl Into<Option<RangeInclusive<u32>>>) -> Self {
+        self.filter.attempts = range.into();
         self
     }
 

--- a/src/store/read.rs
+++ b/src/store/read.rs
@@ -3378,4 +3378,52 @@ mod tests {
             .unwrap();
         assert_eq!(count, 3);
     }
+
+    #[tokio::test]
+    async fn list_jobs_filters_by_attempts_range() {
+        use super::super::test_support::test_failure_opts;
+
+        let store = test_store();
+        let now = now_millis();
+
+        // Three jobs on separate queues so we can address each by queue.
+        let mut ids: Vec<String> = Vec::new();
+        for q in ["a", "b", "c"] {
+            let id = store
+                .enqueue(now, EnqueueOptions::new("t", q, serde_json::json!(null)))
+                .await
+                .unwrap()
+                .into_job()
+                .id;
+            ids.push(id);
+        }
+
+        // Take and fail "a" once → attempts=1. Leave "b" and "c" untouched.
+        let taken = store
+            .take_next_job(now, &["a".into()].into())
+            .await
+            .unwrap()
+            .expect("ready job");
+        store
+            .record_failure(now, &taken.id, test_failure_opts())
+            .await
+            .unwrap();
+
+        // attempts=1..=1 selects exactly the failed job.
+        let page = store
+            .list_jobs(ListJobsOptions::new().attempts(1..=1))
+            .await
+            .unwrap();
+        assert_eq!(page.jobs.len(), 1);
+        assert_eq!(page.jobs[0].queue, "a");
+        assert_eq!(page.jobs[0].attempts, 1);
+
+        // attempts=0..=0 selects the other two.
+        let page = store
+            .list_jobs(ListJobsOptions::new().attempts(0..=0))
+            .await
+            .unwrap();
+        assert_eq!(page.jobs.len(), 2);
+        assert!(page.jobs.iter().all(|j| j.attempts == 0));
+    }
 }

--- a/src/store/scan.rs
+++ b/src/store/scan.rs
@@ -648,8 +648,8 @@ impl<'a, R: Readable> Iterator for JobStream<'a, R> {
     }
 }
 
-/// Wraps a job iterator and skips jobs whose `priority` or `ready_at`
-/// falls outside the supplied inclusive range(s).
+/// Wraps a job iterator and skips jobs whose numeric fields fall outside
+/// the supplied inclusive range(s).
 ///
 /// Both bounds are checked off the already-hydrated `Job` record, so no
 /// extra disk reads are required. Cheap integer comparisons — chain this
@@ -659,6 +659,7 @@ pub(super) struct RangeFilteredIter<I> {
     pub(super) inner: I,
     pub(super) priority: Option<RangeInclusive<u16>>,
     pub(super) ready_at: Option<RangeInclusive<u64>>,
+    pub(super) attempts: Option<RangeInclusive<u32>>,
 }
 
 impl<I: Iterator<Item = Result<Job, StoreError>>> Iterator for RangeFilteredIter<I> {
@@ -678,6 +679,11 @@ impl<I: Iterator<Item = Result<Job, StoreError>>> Iterator for RangeFilteredIter
             }
             if let Some(range) = &self.ready_at {
                 if !range.contains(&job.ready_at) {
+                    continue;
+                }
+            }
+            if let Some(range) = &self.attempts {
+                if !range.contains(&job.attempts) {
                     continue;
                 }
             }
@@ -795,11 +801,12 @@ pub(super) fn apply_filters<'a, R: Readable + 'a>(
     filter: &JobFilter,
 ) -> Box<dyn Iterator<Item = Result<Job, StoreError>> + 'a> {
     let stream: Box<dyn Iterator<Item = Result<Job, StoreError>> + 'a> =
-        if filter.priority.is_some() || filter.ready_at.is_some() {
+        if filter.priority.is_some() || filter.ready_at.is_some() || filter.attempts.is_some() {
             Box::new(RangeFilteredIter {
                 inner,
                 priority: filter.priority.clone(),
                 ready_at: filter.ready_at.clone(),
+                attempts: filter.attempts.clone(),
             })
         } else {
             Box::new(inner)


### PR DESCRIPTION
Same as for `priority` and `ready_at`, this time for `attempts`.