### PR TITLE
Implement `InFlightIndex` in `Store`.

### DIFF
--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -16,7 +16,6 @@
 //! previous window to produce add/remove events. Only genuinely new IDs
 //! trigger a `get_job` disk read.
 
-use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use axum::extract::State;
@@ -60,12 +59,8 @@ struct ConnectionState {
     /// Previous ready window: sorted `(priority, id)` keys.
     prev_ready: Vec<(u16, String)>,
 
-    /// Full ordered set of in-flight jobs: `(dequeued_at, id)`.
-    /// Maintained from `StoreEvent`s — append on `JobInFlight`,
-    /// remove on `JobCompleted`/`JobFailed`.
-    in_flight_ids: BTreeSet<(u64, String)>,
-
-    /// Previous in-flight window entries from `in_flight_ids`.
+    /// Previous in-flight window: sorted `(dequeued_at, id)` keys, read
+    /// from the server-side `InFlightIndex` via `scan_in_flight_ids`.
     prev_in_flight: Vec<(u64, String)>,
 
     /// Previous scheduled window: sorted `(ready_at, id)` keys.
@@ -329,33 +324,12 @@ async fn send_snapshot_with_subs(
     scheduled_sub: Subscription,
     detail: bool,
 ) -> Result<ConnectionState, String> {
-    // Build the initial in-flight ID set from a full query.
-    let mut in_flight_jobs = state
-        .store
-        .list_jobs(
-            store::ListJobsOptions::new()
-                .statuses([store::JobStatus::InFlight].into())
-                .limit(usize::MAX),
-        )
-        .await
-        .map(|page| page.jobs)
-        .unwrap_or_else(|e| {
-            tracing::error!(%e, "admin ws: failed to list in-flight jobs for snapshot");
-            Vec::new()
-        });
-
-    in_flight_jobs.sort_by_key(|j| j.dequeued_at.unwrap_or(0));
-
-    let in_flight_ids: BTreeSet<(u64, String)> = in_flight_jobs
-        .iter()
-        .map(|j| (j.dequeued_at.unwrap_or(0), j.id.clone()))
-        .collect();
-
-    // Seed a ConnectionState with empty baselines — build_snapshot will
-    // populate them and return the snapshot event.
+    // Seed a ConnectionState with empty diff baselines — build_snapshot
+    // will populate them and return the snapshot event. The in-flight
+    // source of truth lives in the server-side `InFlightIndex`, so there
+    // is no per-connection set to pre-populate.
     let mut conn = ConnectionState {
         prev_ready: Vec::new(),
-        in_flight_ids,
         prev_in_flight: Vec::new(),
         prev_scheduled: Vec::new(),
         ready_sub,
@@ -390,63 +364,42 @@ async fn process_store_event(
     conn: &mut ConnectionState,
 ) -> Vec<AdminEvent> {
     match event {
-        StoreEvent::JobCreated { ref id, .. } => {
-            // `JobCreated` covers both fresh enqueues and `requeue` calls
-            // (worker disconnect cleanup). For requeues, the job was
-            // previously InFlight from this connection's perspective —
-            // it has to be evicted from `in_flight_ids` so the next
-            // `diff_in_flight` emits an `InFlightRemoved` event. For
-            // fresh enqueues the set never contained the id so this is
-            // a harmless no-op.
-            let was_in_flight = conn.in_flight_ids.iter().any(|(_, wid)| wid == id);
-            if was_in_flight {
-                conn.in_flight_ids.retain(|(_, wid)| wid != id);
-            }
+        StoreEvent::JobCreated { .. } => {
+            // Covers both fresh enqueues and `requeue` calls. A requeue
+            // also dropped an entry from the server-side InFlightIndex,
+            // so we re-diff all three windows. Fresh enqueues will see
+            // an unchanged in-flight scan, so the diff is a cheap no-op.
             let mut events = diff_ready(store, conn).await;
+            events.extend(diff_in_flight(store, conn).await);
             events.extend(diff_scheduled(store, conn).await);
-            if was_in_flight {
-                events.extend(diff_in_flight(store, conn).await);
-            }
             events
         }
-        StoreEvent::JobInFlight { id } => {
-            let mut events = Vec::new();
-            // Insert into in-flight set.
-            if let Ok(Some(job)) = store.get_job(now_millis(), &id).await {
-                conn.in_flight_ids
-                    .insert((job.dequeued_at.unwrap_or(0), id.clone()));
-            }
-            // Diff in-flight window (new entry may appear).
-            events.extend(diff_in_flight(store, conn).await);
-            // Diff ready window (job left ready, backfill may be needed).
+        StoreEvent::JobInFlight { .. } => {
+            // The store already inserted into InFlightIndex; re-diff
+            // the in-flight window to pick up the new entry, and the
+            // ready window since the job left it.
+            let mut events = diff_in_flight(store, conn).await;
             events.extend(diff_ready(store, conn).await);
             events
         }
         StoreEvent::JobCompleted { id } => {
-            let mut events = Vec::new();
-            // Remove from in-flight set.
-            conn.in_flight_ids.retain(|(_, wid)| wid != &id);
-            // Emit semantic "completed" event.
-            events.push(AdminEvent::JobChanged {
+            // Emit semantic "completed" event, then re-diff in-flight
+            // for the removal + any backfill. The server-side index
+            // already removed this id.
+            let mut events = vec![AdminEvent::JobChanged {
                 id,
                 status: JobChangeStatus::Completed,
                 job: None,
-            });
-            // Diff in-flight window for backfill.
+            }];
             events.extend(diff_in_flight(store, conn).await);
             events
         }
         StoreEvent::JobFailed { id, .. } => {
-            let mut events = Vec::new();
-            // Remove from in-flight set.
-            conn.in_flight_ids.retain(|(_, wid)| wid != &id);
-            // Emit semantic "dead" event.
-            events.push(AdminEvent::JobChanged {
+            let mut events = vec![AdminEvent::JobChanged {
                 id,
                 status: JobChangeStatus::Dead,
                 job: None,
-            });
-            // Diff in-flight window for backfill.
+            }];
             events.extend(diff_in_flight(store, conn).await);
             events
         }
@@ -457,10 +410,8 @@ async fn process_store_event(
             // visible window. Send a fresh snapshot instead.
             vec![build_snapshot(store, conn).await]
         }
-        StoreEvent::JobDeleted { id } => {
-            let mut events = Vec::new();
-            conn.in_flight_ids.retain(|(_, wid)| wid != &id);
-            events.extend(diff_ready(store, conn).await);
+        StoreEvent::JobDeleted { .. } => {
+            let mut events = diff_ready(store, conn).await;
             events.extend(diff_in_flight(store, conn).await);
             events.extend(diff_scheduled(store, conn).await);
             events
@@ -524,30 +475,17 @@ async fn handle_subscribe(
         items: to_admin_jobs(store, ready_jobs, conn.detail).await,
     };
 
-    let in_flight_items: Vec<store::Job> = {
-        let mut jobs = Vec::new();
-        for (_dequeued_at, id) in conn
-            .in_flight_ids
-            .iter()
-            .skip(conn.in_flight_sub.offset)
-            .take(conn.in_flight_sub.limit)
-        {
-            if let Ok(Some(job)) = store.get_job(now_millis(), id).await {
-                jobs.push(job);
-            }
-        }
-        jobs
-    };
+    let in_flight_items = store
+        .list_in_flight_jobs(conn.in_flight_sub.offset, conn.in_flight_sub.limit)
+        .await
+        .unwrap_or_default();
     conn.prev_in_flight = in_flight_items
         .iter()
         .map(|j| (j.dequeued_at.unwrap_or(0), j.id.clone()))
         .collect();
     let in_flight_window = JobWindow {
         offset: conn.in_flight_sub.offset,
-        items: in_flight_items
-            .into_iter()
-            .map(|j| AdminJob::from_store(j, conn.detail))
-            .collect(),
+        items: to_admin_jobs(store, in_flight_items, conn.detail).await,
     };
 
     let scheduled_jobs = store
@@ -610,16 +548,12 @@ async fn diff_ready(store: &store::Store, conn: &mut ConnectionState) -> Vec<Adm
     events
 }
 
-/// Diff the in-flight window: take entries from `in_flight_ids` using
+/// Diff the in-flight window: scan IDs from the InFlightIndex using
 /// subscription offset/limit, compare against `prev_in_flight`, emit adds/removes.
 async fn diff_in_flight(store: &store::Store, conn: &mut ConnectionState) -> Vec<AdminEvent> {
-    let current: Vec<(u64, String)> = conn
-        .in_flight_ids
-        .iter()
-        .skip(conn.in_flight_sub.offset)
-        .take(conn.in_flight_sub.limit)
-        .cloned()
-        .collect();
+    let current = store
+        .scan_in_flight_ids(conn.in_flight_sub.offset, conn.in_flight_sub.limit)
+        .await;
     let (adds, removes) = diff_sorted(&current, &conn.prev_in_flight);
     let mut events = Vec::with_capacity(adds.len() + removes.len());
 
@@ -711,40 +645,32 @@ async fn build_snapshot(store: &store::Store, conn: &mut ConnectionState) -> Adm
         .await
         .unwrap_or_default();
 
+    let capped_in_flight = store
+        .list_in_flight_jobs(conn.in_flight_sub.offset, conn.in_flight_sub.limit)
+        .await
+        .unwrap_or_default();
+
     let capped_scheduled = store
         .list_scheduled_jobs(conn.scheduled_sub.offset, conn.scheduled_sub.limit)
         .await
         .unwrap_or_default();
-
-    // In-flight: re-read from the connection's in_flight_ids set
-    // (maintained by JobInFlight/JobCompleted/JobFailed/JobDeleted events).
-    let in_flight_window: Vec<(u64, String)> = conn
-        .in_flight_ids
-        .iter()
-        .skip(conn.in_flight_sub.offset)
-        .take(conn.in_flight_sub.limit)
-        .cloned()
-        .collect();
-
-    let mut in_flight_jobs = Vec::with_capacity(in_flight_window.len());
-    for (_, id) in &in_flight_window {
-        if let Ok(Some(job)) = store.get_job(now_millis(), id).await {
-            in_flight_jobs.push(AdminJob::from_store(job, conn.detail));
-        }
-    }
 
     // Reset diff baselines.
     conn.prev_ready = capped_ready
         .iter()
         .map(|j| (j.priority, j.id.clone()))
         .collect();
-    conn.prev_in_flight = in_flight_window;
+    conn.prev_in_flight = capped_in_flight
+        .iter()
+        .map(|j| (j.dequeued_at.unwrap_or(0), j.id.clone()))
+        .collect();
     conn.prev_scheduled = capped_scheduled
         .iter()
         .map(|j| (j.ready_at, j.id.clone()))
         .collect();
 
     let ready_items = to_admin_jobs(store, capped_ready, conn.detail).await;
+    let in_flight_items = to_admin_jobs(store, capped_in_flight, conn.detail).await;
     let scheduled_items = to_admin_jobs(store, capped_scheduled, conn.detail).await;
 
     AdminEvent::JobSnapshot {
@@ -754,7 +680,7 @@ async fn build_snapshot(store: &store::Store, conn: &mut ConnectionState) -> Adm
         },
         in_flight: JobWindow {
             offset: conn.in_flight_sub.offset,
-            items: in_flight_jobs,
+            items: in_flight_items,
         },
         scheduled: JobWindow {
             offset: conn.scheduled_sub.offset,
@@ -1102,15 +1028,14 @@ mod tests {
         assert_eq!(statuses, vec!["in_flight", "ready_removed"]);
     }
 
-    /// Regression: when a worker disconnected, the take handler called
-    /// `store.requeue(id)` for each in-flight job. That emits a
-    /// `JobCreated` event. The admin handler used to handle `JobCreated`
-    /// only as "new ready job" — diffing the ready/scheduled windows but
-    /// never removing the id from `conn.in_flight_ids`. The result was
-    /// stale rows lingering in the `zizq top` in-flight tab even though
-    /// the header total had dropped to zero. The handler now evicts the
-    /// id from `in_flight_ids` on `JobCreated`, so the next
-    /// `diff_in_flight` emits an `in_flight_removed`.
+    /// Regression: when a worker disconnects, the take handler calls
+    /// `store.requeue(id)` for each in-flight job, which emits a
+    /// `JobCreated` event. The admin handler used to only diff ready and
+    /// scheduled on `JobCreated`, leaving stale in-flight rows in the
+    /// `zizq top` tab even though `store.requeue` had removed them from
+    /// the server-side `InFlightIndex`. The handler now always re-runs
+    /// `diff_in_flight` on `JobCreated`, so the removal surfaces as an
+    /// `in_flight_removed` event.
     #[tokio::test]
     async fn requeue_emits_in_flight_removed_and_ready() {
         let state = test_state();

--- a/src/store/complete/batcher.rs
+++ b/src/store/complete/batcher.rs
@@ -42,10 +42,10 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::broadcast;
 
+use super::super::in_flight_index::InFlightIndex;
 use super::super::ready_index::ReadyIndex;
 use super::super::results::BulkCompleteResult;
 use super::super::store::{Keyspaces, StoreEvent};
@@ -74,7 +74,7 @@ impl CompleteBatcher {
     pub(in crate::store) fn start(
         ks: Arc<Keyspaces>,
         ready_index: Arc<ReadyIndex>,
-        in_flight_count: Arc<AtomicU64>,
+        in_flight_index: Arc<InFlightIndex>,
         event_tx: broadcast::Sender<StoreEvent>,
         default_completed_retention_ms: u64,
         batch_size: usize,
@@ -99,7 +99,7 @@ impl CompleteBatcher {
                     process_batch(
                         &ks,
                         &ready_index,
-                        &in_flight_count,
+                        &in_flight_index,
                         &event_tx,
                         default_completed_retention_ms,
                         batch,
@@ -135,7 +135,7 @@ impl CompleteBatcher {
 fn process_batch(
     ks: &Keyspaces,
     ready_index: &ReadyIndex,
-    in_flight_count: &AtomicU64,
+    in_flight_index: &InFlightIndex,
     event_tx: &broadcast::Sender<StoreEvent>,
     default_completed_retention_ms: u64,
     batch: Vec<CompleteOp>,
@@ -253,23 +253,21 @@ fn process_batch(
         break (prepared, not_found_set);
     };
 
-    // Update ready_index once per unique completed id.
+    // Update ready_index and remove from in_flight_index once per id.
+    // `prepared` is already dedup'd: `flat_ids` is built via `global_seen`
+    // above, and `pre_read_completes` preserves that uniqueness.
+    let mut completed_set: HashSet<String> = HashSet::with_capacity(prepared.len());
     for p in &prepared {
         ready_index.remove(&p.queue, p.priority, &p.id);
+        in_flight_index.remove(p.dequeued_at, &p.id);
+        completed_set.insert(p.id.clone());
     }
 
-    // Broadcast JobCompleted + decrement in_flight_count once per
-    // unique completed id (not per occurrence across ops).
-    let completed_set: HashSet<String> = prepared.into_iter().map(|p| p.id).collect();
+    // Broadcast JobCompleted once per completed id.
     for id in &completed_set {
         let _ = event_tx.send(StoreEvent::JobCompleted { id: id.clone() });
     }
-    let unique_completed = completed_set.len() as u64;
-    if unique_completed > 0 {
-        let _ = in_flight_count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-            Some(v.saturating_sub(unique_completed))
-        });
-    }
+    let unique_completed = completed_set.len();
 
     tracing::debug!(
         ops = ops_count,

--- a/src/store/complete/pre_read.rs
+++ b/src/store/complete/pre_read.rs
@@ -24,6 +24,9 @@ pub(super) struct PreparedComplete {
     pub(super) queue: String,
     pub(super) pre_bytes: Slice,
     pub(super) priority: u16,
+    /// Dequeue timestamp from the in-flight record, used to remove the
+    /// matching entry from the `InFlightIndex` after commit.
+    pub(super) dequeued_at: u64,
     /// `None` for zero-retention completions (which delete the job).
     pub(super) updated_bytes: Option<Slice>,
     /// `Some` for zero-retention completions (delete-paths).
@@ -81,6 +84,8 @@ pub(super) fn pre_read_completes(
             .and_then(|r| r.completed_ms)
             .unwrap_or(default_completed_retention_ms);
 
+        let dequeued_at = job.dequeued_at.unwrap_or(0);
+
         if retention_ms == 0 {
             let del = prepare_job_deletion(&job, JobStatus::InFlight, ks);
             prepared.push(PreparedComplete {
@@ -88,6 +93,7 @@ pub(super) fn pre_read_completes(
                 queue: job.queue.clone(),
                 pre_bytes,
                 priority: job.priority,
+                dequeued_at,
                 updated_bytes: None,
                 deletion: Some(del),
                 index_keys: None,
@@ -113,6 +119,7 @@ pub(super) fn pre_read_completes(
                 queue,
                 pre_bytes,
                 priority: job.priority,
+                dequeued_at,
                 updated_bytes: Some(updated_slice),
                 deletion: None,
                 index_keys: Some(CompletionRetentionKeys {

--- a/src/store/delete.rs
+++ b/src/store/delete.rs
@@ -10,8 +10,6 @@
 //!   events so workers can release capacity for in-flight jobs deleted
 //!   out from under them.
 
-use std::sync::atomic::Ordering;
-
 use tokio::task;
 
 use super::keys::{
@@ -32,7 +30,7 @@ impl Store {
         let ks = self.ks.clone();
         let ready_index = self.ready_index.clone();
         let scheduled_index = self.scheduled_index.clone();
-        let in_flight_count = self.in_flight_count.clone();
+        let in_flight_index = self.in_flight_index.clone();
         let id = id.to_string();
 
         let result = task::spawn_blocking(move || -> Result<_, StoreError> {
@@ -64,11 +62,7 @@ impl Store {
                     scheduled_index.remove(job.ready_at, &id);
                 }
                 JobStatus::InFlight => {
-                    in_flight_count
-                        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                            Some(v.saturating_sub(1))
-                        })
-                        .ok();
+                    in_flight_index.remove(job.dequeued_at.unwrap_or(0), &id);
                 }
                 _ => {}
             }
@@ -106,7 +100,7 @@ impl Store {
         let ks = self.ks.clone();
         let ready_index = self.ready_index.clone();
         let scheduled_index = self.scheduled_index.clone();
-        let in_flight_count = self.in_flight_count.clone();
+        let in_flight_index = self.in_flight_index.clone();
         let event_tx = self.event_tx.clone();
 
         let deleted_ids = task::spawn_blocking(move || -> Result<_, StoreError> {
@@ -153,6 +147,7 @@ impl Store {
                 status: JobStatus,
                 priority: u16,
                 ready_at: u64,
+                dequeued_at: u64,
             }
 
             let mut deleted: Vec<Deleted> = Vec::new();
@@ -175,6 +170,7 @@ impl Store {
                     status,
                     priority: job.priority,
                     ready_at: job.ready_at,
+                    dequeued_at: job.dequeued_at.unwrap_or(0),
                 });
             }
 
@@ -185,7 +181,6 @@ impl Store {
             ks.commit(tx, ks.default_commit_mode)?;
 
             // Post-commit: clean up in-memory indexes.
-            let mut in_flight_removed: u64 = 0;
             for d in &deleted {
                 match d.status {
                     JobStatus::Ready => {
@@ -195,18 +190,10 @@ impl Store {
                         scheduled_index.remove(d.ready_at, &d.id);
                     }
                     JobStatus::InFlight => {
-                        in_flight_removed += 1;
+                        in_flight_index.remove(d.dequeued_at, &d.id);
                     }
                     _ => {}
                 }
-            }
-
-            if in_flight_removed > 0 {
-                in_flight_count
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                        Some(v.saturating_sub(in_flight_removed))
-                    })
-                    .ok();
             }
 
             let deleted_ids: Vec<String> = deleted.into_iter().map(|d| d.id).collect();

--- a/src/store/fail.rs
+++ b/src/store/fail.rs
@@ -3,8 +3,6 @@
 
 //! Job failure handling: retry vs kill, backoff, error record persistence.
 
-use std::sync::atomic::Ordering;
-
 use fjall::Slice;
 use tokio::task;
 
@@ -217,11 +215,8 @@ impl Store {
 
         // Emit events outside spawn_blocking due to &self.event_tx.
         if let Some(ref job) = result {
-            let _ = self
-                .in_flight_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_sub(1))
-                });
+            self.in_flight_index
+                .remove(job.dequeued_at.unwrap_or(0), &id_for_event);
 
             // Always emit JobFailed first so workers prune their
             // in-flight set before any downstream events arrive.

--- a/src/store/in_flight_index.rs
+++ b/src/store/in_flight_index.rs
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+use crossbeam_skiplist::SkipSet;
+
+/// In-memory chronological index of in-flight jobs.
+///
+/// Keeps a `SkipSet<(u64, String)>` ordered by `(dequeued_at, job_id)`.
+/// The tuple's derived `Ord` gives dequeue-time ordering (oldest first),
+/// then FIFO within the same timestamp (scru128 IDs are lexicographically
+/// time-ordered).
+///
+/// Lock-free — uses `crossbeam-skiplist` internally. Producers
+/// (`take_next_n_jobs`) call `insert`; consumers (complete batcher,
+/// `record_failure`, `requeue`, `delete_job`/`delete_jobs`, `purge_job`)
+/// call `remove`. The admin event stream reads via `iter` / `len`.
+///
+/// Starts empty on every process start: `recover_in_flight` migrates all
+/// orphaned InFlight jobs back to Ready before traffic is accepted, so
+/// there is never anything to rebuild.
+///
+/// All access goes through the public methods. Direct access to `entries`
+/// is prevented by module-level privacy.
+pub(super) struct InFlightIndex {
+    entries: SkipSet<(u64, String)>,
+}
+
+impl InFlightIndex {
+    pub(super) fn new() -> Self {
+        Self {
+            entries: SkipSet::new(),
+        }
+    }
+
+    /// Total number of in-flight jobs across all workers.
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Iterate in dequeue-time order. Yields `(dequeued_at, job_id)` pairs.
+    pub(super) fn iter(&self) -> impl Iterator<Item = (u64, String)> + '_ {
+        self.entries.iter().map(|entry| {
+            let (dequeued_at, job_id) = entry.value();
+            (*dequeued_at, job_id.clone())
+        })
+    }
+
+    pub(super) fn insert(&self, dequeued_at: u64, job_id: String) {
+        self.entries.insert((dequeued_at, job_id));
+    }
+
+    pub(super) fn remove(&self, dequeued_at: u64, job_id: &str) {
+        self.entries.remove(&(dequeued_at, job_id.to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_index() {
+        let idx = InFlightIndex::new();
+        assert_eq!(idx.len(), 0);
+        assert_eq!(idx.iter().count(), 0);
+    }
+
+    #[test]
+    fn insert_and_len() {
+        let idx = InFlightIndex::new();
+        idx.insert(1000, "j1".into());
+        idx.insert(2000, "j2".into());
+        idx.insert(3000, "j3".into());
+        assert_eq!(idx.len(), 3);
+    }
+
+    #[test]
+    fn remove() {
+        let idx = InFlightIndex::new();
+        idx.insert(1000, "j1".into());
+        idx.insert(2000, "j2".into());
+        idx.remove(1000, "j1");
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn remove_nonexistent_is_noop() {
+        let idx = InFlightIndex::new();
+        idx.insert(1000, "j1".into());
+        idx.remove(9999, "nonexistent");
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn iter_returns_dequeue_time_order() {
+        let idx = InFlightIndex::new();
+        idx.insert(3000, "j3".into());
+        idx.insert(1000, "j1".into());
+        idx.insert(2000, "j2".into());
+
+        let items: Vec<(u64, String)> = idx.iter().collect();
+        assert_eq!(
+            items,
+            vec![
+                (1000, "j1".into()),
+                (2000, "j2".into()),
+                (3000, "j3".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn iter_breaks_ties_by_job_id() {
+        let idx = InFlightIndex::new();
+        idx.insert(1000, "b".into());
+        idx.insert(1000, "a".into());
+        idx.insert(1000, "c".into());
+
+        let items: Vec<(u64, String)> = idx.iter().collect();
+        assert_eq!(
+            items,
+            vec![(1000, "a".into()), (1000, "b".into()), (1000, "c".into()),]
+        );
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,6 +7,7 @@ mod delete;
 mod enqueue;
 mod fail;
 mod group_committer;
+mod in_flight_index;
 mod keys;
 mod maintenance;
 mod options;

--- a/src/store/read.rs
+++ b/src/store/read.rs
@@ -322,6 +322,49 @@ impl Store {
             .unwrap_or_default()
     }
 
+    /// List in-flight jobs in dequeue-time order from the in-memory index.
+    ///
+    /// Iterates the `InFlightIndex` SkipSet and hydrates job metadata from
+    /// the `jobs` keyspace. Skips jobs whose metadata is missing. Does NOT
+    /// hydrate payloads.
+    pub async fn list_in_flight_jobs(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<Job>, StoreError> {
+        let in_flight_index = self.in_flight_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let mut jobs = Vec::with_capacity(limit);
+            for (_dequeued_at, job_id) in in_flight_index.iter().skip(offset) {
+                if jobs.len() >= limit {
+                    break;
+                }
+                let job_key = make_job_key(&job_id);
+                if let Some(bytes) = ks.data.get(&job_key)? {
+                    let job: Job = rmp_serde::from_slice(&bytes)?;
+                    jobs.push(job);
+                }
+            }
+            Ok(jobs)
+        })
+        .await?
+    }
+
+    /// Scan the in-memory InFlightIndex and return up to `limit` keys.
+    ///
+    /// Returns `Vec<(dequeued_at, job_id)>` in dequeue-time order — zero
+    /// disk I/O. Used by the admin event handler to diff capped in-flight
+    /// windows.
+    pub async fn scan_in_flight_ids(&self, offset: usize, limit: usize) -> Vec<(u64, String)> {
+        let in_flight_index = self.in_flight_index.clone();
+
+        task::spawn_blocking(move || in_flight_index.iter().skip(offset).take(limit).collect())
+            .await
+            .unwrap_or_default()
+    }
+
     /// Get a single error record by job ID and attempt number.
     ///
     /// Returns `None` if the job or attempt doesn't exist.

--- a/src/store/requeue.rs
+++ b/src/store/requeue.rs
@@ -4,7 +4,7 @@
 //! Requeue: return an in-flight job to the ready queue.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 
 use fjall::Slice;
 use tokio::task;
@@ -50,6 +50,7 @@ impl Store {
 
                 let queue = job.queue.clone();
                 let priority = job.priority;
+                let dequeued_at = job.dequeued_at.unwrap_or(0);
                 job.status = JobStatus::Ready.into();
 
                 let updated_slice: Slice = rmp_serde::to_vec_named(&job)?.into();
@@ -72,17 +73,13 @@ impl Store {
                 // Insert into the in-memory ready index after commit succeeds.
                 ready_index.insert(&queue, priority, id.clone());
 
-                return Ok(Some(queue));
+                return Ok(Some((queue, dequeued_at)));
             }
         })
         .await??;
 
-        if let Some(queue) = result {
-            let _ = self
-                .in_flight_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_sub(1))
-                });
+        if let Some((queue, dequeued_at)) = result {
+            self.in_flight_index.remove(dequeued_at, &event_id);
             let _ = self.event_tx.send(StoreEvent::JobCreated {
                 id: event_id,
                 queue,

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -21,7 +21,7 @@
 //! use sorted stream intersection across the tag-prefixed ranges.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::AtomicBool;
 
 use fjall::config::{FilterPolicy, PinningPolicy};
 use fjall::{SingleWriterTxDatabase, SingleWriterTxKeyspace};
@@ -31,6 +31,7 @@ use super::complete::CompleteBatcher;
 use super::cron::CronScheduleIndex;
 use super::enqueue::EnqueueBatcher;
 use super::group_committer::GroupCommitter;
+use super::in_flight_index::InFlightIndex;
 use super::ready_index::ReadyIndex;
 use super::scheduled_index::ScheduledIndex;
 use super::storage_config::StorageConfig;
@@ -143,6 +144,16 @@ pub struct Store {
     /// `Ready` once their time arrives.
     pub(super) scheduled_index: Arc<ScheduledIndex>,
 
+    /// In-memory chronological index of in-flight jobs.
+    ///
+    /// Ordered by `(dequeued_at, job_id)`. Starts empty on every process
+    /// start — `recover_in_flight` ensures no orphaned InFlight rows
+    /// remain on disk before traffic is accepted. Maintained by
+    /// `take_next_n_jobs` (insert), `mark_completed` (remove via complete
+    /// batcher), `record_failure` (remove), `requeue` (remove),
+    /// `delete_job`/`delete_jobs`/`purge_job` (remove if currently InFlight).
+    pub(super) in_flight_index: Arc<InFlightIndex>,
+
     /// In-memory index of cron entries ordered by `next_enqueue_at`.
     pub(super) cron_index: Arc<CronScheduleIndex>,
 
@@ -162,13 +173,6 @@ pub struct Store {
     /// Guards on `take_next_job`, `list_ready_jobs`, and `scan_ready_ids`
     /// return empty results while `false`.
     pub(super) index_ready: Arc<AtomicBool>,
-
-    /// Current number of in-flight jobs across all connections.
-    ///
-    /// Incremented when jobs are taken (`take_next_n_jobs`), decremented
-    /// when jobs complete, fail, or are requeued. Used by the HTTP layer
-    /// to enforce `global_in_flight_limit` without hitting disk.
-    pub(super) in_flight_count: Arc<AtomicU64>,
 
     /// Broadcast channel for store events.
     ///
@@ -326,6 +330,7 @@ impl Store {
         });
         let ready_index = Arc::new(ReadyIndex::new());
         let scheduled_index = Arc::new(ScheduledIndex::new());
+        let in_flight_index = Arc::new(InFlightIndex::new());
 
         // Start the enqueue auto-batcher — a dedicated OS thread that
         // coalesces concurrent enqueue requests (singular + bulk) into
@@ -340,14 +345,12 @@ impl Store {
             config.enqueue_batch_size,
         ));
 
-        let in_flight_count = Arc::new(AtomicU64::new(0));
-
         // Start the complete auto-batcher — same shape as the enqueue
         // batcher, coalesces concurrent completion (ack) requests.
         let complete_batcher = Arc::new(CompleteBatcher::start(
             ks.clone(),
             ready_index.clone(),
-            in_flight_count.clone(),
+            in_flight_index.clone(),
             event_tx.clone(),
             config.default_completed_retention_ms,
             config.complete_batch_size,
@@ -358,12 +361,12 @@ impl Store {
             ks,
             ready_index,
             scheduled_index,
+            in_flight_index,
             cron_index: Arc::new(CronScheduleIndex::new()),
             default_dead_retention_ms: config.default_dead_retention_ms,
             default_retry_limit: config.default_retry_limit,
             default_backoff: config.default_backoff,
             index_ready: Arc::new(AtomicBool::new(true)),
-            in_flight_count,
             event_tx,
             enqueue_batcher,
             complete_batcher,
@@ -382,7 +385,7 @@ impl Store {
 
     /// Total number of in-flight jobs across all connections.
     pub fn in_flight_count(&self) -> usize {
-        self.in_flight_count.load(Ordering::Relaxed) as usize
+        self.in_flight_index.len()
     }
 
     /// Total number of scheduled jobs.

--- a/src/store/take.rs
+++ b/src/store/take.rs
@@ -244,12 +244,10 @@ impl Store {
         })
         .await??;
 
-        // Update the in-flight counter and broadcast events.
-        if !jobs.is_empty() {
-            self.in_flight_count
-                .fetch_add(jobs.len() as u64, Ordering::Relaxed);
-        }
+        // Insert into the in-flight index and broadcast events.
         for job in &jobs {
+            self.in_flight_index
+                .insert(job.dequeued_at.unwrap_or(now), job.id.clone());
             let _ = self
                 .event_tx
                 .send(StoreEvent::JobInFlight { id: job.id.clone() });


### PR DESCRIPTION
Replaces the global `in_flight_count` `AtomicU64` and keeps track of each job as it moves between `InFlight` and other statuses. This is now used by `zizq top` instead of querying fjall directly.

We will be implementing filtering in `zizq top` in a follow-up.