### PR TITLE
Add Search Support to `zizq top`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.5.1
+
+- Added `/` search to `zizq top`. Two labeled fields — Type and Queue
+  — with `Tab` to switch between them. Each field supports the standard
+  editing keys (Left/Right, Home/End, Delete, Backspace) via the
+  `tui-input` crate. `n` steps to the next match, `N` to the previous,
+  Esc unpins. Comma- or space-separate multiple values in a field to
+  OR them. Values match as substrings (`audit` matches `audit.create`,
+  `payment.audit`); the two fields AND together. Reopening `/` while
+  a search is active prefills the current query. `/` and `n`/`N` walk
+  forward from the cursor's current row rather than restarting at the
+  top of the list — `g` then `n` searches from the beginning.
+- Reworked list navigation in `zizq top` around an anchor-based
+  subscription model. The client only holds a buffer of rows around
+  the cursor and requests more as you scroll; the cursor is
+  identified by job id when tracking a search match (so it stays on
+  the same row through queue churn), and by depth when free-scrolling
+  (so the viewport row you're on stays stable while items shift
+  underneath). Scrolling past the loaded edge stops at the edge and
+  waits for a prefetch instead of blanking the viewport. Prefetch
+  subscribes are rate-limited to at most one per 100 ms per tab so
+  a held arrow key or `JobChanged` burst doesn't spam the server.
+- Reformatted the `zizq top` help bar in htop's key-and-label style
+  (no space between key and label; color contrast marks the boundary)
+  and added a `/Find` entry.
+- Added an in-memory `InFlightIndex` to the store, mirroring the
+  existing `ReadyIndex` and `ScheduledIndex`. Powers the in-flight
+  view in the admin API without walking the LSM tree.
+
 ## 0.5.0
 
 - Added `priority`, `ready_at`, and `attempts` range filters to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4234,6 +4234,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-input"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd014a652e31cf25ea68d11b10a7b09549863449b19387505c9933f11eb05fa"
+dependencies = [
+ "ratatui",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,9 +4309,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -5158,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "bytesize",
@@ -5207,6 +5218,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tui-input",
  "urlencoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "BUSL-1.1"
 
@@ -30,6 +30,7 @@ humantime = "2"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 ratatui = "0.30"
 crossterm = "0.29"
+tui-input = "0.15"
 libc = "0.2"
 futures-util = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls-no-provider"] }

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.0/zizq-0.5.0-linux-x86_64.tar.gz
-tar -xvzf zizq-0.5.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.1/zizq-0.5.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -57,7 +57,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.5.0
+Zizq 0.5.1
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.0/zizq-0.5.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.1/zizq-0.5.1-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.5.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.5.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -15,13 +15,13 @@ does almost all of the work.
 ### 1. Download the binary.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.0/zizq-0.5.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.1/zizq-0.5.1-linux-x86_64.tar.gz
 ```
 
 ### 2. Extract it.
 
 ```shell
-tar -xvzf zizq-0.5.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
 ```
 
 ### 3. Run it to start the server.
@@ -29,7 +29,7 @@ tar -xvzf zizq-0.5.0-linux-x86_64.tar.gz
 ```shell
 ./zizq serve
 
-Zizq 0.5.0
+Zizq 0.5.1
 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http

--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -25,12 +25,11 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::sync::broadcast;
 
 use super::{
-    AdminEvent, AdminJob, AdminMessage, ClientMessage, JobChangeStatus, JobWindow, ListName,
-    ServerStatus,
+    AdminEvent, AdminJob, AdminMessage, ClientMessage, Direction, Fallback, FindAnchor,
+    JobChangeStatus, JobWindow, ListName, SearchQuery, ServerStatus, SubscribeAnchor,
 };
 use crate::state::AppState;
 use crate::store::{self, StoreEvent};
-use crate::time::now_millis;
 
 /// Default subscription window size.
 const DEFAULT_LIMIT: usize = 200;
@@ -38,33 +37,35 @@ const DEFAULT_LIMIT: usize = 200;
 /// Maximum subscription window for free-tier connections.
 const FREE_TIER_CAP: usize = 10;
 
-/// Per-list subscription parameters.
+/// Per-list subscription parameters. The dashboard addresses rows by
+/// job id, not by numeric offset — see `store::WindowAnchor` docs.
 #[derive(Clone)]
 struct Subscription {
-    offset: usize,
+    anchor: store::WindowAnchor,
+    fallback: store::WindowFallback,
     limit: usize,
 }
 
 impl Default for Subscription {
     fn default() -> Self {
         Self {
-            offset: 0,
+            anchor: store::WindowAnchor::Head,
+            fallback: store::WindowFallback::Head,
             limit: DEFAULT_LIMIT,
         }
     }
 }
 
-/// Per-connection state tracking the previous capped windows.
+/// Per-connection state tracking the set of ids currently in each
+/// list's window. Position is irrelevant for change detection under
+/// anchor-based addressing — we just diff id sets.
 struct ConnectionState {
-    /// Previous ready window: sorted `(priority, id)` keys.
-    prev_ready: Vec<(u16, String)>,
-
-    /// Previous in-flight window: sorted `(dequeued_at, id)` keys, read
-    /// from the server-side `InFlightIndex` via `scan_in_flight_ids`.
-    prev_in_flight: Vec<(u64, String)>,
-
-    /// Previous scheduled window: sorted `(ready_at, id)` keys.
-    prev_scheduled: Vec<(u64, String)>,
+    /// IDs currently in the ready window (sorted by priority).
+    prev_ready: Vec<String>,
+    /// IDs currently in the in-flight window (sorted by dequeued_at).
+    prev_in_flight: Vec<String>,
+    /// IDs currently in the scheduled window (sorted by ready_at).
+    prev_scheduled: Vec<String>,
 
     /// Per-list subscription state.
     ready_sub: Subscription,
@@ -110,14 +111,18 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                 // Client subscribe messages.
                 client_msg = client_rx.recv() => {
                     match client_msg {
-                        Some(ClientMessage::Subscribe { list, offset, limit }) => {
+                        Some(ClientMessage::Subscribe {
+                            list,
+                            anchor,
+                            limit,
+                        }) => {
                             handle_subscribe(
                                 &send_state,
                                 store,
                                 &mut conn,
                                 &mut sender,
                                 list,
-                                offset,
+                                anchor,
                                 limit,
                             )
                             .await;
@@ -143,6 +148,26 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                             // connected client (including this one).
                             if let Err(e) = send_state.store.delete_job(&id).await {
                                 tracing::warn!(%e, %id, "admin ws: delete_job failed");
+                            }
+                        }
+                        Some(ClientMessage::Find {
+                            list,
+                            anchor,
+                            direction,
+                            query,
+                            limit,
+                        }) => {
+                            let event =
+                                handle_find(&send_state, list, anchor, direction, query, limit)
+                                    .await;
+                            let msg = AdminMessage {
+                                server: server_status(&send_state),
+                                event,
+                            };
+                            if let Ok(json) = serde_json::to_string(&msg) {
+                                if sender.send(Message::Text(json.into())).await.is_err() {
+                                    break;
+                                }
                             }
                         }
                         None => break,
@@ -273,11 +298,12 @@ fn can_show_live_queue(state: &AppState) -> bool {
         .is_ok()
 }
 
-/// Query each set: ready, in-flight, scheduled jobs, send a `JobSnapshot`, and
-/// return initial `ConnectionState`.
+/// Send the initial `JobSnapshot` covering all three lists (each
+/// anchored at `Head` by default) and build the connection state.
 ///
-/// When the license does not permit live queue detail, job lists are empty —
-/// the header totals are still populated via `ServerStatus`.
+/// When the license does not permit live queue detail, the connection
+/// still exists but every list request comes back with the free-tier
+/// capped limit.
 async fn send_initial_snapshot(
     state: &AppState,
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
@@ -288,7 +314,8 @@ async fn send_initial_snapshot(
             Subscription::default()
         } else {
             Subscription {
-                offset: 0,
+                anchor: store::WindowAnchor::Head,
+                fallback: store::WindowFallback::Head,
                 limit: FREE_TIER_CAP,
             }
         }
@@ -298,8 +325,9 @@ async fn send_initial_snapshot(
 }
 
 /// Re-send a full snapshot using the existing connection's subscription
-/// windows and detail flag, used to recover from a `broadcast` lag without
-/// losing the client's prior `SetDetailLevel` / `Subscribe` choices.
+/// windows and detail flag, used to recover from a `broadcast` lag
+/// without losing the client's prior `SetDetailLevel` / `Subscribe`
+/// choices.
 async fn resync_snapshot(
     state: &AppState,
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
@@ -325,9 +353,7 @@ async fn send_snapshot_with_subs(
     detail: bool,
 ) -> Result<ConnectionState, String> {
     // Seed a ConnectionState with empty diff baselines — build_snapshot
-    // will populate them and return the snapshot event. The in-flight
-    // source of truth lives in the server-side `InFlightIndex`, so there
-    // is no per-connection set to pre-populate.
+    // will populate them from the initial `list_window_*` responses.
     let mut conn = ConnectionState {
         prev_ready: Vec::new(),
         prev_in_flight: Vec::new(),
@@ -428,23 +454,31 @@ async fn process_store_event(
     }
 }
 
-/// Handle a subscribe message: update subscription, reset diff state, re-send snapshot.
+/// Handle a subscribe message: update the per-list subscription and
+/// re-emit a snapshot for all three lists.
+///
+/// Only the list named in the request has its anchor swapped — the
+/// other two lists' subs are preserved and re-scanned so the client
+/// receives a fully-consistent snapshot.
 async fn handle_subscribe(
     state: &AppState,
     store: &store::Store,
     conn: &mut ConnectionState,
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     list: ListName,
-    offset: usize,
+    anchor: SubscribeAnchor,
     limit: usize,
 ) {
-    let sub = if can_show_live_queue(state) {
-        Subscription { offset, limit }
+    let (store_anchor, store_fallback) = to_store_anchor(anchor);
+    let limit = if can_show_live_queue(state) {
+        limit
     } else {
-        Subscription {
-            offset: 0,
-            limit: FREE_TIER_CAP,
-        }
+        FREE_TIER_CAP
+    };
+    let sub = Subscription {
+        anchor: store_anchor,
+        fallback: store_fallback,
+        limit,
     };
     match list {
         ListName::Ready => {
@@ -461,242 +495,383 @@ async fn handle_subscribe(
         }
     }
 
-    // Re-send a full snapshot at the new window.
-    let ready_jobs = store
-        .list_ready_jobs(conn.ready_sub.offset, conn.ready_sub.limit)
-        .await
-        .unwrap_or_default();
-    conn.prev_ready = ready_jobs
-        .iter()
-        .map(|j| (j.priority, j.id.clone()))
-        .collect();
-    let ready_window = JobWindow {
-        offset: conn.ready_sub.offset,
-        items: to_admin_jobs(store, ready_jobs, conn.detail).await,
-    };
-
-    let in_flight_items = store
-        .list_in_flight_jobs(conn.in_flight_sub.offset, conn.in_flight_sub.limit)
-        .await
-        .unwrap_or_default();
-    conn.prev_in_flight = in_flight_items
-        .iter()
-        .map(|j| (j.dequeued_at.unwrap_or(0), j.id.clone()))
-        .collect();
-    let in_flight_window = JobWindow {
-        offset: conn.in_flight_sub.offset,
-        items: to_admin_jobs(store, in_flight_items, conn.detail).await,
-    };
-
-    let scheduled_jobs = store
-        .list_scheduled_jobs(conn.scheduled_sub.offset, conn.scheduled_sub.limit)
-        .await
-        .unwrap_or_default();
-    conn.prev_scheduled = scheduled_jobs
-        .iter()
-        .map(|j| (j.ready_at, j.id.clone()))
-        .collect();
-    let scheduled_window = JobWindow {
-        offset: conn.scheduled_sub.offset,
-        items: to_admin_jobs(store, scheduled_jobs, conn.detail).await,
-    };
-
+    let event = build_snapshot(store, conn).await;
     let snapshot = AdminMessage {
         server: server_status(state),
-        event: AdminEvent::JobSnapshot {
-            ready: ready_window,
-            in_flight: in_flight_window,
-            scheduled: scheduled_window,
-        },
+        event,
     };
-
     if let Ok(json) = serde_json::to_string(&snapshot) {
         let _ = sender.send(Message::Text(json.into())).await;
     }
 }
 
-/// Diff the ready window: scan IDs from the ReadyIndex using subscription
-/// offset/limit, compare against `prev_ready`, emit adds/removes.
+/// Translate the wire `SubscribeAnchor` into the store's
+/// `(WindowAnchor, WindowFallback)` pair. `Head` and `Tail` don't have
+/// a meaningful fallback — the value we pick is only consulted when
+/// the anchor's job id is missing, and neither of these can miss.
+fn to_store_anchor(anchor: SubscribeAnchor) -> (store::WindowAnchor, store::WindowFallback) {
+    match anchor {
+        SubscribeAnchor::Head => (store::WindowAnchor::Head, store::WindowFallback::Head),
+        SubscribeAnchor::Tail => (store::WindowAnchor::Tail, store::WindowFallback::Tail),
+        SubscribeAnchor::Offset { offset } => (
+            store::WindowAnchor::Offset(offset),
+            store::WindowFallback::Tail,
+        ),
+        SubscribeAnchor::Around { id, fallback } => {
+            let f = match fallback {
+                Fallback::Head => store::WindowFallback::Head,
+                Fallback::Tail => store::WindowFallback::Tail,
+                Fallback::Nowhere => store::WindowFallback::Nowhere,
+            };
+            (store::WindowAnchor::Around(id), f)
+        }
+    }
+}
+
+/// Handle a `Find` client message: translate the wire enums into the
+/// store's shape, dispatch to the appropriate `Store::find_*`, and
+/// build a `FindResult` event. See `store::find` module docs for the
+/// walk semantics and race-free rationale.
+async fn handle_find(
+    state: &AppState,
+    list: ListName,
+    anchor: FindAnchor,
+    direction: Direction,
+    query: SearchQuery,
+    limit: usize,
+) -> AdminEvent {
+    // Nonsense direction/anchor combos short-circuit to a null result:
+    // `Start + Backward` and `End + Forward` have nothing to search.
+    let nonsense = matches!(
+        (&anchor, direction),
+        (FindAnchor::Start, Direction::Backward) | (FindAnchor::End, Direction::Forward)
+    );
+    if nonsense {
+        return AdminEvent::FindResult {
+            list,
+            matched_position: None,
+            window: empty_window(),
+        };
+    }
+
+    let anchor_id = match anchor {
+        FindAnchor::JobId { id } => Some(id),
+        FindAnchor::Start | FindAnchor::End => None,
+    };
+    let store_direction = match direction {
+        Direction::Forward => store::FindDirection::Forward,
+        Direction::Backward => store::FindDirection::Backward,
+        Direction::Locate => store::FindDirection::Locate,
+    };
+
+    let outcome = match list {
+        ListName::Ready => {
+            state
+                .store
+                .find_ready(anchor_id, store_direction, query.queues, query.types, limit)
+                .await
+        }
+        ListName::InFlight => {
+            state
+                .store
+                .find_in_flight(anchor_id, store_direction, query.queues, query.types, limit)
+                .await
+        }
+        ListName::Scheduled => {
+            state
+                .store
+                .find_scheduled(anchor_id, store_direction, query.queues, query.types, limit)
+                .await
+        }
+    };
+
+    // Look up the list's total so the client can render its depth-bar
+    // marker. Under the anchor-based Subscribe model the depth-bar is
+    // decoupled from the window shape, so we consult the index length
+    // here rather than piggybacking on `FindOutcome`.
+    let total = match list {
+        ListName::Ready => state.store.ready_count(),
+        ListName::InFlight => state.store.in_flight_count(),
+        ListName::Scheduled => state.store.scheduled_count(),
+    };
+
+    match outcome {
+        Ok(Some(outcome)) => {
+            let matched_id = outcome
+                .window_items
+                .get(
+                    outcome
+                        .matched_position
+                        .saturating_sub(outcome.window_offset),
+                )
+                .map(|j| j.id.clone());
+            AdminEvent::FindResult {
+                list,
+                matched_position: Some(outcome.matched_position),
+                window: JobWindow {
+                    items: outcome
+                        .window_items
+                        .into_iter()
+                        .map(|j| AdminJob::from_store(j, false))
+                        .collect(),
+                    first_position: outcome.window_offset,
+                    total,
+                    resolved_anchor: matched_id,
+                },
+            }
+        }
+        Ok(None) => AdminEvent::FindResult {
+            list,
+            matched_position: None,
+            window: empty_window(),
+        },
+        Err(e) => {
+            tracing::error!(%e, "admin ws: find failed");
+            AdminEvent::FindResult {
+                list,
+                matched_position: None,
+                window: empty_window(),
+            }
+        }
+    }
+}
+
+/// Build an empty `JobWindow` for "no match" / error paths.
+fn empty_window() -> JobWindow {
+    JobWindow {
+        items: Vec::new(),
+        first_position: 0,
+        total: 0,
+        resolved_anchor: None,
+    }
+}
+
+/// Diff the ready window: re-fetch it via the subscription's anchor
+/// and emit `JobChanged` events for ids that entered or left the
+/// window since last diff.
 async fn diff_ready(store: &store::Store, conn: &mut ConnectionState) -> Vec<AdminEvent> {
-    let current = store
-        .scan_ready_ids(conn.ready_sub.offset, conn.ready_sub.limit)
-        .await;
-    let (adds, removes) = diff_sorted(&current, &conn.prev_ready);
-    let mut events = Vec::with_capacity(adds.len() + removes.len());
-
-    // Emit removals first so the TUI frees space before inserts.
-    for (_priority, id) in removes {
-        events.push(AdminEvent::JobChanged {
-            id,
-            status: JobChangeStatus::ReadyRemoved,
-            job: None,
+    let outcome = store
+        .list_window_ready(
+            conn.ready_sub.anchor.clone(),
+            conn.ready_sub.fallback,
+            conn.ready_sub.limit,
+        )
+        .await
+        .unwrap_or_else(|_| store::WindowOutcome {
+            items: Vec::new(),
+            first_position: 0,
+            total: 0,
+            resolved_anchor: None,
         });
-    }
-
-    // Emit additions — fetch metadata only for genuinely new IDs.
-    for (_priority, id) in adds {
-        if let Ok(Some(job)) = store.get_job(now_millis(), &id).await {
-            events.push(AdminEvent::JobChanged {
-                id,
-                status: JobChangeStatus::Ready,
-                job: Some(AdminJob::from_store(job, conn.detail)),
-            });
-        }
-    }
-
-    conn.prev_ready = current;
-    events
+    diff_list_window(
+        conn,
+        outcome,
+        ListSelector::Ready,
+        JobChangeStatus::Ready,
+        JobChangeStatus::ReadyRemoved,
+    )
+    .await
 }
 
-/// Diff the in-flight window: scan IDs from the InFlightIndex using
-/// subscription offset/limit, compare against `prev_in_flight`, emit adds/removes.
+/// Diff the in-flight window.
 async fn diff_in_flight(store: &store::Store, conn: &mut ConnectionState) -> Vec<AdminEvent> {
-    let current = store
-        .scan_in_flight_ids(conn.in_flight_sub.offset, conn.in_flight_sub.limit)
-        .await;
-    let (adds, removes) = diff_sorted(&current, &conn.prev_in_flight);
-    let mut events = Vec::with_capacity(adds.len() + removes.len());
-
-    // Emit removals.
-    for (_dequeued_at, id) in removes {
-        events.push(AdminEvent::JobChanged {
-            id,
-            status: JobChangeStatus::InFlightRemoved,
-            job: None,
+    let outcome = store
+        .list_window_in_flight(
+            conn.in_flight_sub.anchor.clone(),
+            conn.in_flight_sub.fallback,
+            conn.in_flight_sub.limit,
+        )
+        .await
+        .unwrap_or_else(|_| store::WindowOutcome {
+            items: Vec::new(),
+            first_position: 0,
+            total: 0,
+            resolved_anchor: None,
         });
-    }
-
-    // Emit additions — fetch metadata for new IDs.
-    for (_dequeued_at, id) in adds {
-        if let Ok(Some(job)) = store.get_job(now_millis(), &id).await {
-            events.push(AdminEvent::JobChanged {
-                id,
-                status: JobChangeStatus::InFlight,
-                job: Some(AdminJob::from_store(job, conn.detail)),
-            });
-        }
-    }
-
-    conn.prev_in_flight = current;
-    events
+    diff_list_window(
+        conn,
+        outcome,
+        ListSelector::InFlight,
+        JobChangeStatus::InFlight,
+        JobChangeStatus::InFlightRemoved,
+    )
+    .await
 }
 
-/// Diff the scheduled window: scan IDs from the ScheduledIndex using
-/// subscription offset/limit, compare against `prev_scheduled`, emit adds/removes.
+/// Diff the scheduled window.
 async fn diff_scheduled(store: &store::Store, conn: &mut ConnectionState) -> Vec<AdminEvent> {
-    let current = store
-        .scan_scheduled_ids(conn.scheduled_sub.offset, conn.scheduled_sub.limit)
-        .await;
-    let (adds, removes) = diff_sorted(&current, &conn.prev_scheduled);
-    let mut events = Vec::with_capacity(adds.len() + removes.len());
+    let outcome = store
+        .list_window_scheduled(
+            conn.scheduled_sub.anchor.clone(),
+            conn.scheduled_sub.fallback,
+            conn.scheduled_sub.limit,
+        )
+        .await
+        .unwrap_or_else(|_| store::WindowOutcome {
+            items: Vec::new(),
+            first_position: 0,
+            total: 0,
+            resolved_anchor: None,
+        });
+    diff_list_window(
+        conn,
+        outcome,
+        ListSelector::Scheduled,
+        JobChangeStatus::Scheduled,
+        JobChangeStatus::ScheduledRemoved,
+    )
+    .await
+}
 
+/// Which of the three list buffers a diff/refresh operates over.
+#[derive(Copy, Clone)]
+enum ListSelector {
+    Ready,
+    InFlight,
+    Scheduled,
+}
+
+/// Shared diff body. Given a freshly-scanned window and a selector
+/// for which `prev_*` list to compare/update, emits `JobChanged`
+/// events for the added and removed ids.
+async fn diff_list_window(
+    conn: &mut ConnectionState,
+    outcome: store::WindowOutcome,
+    selector: ListSelector,
+    added_status: JobChangeStatus,
+    removed_status: JobChangeStatus,
+) -> Vec<AdminEvent> {
+    let current_ids: Vec<String> = outcome.items.iter().map(|j| j.id.clone()).collect();
+    let prev = match selector {
+        ListSelector::Ready => &mut conn.prev_ready,
+        ListSelector::InFlight => &mut conn.prev_in_flight,
+        ListSelector::Scheduled => &mut conn.prev_scheduled,
+    };
+    let (added_ids, removed_ids) = diff_ids(&current_ids, prev);
+    *prev = current_ids;
+
+    let mut events = Vec::with_capacity(added_ids.len() + removed_ids.len());
     // Emit removals first so the TUI frees space before inserts.
-    for (_ready_at, id) in removes {
+    for id in removed_ids {
         events.push(AdminEvent::JobChanged {
             id,
-            status: JobChangeStatus::ScheduledRemoved,
+            status: removed_status,
             job: None,
         });
     }
-
-    // Emit additions — fetch metadata only for genuinely new IDs.
-    for (_ready_at, id) in adds {
-        if let Ok(Some(job)) = store.get_job(now_millis(), &id).await {
+    for id in added_ids {
+        // The `WindowOutcome` already contains the hydrated job, so no
+        // extra `get_job` round-trip is needed.
+        if let Some(job) = outcome.items.iter().find(|j| j.id == id) {
             events.push(AdminEvent::JobChanged {
-                id,
-                status: JobChangeStatus::Scheduled,
-                job: Some(AdminJob::from_store(job, conn.detail)),
+                id: id.clone(),
+                status: added_status,
+                job: Some(AdminJob::from_store(job.clone(), conn.detail)),
             });
         }
     }
-
-    conn.prev_scheduled = current;
     events
 }
 
-/// Convert a list of store jobs to admin jobs, hydrating payloads when detail
-/// mode is active. The list functions (`list_ready_jobs`, etc.) don't read
-/// payloads from disk, so when detail is on we re-fetch each job via `get_job`.
-async fn to_admin_jobs(store: &store::Store, jobs: Vec<store::Job>, detail: bool) -> Vec<AdminJob> {
-    if !detail {
-        return jobs
-            .into_iter()
-            .map(|j| AdminJob::from_store(j, false))
-            .collect();
-    }
-    let mut result = Vec::with_capacity(jobs.len());
-    for job in jobs {
-        let hydrated = store.get_job(now_millis(), &job.id).await;
-        match hydrated {
-            Ok(Some(j)) => result.push(AdminJob::from_store(j, true)),
-            _ => result.push(AdminJob::from_store(job, true)),
-        }
-    }
-    result
-}
-
-/// Build a fresh `JobSnapshot` event and reset the connection's diff baseline.
-///
-/// Used when incremental diffs can't capture the change (e.g. field-level
-/// patches that don't alter the ID set).
+/// Build a fresh `JobSnapshot` event and reset the connection's diff
+/// baseline. Called after connect, resubscribe, and `SetDetailLevel`.
 async fn build_snapshot(store: &store::Store, conn: &mut ConnectionState) -> AdminEvent {
-    let capped_ready = store
-        .list_ready_jobs(conn.ready_sub.offset, conn.ready_sub.limit)
-        .await
-        .unwrap_or_default();
-
-    let capped_in_flight = store
-        .list_in_flight_jobs(conn.in_flight_sub.offset, conn.in_flight_sub.limit)
-        .await
-        .unwrap_or_default();
-
-    let capped_scheduled = store
-        .list_scheduled_jobs(conn.scheduled_sub.offset, conn.scheduled_sub.limit)
-        .await
-        .unwrap_or_default();
-
-    // Reset diff baselines.
-    conn.prev_ready = capped_ready
-        .iter()
-        .map(|j| (j.priority, j.id.clone()))
-        .collect();
-    conn.prev_in_flight = capped_in_flight
-        .iter()
-        .map(|j| (j.dequeued_at.unwrap_or(0), j.id.clone()))
-        .collect();
-    conn.prev_scheduled = capped_scheduled
-        .iter()
-        .map(|j| (j.ready_at, j.id.clone()))
-        .collect();
-
-    let ready_items = to_admin_jobs(store, capped_ready, conn.detail).await;
-    let in_flight_items = to_admin_jobs(store, capped_in_flight, conn.detail).await;
-    let scheduled_items = to_admin_jobs(store, capped_scheduled, conn.detail).await;
+    let ready = fetch_window(store, conn, ListSelector::Ready).await;
+    let in_flight = fetch_window(store, conn, ListSelector::InFlight).await;
+    let scheduled = fetch_window(store, conn, ListSelector::Scheduled).await;
 
     AdminEvent::JobSnapshot {
-        ready: JobWindow {
-            offset: conn.ready_sub.offset,
-            items: ready_items,
-        },
-        in_flight: JobWindow {
-            offset: conn.in_flight_sub.offset,
-            items: in_flight_items,
-        },
-        scheduled: JobWindow {
-            offset: conn.scheduled_sub.offset,
-            items: scheduled_items,
-        },
+        ready,
+        in_flight,
+        scheduled,
     }
 }
 
-/// Diff two sorted slices, returning `(added, removed)` elements.
-///
-/// Both slices must be sorted by their natural `Ord`. Elements present
-/// in `current` but not `previous` are "added"; elements in `previous`
-/// but not `current` are "removed".
-///
-/// Used by both `diff_ready` and `diff_in_flight` to compare capped
-/// windows against their previous state.
+/// Fetch a `JobWindow` for one list and update the connection's
+/// `prev_*` baseline to match. Shared by `build_snapshot` (all three
+/// lists) and `handle_subscribe` (one list at a time via
+/// `build_snapshot` too).
+async fn fetch_window(
+    store: &store::Store,
+    conn: &mut ConnectionState,
+    selector: ListSelector,
+) -> JobWindow {
+    let (outcome, prev) = match selector {
+        ListSelector::Ready => (
+            store
+                .list_window_ready(
+                    conn.ready_sub.anchor.clone(),
+                    conn.ready_sub.fallback,
+                    conn.ready_sub.limit,
+                )
+                .await,
+            &mut conn.prev_ready,
+        ),
+        ListSelector::InFlight => (
+            store
+                .list_window_in_flight(
+                    conn.in_flight_sub.anchor.clone(),
+                    conn.in_flight_sub.fallback,
+                    conn.in_flight_sub.limit,
+                )
+                .await,
+            &mut conn.prev_in_flight,
+        ),
+        ListSelector::Scheduled => (
+            store
+                .list_window_scheduled(
+                    conn.scheduled_sub.anchor.clone(),
+                    conn.scheduled_sub.fallback,
+                    conn.scheduled_sub.limit,
+                )
+                .await,
+            &mut conn.prev_scheduled,
+        ),
+    };
+    let outcome = outcome.unwrap_or_else(|_| store::WindowOutcome {
+        items: Vec::new(),
+        first_position: 0,
+        total: 0,
+        resolved_anchor: None,
+    });
+    *prev = outcome.items.iter().map(|j| j.id.clone()).collect();
+
+    let admin_items: Vec<AdminJob> = outcome
+        .items
+        .into_iter()
+        .map(|j| AdminJob::from_store(j, conn.detail))
+        .collect();
+    JobWindow {
+        items: admin_items,
+        first_position: outcome.first_position,
+        total: outcome.total,
+        resolved_anchor: outcome.resolved_anchor,
+    }
+}
+
+/// Diff two id lists (each sorted per the list's ordering key),
+/// returning `(added, removed)` ids.
+fn diff_ids(current: &[String], previous: &[String]) -> (Vec<String>, Vec<String>) {
+    let prev_set: std::collections::HashSet<&String> = previous.iter().collect();
+    let curr_set: std::collections::HashSet<&String> = current.iter().collect();
+    let added: Vec<String> = current
+        .iter()
+        .filter(|id| !prev_set.contains(id))
+        .cloned()
+        .collect();
+    let removed: Vec<String> = previous
+        .iter()
+        .filter(|id| !curr_set.contains(id))
+        .cloned()
+        .collect();
+    (added, removed)
+}
+
+/// Legacy sorted-slice diff (unused by the new anchor-based flow but
+/// retained for the tests that touched it directly). Elements
+/// present in `current` but not `previous` are "added"; elements in
+/// `previous` but not `current` are "removed".
+#[allow(dead_code)]
 fn diff_sorted<K: Ord + Clone>(
     current: &[(K, String)],
     previous: &[(K, String)],

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -16,6 +16,7 @@ mod types;
 
 pub use handlers::app;
 pub use types::{
-    AdminBackoff, AdminEvent, AdminJob, AdminMessage, AdminRetention, ClientMessage,
-    JobChangeStatus, JobWindow, ListName, ServerStatus,
+    AdminBackoff, AdminEvent, AdminJob, AdminMessage, AdminRetention, ClientMessage, Direction,
+    Fallback, FindAnchor, JobChangeStatus, JobWindow, ListName, SearchQuery, ServerStatus,
+    SubscribeAnchor,
 };

--- a/src/api/admin/types.rs
+++ b/src/api/admin/types.rs
@@ -53,22 +53,59 @@ pub enum AdminEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         job: Option<AdminJob>,
     },
+
+    /// Response to a `ClientMessage::Find` request.
+    ///
+    /// Carries the matched job's absolute position within the unfiltered
+    /// index at the moment the server walked, plus a `JobWindow` of
+    /// surrounding items so the dashboard can render the match's
+    /// neighbourhood without a follow-up `Subscribe`. Under
+    /// `Direction::Locate` a `matched_position: None` means the anchor
+    /// id no longer exists (job completed / requeued out) and the
+    /// dashboard should unpin.
+    FindResult {
+        list: ListName,
+        matched_position: Option<usize>,
+        window: JobWindow,
+    },
 }
 
-/// A windowed slice of jobs with offset metadata.
+/// A windowed slice of jobs centered on (or clamped near) an anchor.
+///
+/// The dashboard renders the job's row as `items[cursor_local_idx]`,
+/// where `cursor_local_idx` is derived by looking up its currently
+/// pinned job id inside `items`. Position is descriptive metadata,
+/// not the primary index: the client cursor lives in job-id space.
+///
+/// `first_position` and `total` power the depth-bar (they answer
+/// "where in the queue is the first item and how deep is the queue"),
+/// but the cursor does not use them.
+///
+/// `resolved_anchor` reflects whether the server found the requested
+/// `Around` anchor in the list at scan time:
+///
+/// - `Some(id)`: the anchor id is present; `items` is centered on it.
+/// - `None`: the anchor was requested but wasn't found — `items` was
+///   filled per the client's `fallback` (or is empty for `Nowhere`).
+///   The client should treat its previously-pinned cursor as lost.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobWindow {
-    pub offset: usize,
     pub items: Vec<AdminJob>,
+    pub first_position: usize,
+    pub total: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_anchor: Option<String>,
 }
 
 /// Client-to-server message for controlling subscriptions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClientMessage {
+    /// Ask the server for a window of jobs around an anchor. See
+    /// `SubscribeAnchor` for the anchor semantics.
     Subscribe {
         list: ListName,
-        offset: usize,
+        anchor: SubscribeAnchor,
         limit: usize,
     },
     SetDetailLevel {
@@ -80,6 +117,121 @@ pub enum ClientMessage {
     DeleteJob {
         id: String,
     },
+    /// Search for a job in one of the lists. Behaves like `less`'s `/`,
+    /// `n`, `N`: the server walks the appropriate in-memory index in
+    /// the requested `direction` starting from `anchor`, tests each
+    /// entry against `query`, and returns the first match — plus a
+    /// window of surrounding items so the dashboard can render the
+    /// match's neighbourhood without a second round-trip.
+    ///
+    /// Under `Direction::Locate` the server just resolves the anchor
+    /// id's current position and returns a window centered on it —
+    /// used by the dashboard to re-center on a pinned job that has
+    /// drifted out of the local buffer.
+    Find {
+        list: ListName,
+        anchor: FindAnchor,
+        direction: Direction,
+        #[serde(default)]
+        query: SearchQuery,
+        limit: usize,
+    },
+}
+
+/// Anchor point for a `Find` walk. The server resolves an anchor to
+/// an absolute position in the appropriate list's in-memory index
+/// (priority for `Ready`, `dequeued_at` for `InFlight`, `ready_at`
+/// for `Scheduled`), then walks from there.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FindAnchor {
+    /// Anchor at the current position of a specific job id. If the id
+    /// is not in the index, the walk falls back to `Start` (for
+    /// `Forward`) or `End` (for `Backward`), and `Locate` returns
+    /// `matched_position: None`.
+    JobId { id: String },
+    /// Walk from position 0.
+    Start,
+    /// Walk from the last position (`len - 1`).
+    End,
+}
+
+/// Direction of a `Find` walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Direction {
+    /// Skip the anchor, walk forward, return first match.
+    Forward,
+    /// Skip the anchor, walk backward, return first match.
+    Backward,
+    /// Return the anchor's current position. `query` is ignored.
+    /// Used by the dashboard's row-sticky follow when a pinned job
+    /// has drifted out of the local buffer.
+    Locate,
+}
+
+/// Predicate applied to each candidate during a `Find` walk. Empty
+/// vectors mean "no constraint on this dimension." Multiple values in
+/// a vector are OR'd; different fields are AND'd.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchQuery {
+    #[serde(default)]
+    pub queues: Vec<String>,
+    #[serde(default)]
+    pub types: Vec<String>,
+}
+
+/// Anchor of a `Subscribe` request.
+///
+/// The dashboard addresses jobs by their (stable) job id rather than
+/// by (drifting) numeric position: a queue shifts every time a worker
+/// takes the head job, so "position 500" points at a different job
+/// each round. `Around` scopes the returned window to the neighbourhood
+/// of a specific job so the client's cursor can stay pinned even as
+/// the queue churns underneath it. `Head` and `Tail` are natural
+/// starting anchors (e.g. `G` in `zizq top` sends `Tail`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SubscribeAnchor {
+    /// Follow a specific job id. Used by search / pin — the cursor
+    /// tracks a specific matched job as the queue churns around it.
+    Around {
+        id: String,
+        /// What the server should do when `id` is no longer in the
+        /// list. See `Fallback`.
+        #[serde(default)]
+        fallback: Fallback,
+    },
+    /// Numeric depth anchor. Used by arrow-key navigation and
+    /// paging: the cursor cares about being at depth N of the queue,
+    /// not about a specific job. The server clamps to
+    /// `max(0, total - limit)` when `offset >= total`, so under drain
+    /// the client always receives real tail items instead of an
+    /// empty window.
+    Offset {
+        offset: usize,
+    },
+    Head,
+    Tail,
+}
+
+/// Fallback behaviour for `SubscribeAnchor::Around` when the anchor
+/// id is not in the list at scan time.
+///
+/// - `Head`: return the head-most `limit` items. Used when the client
+///   was following the top of the list.
+/// - `Tail`: return the last `limit` items. Used when the client was
+///   following the bottom (e.g. after `G`).
+/// - `Nowhere`: return an empty window. Used when the client would
+///   prefer to render a "cursor lost" state and wait for the next
+///   navigation action rather than teleport somewhere unexpected.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Fallback {
+    Head,
+    Tail,
+    #[default]
+    Nowhere,
 }
 
 /// Which job list a subscription targets.

--- a/src/commands/top/app.rs
+++ b/src/commands/top/app.rs
@@ -3,12 +3,99 @@
 
 //! TUI application state model.
 
-use tokio::sync::mpsc;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
 
-use crate::api::admin::{AdminJob, JobChangeStatus, JobWindow, ServerStatus};
+use tokio::sync::mpsc;
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+use crate::api::admin::{
+    AdminJob, Direction, Fallback, FindAnchor, JobChangeStatus, JobWindow, ListName, SearchQuery,
+    ServerStatus, SubscribeAnchor,
+};
 use crate::license::Tier;
 
-use super::events::{self, Event};
+use super::events::{self, Event, InputModeFlag};
+
+/// Which of the two search prompt fields currently receives input.
+/// Type takes focus first — it's the more common initial filter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SearchField {
+    #[default]
+    Type,
+    Queue,
+}
+
+impl SearchField {
+    fn toggle(self) -> Self {
+        match self {
+            SearchField::Type => SearchField::Queue,
+            SearchField::Queue => SearchField::Type,
+        }
+    }
+}
+
+/// State of the `/` search prompt: two independent single-line input
+/// fields (Type and Queue) plus which one is currently focused. Enter
+/// combines both into a `SearchQuery`; Tab switches fields.
+#[derive(Clone, Default)]
+pub struct SearchPrompt {
+    pub type_input: Input,
+    pub queue_input: Input,
+    pub active: SearchField,
+}
+
+impl SearchPrompt {
+    pub fn active_input(&self) -> &Input {
+        match self.active {
+            SearchField::Type => &self.type_input,
+            SearchField::Queue => &self.queue_input,
+        }
+    }
+
+    fn active_input_mut(&mut self) -> &mut Input {
+        match self.active {
+            SearchField::Type => &mut self.type_input,
+            SearchField::Queue => &mut self.queue_input,
+        }
+    }
+
+    fn switch_field(&mut self) {
+        self.active = self.active.toggle();
+    }
+
+    /// Split a field's value on commas or whitespace into non-empty
+    /// tokens. Lets users filter by multiple queues or types from a
+    /// single field (e.g. `emails, billing`).
+    fn tokens(value: &str) -> Vec<String> {
+        value
+            .split(|c: char| c == ',' || c.is_whitespace())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    pub fn to_query(&self) -> SearchQuery {
+        SearchQuery {
+            queues: Self::tokens(self.queue_input.value()),
+            types: Self::tokens(self.type_input.value()),
+        }
+    }
+
+    /// Build a prompt pre-filled from a previously-submitted query.
+    /// Used when `/` is pressed with an active search so the user can
+    /// tweak the existing filters instead of retyping from scratch.
+    /// Multi-value fields are joined with `, ` (the same delimiter
+    /// `to_query` accepts on the way back in).
+    pub fn from_query(query: &SearchQuery) -> Self {
+        Self {
+            type_input: query.types.join(", ").into(),
+            queue_input: query.queues.join(", ").into(),
+            active: SearchField::default(),
+        }
+    }
+}
 
 /// Active tab in the TUI.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,31 +140,67 @@ pub enum ConnectionStatus {
 }
 
 /// Per-list scroll and buffering state.
+///
+/// Hybrid model: the *authoritative* cursor is `cursor_id` (a job id),
+/// but a numeric mirror (`cursor`) is derived from it on each buffer
+/// update. Scroll math still works numerically — moves compute a
+/// new numeric position, look up the id at that position, and re-pin
+/// `cursor_id`. When the queue churns underneath us, `cursor_id`
+/// stays anchored to the same *job*; on the next diff/snapshot we
+/// recompute the numeric `cursor` from wherever that job now sits.
+/// If the job leaves the buffer entirely we fire a `Find { Locate }`
+/// to relocate — same mechanism as the pinned-search path.
 #[derive(Clone)]
 pub struct ListState {
-    /// Selected row index in the full (server-side) list.
+    /// Job id of the selected row — authoritative. `None` when there
+    /// is no selection (empty list or transient "cursor lost" state).
+    pub cursor_id: Option<String>,
+    /// Numeric mirror of `cursor_id`, re-derived on every buffer
+    /// update. Kept for the existing scroll math + rendering paths.
     pub cursor: usize,
-    /// First visible row in the viewport.
+    /// First visible row in the viewport (numeric position).
     pub scroll_pos: usize,
-    /// Offset of buffered data from server.
+    /// Position of `items[0]` in the underlying sorted list, as of
+    /// the last received `JobWindow`. Zero when there is no buffer.
     pub buffer_offset: usize,
-    /// Whether the cursor should follow the bottom of the list.
+    /// Total items in the list, as of the last received `JobWindow`.
+    /// Server's `ServerStatus.total_*` counters are the same value in
+    /// steady state but land via a different code path.
+    pub total: usize,
+    /// Whether the cursor should track the bottom of the list.
     pub follow_bottom: bool,
-    /// Last subscribe (offset, limit) sent — used to avoid duplicate requests.
-    last_subscribe: Option<(usize, usize)>,
+    /// Last `(SubscribeAnchor, limit)` sent — used to avoid duplicate
+    /// requests when `maybe_prefetch` fires repeatedly on the same
+    /// underlying state.
+    last_subscribe: Option<(SubscribeAnchor, usize)>,
+    /// When the last `maybe_prefetch` subscribe was sent for this tab.
+    /// Used to rate-limit prefetches so held-down arrow keys and
+    /// drain-driven `JobChanged` bursts don't spam the server with
+    /// near-identical subscribes at key-repeat / event-arrival cadence.
+    last_prefetch_at: Option<Instant>,
 }
 
 impl Default for ListState {
     fn default() -> Self {
         Self {
+            cursor_id: None,
             cursor: 0,
             scroll_pos: 0,
             buffer_offset: 0,
+            total: 0,
             follow_bottom: false,
             last_subscribe: None,
+            last_prefetch_at: None,
         }
     }
 }
+
+/// Minimum interval between prefetch subscribes for a single tab.
+/// The key-based dedup handles held-down arrows while the cursor is
+/// stuck at the buffer edge, but once responses start arriving (or
+/// drain events start eating into the buffer) the anchor moves and
+/// dedup no longer helps. This throttle covers those cases.
+const PREFETCH_MIN_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Top-level application state for the TUI.
 pub struct App {
@@ -109,6 +232,28 @@ pub struct App {
     /// is restricted to confirming (`y`) or cancelling (`n` / Esc / `q`).
     pub pending_delete: Option<String>,
     pub ws_tx: Option<mpsc::Sender<String>>,
+    /// Current search state:
+    /// - `search_input`: `Some(text)` while the `/` prompt is open,
+    ///   holding the in-progress query string.
+    /// - `search_query`: the last query submitted, remembered so `n`
+    ///   and `N` can step through subsequent matches.
+    /// - `pinned_job_id`: id of the job the cursor is following. When
+    ///   set, the cursor tracks this specific job's row wherever it
+    ///   moves in the list; on each buffer update we re-locate its
+    ///   local index. Cleared when the user presses Esc, when the
+    ///   server reports the job no longer exists, or when the user
+    ///   opens a fresh search.
+    pub search_input: Option<SearchPrompt>,
+    pub search_query: Option<SearchQuery>,
+    pub pinned_job_id: Option<String>,
+    /// True while a `Locate` request for the pinned job is in flight —
+    /// suppresses duplicate follow-up requests when a burst of
+    /// `JobChanged` events lands before the response.
+    pub pinned_locate_pending: bool,
+    /// Shared with the terminal input reader — set while the search
+    /// prompt is open so the reader forwards raw characters instead
+    /// of interpreting shortcut keys.
+    pub search_mode_flag: Option<InputModeFlag>,
 }
 
 impl Clone for App {
@@ -135,6 +280,11 @@ impl Clone for App {
             paused: self.paused,
             pending_delete: self.pending_delete.clone(),
             ws_tx: self.ws_tx.clone(),
+            search_input: self.search_input.clone(),
+            search_query: self.search_query.clone(),
+            pinned_job_id: self.pinned_job_id.clone(),
+            pinned_locate_pending: self.pinned_locate_pending,
+            search_mode_flag: self.search_mode_flag.clone(),
         }
     }
 }
@@ -163,11 +313,26 @@ impl App {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         }
     }
 
     pub fn set_ws_tx(&mut self, tx: mpsc::Sender<String>) {
         self.ws_tx = Some(tx);
+    }
+
+    pub fn set_search_mode_flag(&mut self, flag: InputModeFlag) {
+        self.search_mode_flag = Some(flag);
+    }
+
+    fn set_search_mode(&self, on: bool) {
+        if let Some(flag) = &self.search_mode_flag {
+            flag.store(on, Ordering::Release);
+        }
     }
 
     /// Get the total count for the active tab.
@@ -188,16 +353,16 @@ impl App {
         }
     }
 
-    /// Send a subscribe message over WebSocket.
-    fn send_subscribe(&self, tab: Tab, offset: usize, limit: usize) {
+    /// Send a subscribe message over WebSocket with the given anchor.
+    fn send_subscribe(&self, tab: Tab, anchor: SubscribeAnchor, limit: usize) {
         if let Some(tx) = &self.ws_tx {
-            let msg = events::subscribe_message(tab.list_name(), offset, limit);
+            let msg = events::subscribe_message(tab.list_name(), anchor, limit);
             let _ = tx.try_send(msg);
         }
     }
 
-    /// Re-subscribe all tabs with a window sized to the current viewport.
-    /// Called when the terminal is resized.
+    /// Re-subscribe all tabs with a fresh window centered on each
+    /// tab's cursor. Called when the terminal is resized.
     pub fn resubscribe_all(&mut self) {
         if self.subscription_limit.is_some() {
             return;
@@ -208,25 +373,49 @@ impl App {
         }
         let limit = vh * 3;
         for tab in [Tab::InFlight, Tab::Ready, Tab::Scheduled] {
-            let ls = &mut self.list_states[tab.idx()];
-            let offset = ls.cursor.saturating_sub(limit / 2);
-            ls.last_subscribe = Some((offset, limit));
-            if let Some(tx) = &self.ws_tx {
-                let msg = events::subscribe_message(tab.list_name(), offset, limit);
-                let _ = tx.try_send(msg);
-            }
+            let anchor = self.anchor_for_prefetch(tab);
+            self.list_states[tab.idx()].last_subscribe = Some((anchor.clone(), limit));
+            self.send_subscribe(tab, anchor, limit);
         }
     }
 
+    /// Choose the anchor to use for a `Subscribe` prefetch on `tab`.
+    ///
+    /// Two navigation intents map to two anchor kinds:
+    ///
+    /// - **Pinned / following a specific job** (search, `n`/`N`): use
+    ///   `Around(pinned_id, Nowhere)` so the cursor tracks that job as
+    ///   the queue churns. If the job has been processed the server
+    ///   returns an empty window and the client unpins.
+    /// - **Depth-based navigation** (arrow keys, page down, plain
+    ///   scrolling): use `Offset(cursor_depth - vh)` so the returned
+    ///   window sits roughly around the cursor's current depth. Under
+    ///   drain the server clamps to the current tail rather than
+    ///   returning an empty window — no dead space, no teleporting
+    ///   to Head because a specific job vanished.
+    ///
+    /// `G` and `g` are handled outside this helper: they send `Tail`
+    /// and `Head` directly.
+    fn anchor_for_prefetch(&self, tab: Tab) -> SubscribeAnchor {
+        if let Some(id) = &self.pinned_job_id {
+            return SubscribeAnchor::Around {
+                id: id.clone(),
+                fallback: Fallback::Nowhere,
+            };
+        }
+        let ls = &self.list_states[tab.idx()];
+        // Center the requested window on the cursor's depth.
+        let half = self.viewport_height.saturating_mul(3) / 2;
+        let offset = ls.cursor.saturating_sub(half);
+        SubscribeAnchor::Offset { offset }
+    }
+
     /// Check if prefetch is needed and send subscribe if so.
-    /// Deduplicates: won't re-send the same (offset, limit) for the same tab.
+    /// Deduplicates: won't re-send the same anchor + limit for the same tab.
     fn maybe_prefetch(&mut self) {
         if self.subscription_limit.is_some() {
             return;
         }
-        // While paused the visible buffer is intentionally frozen — no
-        // prefetching, so scrolling clamps at whatever rows were already
-        // present at the moment of pause.
         if self.paused {
             return;
         }
@@ -243,21 +432,39 @@ impl App {
         };
         let buffer_end = ls.buffer_offset + buffer_size;
 
-        // Prefetch when cursor is within one viewport of buffer edges.
+        // Prefetch when cursor is within one viewport of a buffer edge
+        // *and* there are more items to fetch in that direction.
         let near_top = ls.cursor < ls.buffer_offset + vh;
         let near_bottom = ls.cursor + vh >= buffer_end;
+        let needs_top = near_top && ls.buffer_offset > 0;
+        let needs_bottom = near_bottom && buffer_end < self.active_total();
 
-        if (near_top && ls.buffer_offset > 0) || (near_bottom && buffer_end < self.active_total()) {
-            let new_limit = vh * 3;
-            let new_offset = ls.cursor.saturating_sub(new_limit / 2);
-            let key = (new_offset, new_limit);
-
-            if self.list_states[tab.idx()].last_subscribe == Some(key) {
-                return;
-            }
-            self.list_states[tab.idx()].last_subscribe = Some(key);
-            self.send_subscribe(tab, new_offset, new_limit);
+        if !(needs_top || needs_bottom) {
+            return;
         }
+
+        let new_limit = vh * 3;
+        let anchor = self.anchor_for_prefetch(tab);
+        let key = (anchor.clone(), new_limit);
+        if self.list_states[tab.idx()].last_subscribe == Some(key.clone()) {
+            return;
+        }
+        // Time-based throttle: even when the anchor has shifted (held
+        // arrow key, or drain events chewing the buffer edge), don't
+        // fire more than one prefetch per `PREFETCH_MIN_INTERVAL`. The
+        // skipped subscribe isn't queued — the next `maybe_prefetch`
+        // call after the window elapses will recompute with the
+        // current cursor and send a fresh, up-to-date anchor.
+        let now = Instant::now();
+        if let Some(last) = self.list_states[tab.idx()].last_prefetch_at
+            && now.duration_since(last) < PREFETCH_MIN_INTERVAL
+        {
+            return;
+        }
+        let ls = &mut self.list_states[tab.idx()];
+        ls.last_subscribe = Some(key);
+        ls.last_prefetch_at = Some(now);
+        self.send_subscribe(tab, anchor, new_limit);
     }
 
     /// Send the current detail level to the server.
@@ -266,6 +473,89 @@ impl App {
             let msg = events::detail_level_message(self.show_detail);
             let _ = tx.try_send(msg);
         }
+    }
+
+    /// Send a `Find` over the WebSocket. `limit` is derived from the
+    /// current viewport so the returned window fills the visible area.
+    fn send_find(&self, tab: Tab, anchor: FindAnchor, direction: Direction, query: SearchQuery) {
+        let Some(tx) = &self.ws_tx else {
+            return;
+        };
+        let limit = if self.viewport_height > 0 {
+            self.viewport_height * 3
+        } else {
+            60
+        };
+        let msg = events::find_message(tab.list_name(), anchor, direction, query, limit);
+        let _ = tx.try_send(msg);
+    }
+
+    /// Anchor to use for a fresh `/` search, and the fallback anchor
+    /// for `n`/`N` when there's no pin.
+    ///
+    /// Prefers the cursor row's job id — so `/` and `n` continue the
+    /// walk forward from wherever the user's eye is, rather than
+    /// snapping back to the top of the list. This is what makes
+    /// `scroll down → n` feel natural instead of jarring.
+    ///
+    /// Falls back to `Start` when the cursor row's id isn't known —
+    /// initial launch (no data / no scroll yet) and after `g`. That
+    /// last case is the escape hatch: `g` then `n` searches from the
+    /// beginning of the list.
+    fn anchor_for_initial_search(&self) -> FindAnchor {
+        if let Some(id) = &self.list_states[self.active_tab.idx()].cursor_id {
+            return FindAnchor::JobId { id: id.clone() };
+        }
+        FindAnchor::Start
+    }
+
+    /// Anchor to use for `n`/`N` stepping: the pinned job (so we skip
+    /// it), falling back to the cursor's row if the pin is missing.
+    fn anchor_for_step(&self) -> FindAnchor {
+        if let Some(id) = &self.pinned_job_id {
+            return FindAnchor::JobId { id: id.clone() };
+        }
+        self.anchor_for_initial_search()
+    }
+
+    /// Re-anchor the cursor to the currently pinned job (if any). Called
+    /// after any buffer mutation (JobSnapshot, JobChanged) so the
+    /// cursor "follows" the pinned row as the queue churns around it.
+    ///
+    /// If the pinned job is in the local buffer, we simply update the
+    /// cursor's numeric position to its current local index. If it's
+    /// no longer in the buffer, we ask the server to `Locate` it and
+    /// send back a fresh window centered on it — cursor and buffer
+    /// re-anchor when that response arrives. The `Locate` request is
+    /// gated by `pinned_locate_pending` so we don't spam duplicate
+    /// requests while one is already in flight.
+    fn follow_pinned_job(&mut self) {
+        let Some(pinned) = self.pinned_job_id.clone() else {
+            return;
+        };
+        let tab = self.active_tab;
+        let jobs = match tab {
+            Tab::Ready => &self.ready_jobs,
+            Tab::InFlight => &self.in_flight_jobs,
+            Tab::Scheduled => &self.scheduled_jobs,
+        };
+        let buffer_offset = self.list_states[tab.idx()].buffer_offset;
+        if let Some(local) = jobs.iter().position(|j| j.id == pinned) {
+            let ls = &mut self.list_states[tab.idx()];
+            ls.cursor = buffer_offset + local;
+            return;
+        }
+        // Pinned job left the buffer — ask the server where it is now.
+        if self.pinned_locate_pending {
+            return;
+        }
+        self.pinned_locate_pending = true;
+        self.send_find(
+            tab,
+            FindAnchor::JobId { id: pinned },
+            Direction::Locate,
+            SearchQuery::default(),
+        );
     }
 
     /// Return the id of the job under the cursor in the active tab,
@@ -331,6 +621,42 @@ impl App {
             return false;
         }
 
+        // Same gating pattern for the `/` search prompt.
+        if self.search_input.is_some() {
+            match event {
+                Event::SearchKey(key) => {
+                    if let Some(prompt) = self.search_input.as_mut() {
+                        prompt
+                            .active_input_mut()
+                            .handle_event(&crossterm::event::Event::Key(key));
+                    }
+                }
+                Event::SearchFieldSwitch => {
+                    if let Some(prompt) = self.search_input.as_mut() {
+                        prompt.switch_field();
+                    }
+                }
+                Event::SearchSubmit => {
+                    let prompt = self.search_input.take().unwrap_or_default();
+                    self.set_search_mode(false);
+                    let query = prompt.to_query();
+                    self.search_query = Some(query.clone());
+                    self.send_find(
+                        self.active_tab,
+                        self.anchor_for_initial_search(),
+                        Direction::Forward,
+                        query,
+                    );
+                }
+                Event::SearchCancel | Event::Quit => {
+                    self.search_input = None;
+                    self.set_search_mode(false);
+                }
+                _ => {}
+            }
+            return false;
+        }
+
         match event {
             Event::Quit => return true,
             Event::NextTab => {
@@ -382,6 +708,48 @@ impl App {
             // Outside of an active prompt these are no-ops — the prompt
             // path above is the only thing that interprets them.
             Event::ConfirmDelete | Event::CancelDelete => {}
+            Event::SearchOpen => {
+                // Prefill from the currently-active query if there is
+                // one — lets the user tweak an existing filter instead
+                // of retyping. A fresh prompt (no prior query) starts
+                // empty.
+                self.search_input = Some(
+                    self.search_query
+                        .as_ref()
+                        .map(SearchPrompt::from_query)
+                        .unwrap_or_default(),
+                );
+                self.set_search_mode(true);
+            }
+            // Outside the search prompt these are no-ops; the prompt
+            // path above interprets them.
+            Event::SearchKey(_)
+            | Event::SearchFieldSwitch
+            | Event::SearchSubmit
+            | Event::SearchCancel => {}
+            Event::SearchNext => {
+                if let Some(query) = self.search_query.clone() {
+                    self.send_find(
+                        self.active_tab,
+                        self.anchor_for_step(),
+                        Direction::Forward,
+                        query,
+                    );
+                }
+            }
+            Event::SearchPrev => {
+                if let Some(query) = self.search_query.clone() {
+                    self.send_find(
+                        self.active_tab,
+                        self.anchor_for_step(),
+                        Direction::Backward,
+                        query,
+                    );
+                }
+            }
+            Event::Unpin => {
+                self.pinned_job_id = None;
+            }
             Event::TogglePause => {
                 self.paused = !self.paused;
                 if !self.paused {
@@ -390,12 +758,12 @@ impl App {
                     // on next prefetch or when they become active.
                     let tab = self.active_tab;
                     let ls = &self.list_states[tab.idx()];
-                    if let Some((offset, limit)) = ls.last_subscribe {
-                        self.send_subscribe(tab, offset, limit);
+                    if let Some((anchor, limit)) = ls.last_subscribe.clone() {
+                        self.send_subscribe(tab, anchor, limit);
                     } else if self.viewport_height > 0 {
                         let limit = self.viewport_height * 3;
-                        let offset = ls.cursor.saturating_sub(limit / 2);
-                        self.send_subscribe(tab, offset, limit);
+                        let anchor = self.anchor_for_prefetch(tab);
+                        self.send_subscribe(tab, anchor, limit);
                     }
                 }
             }
@@ -435,6 +803,7 @@ impl App {
                 self.apply_job_window(Tab::InFlight, in_flight);
                 self.apply_job_window(Tab::Scheduled, scheduled);
                 self.apply_follow_bottom();
+                self.follow_pinned_job();
                 // A snapshot can land with an offset that pre-dates rapid
                 // server-side churn (jobs were enqueued/drained while the
                 // Subscribe was in flight), leaving the cursor outside the
@@ -502,9 +871,57 @@ impl App {
                     }
                 }
                 self.apply_follow_bottom();
+                self.follow_pinned_job();
                 // Each JobChanged can move the follow-bottom cursor; same
                 // reasoning as the snapshot/heartbeat paths.
                 self.maybe_prefetch();
+            }
+            Event::ServerFindResult {
+                server,
+                list,
+                matched_position,
+                window,
+            } => {
+                self.apply_server_status(server);
+                // Any FindResult clears the "waiting for locate" gate —
+                // even a `None` (job gone), since we treat that as an
+                // authoritative unpin below.
+                self.pinned_locate_pending = false;
+                if self.paused {
+                    return false;
+                }
+                let tab = match list {
+                    ListName::Ready => Tab::Ready,
+                    ListName::InFlight => Tab::InFlight,
+                    ListName::Scheduled => Tab::Scheduled,
+                };
+                match matched_position {
+                    Some(pos) => {
+                        // The matched job id is whatever sits at the
+                        // matched position within the returned window.
+                        let local = pos.saturating_sub(window.first_position);
+                        let matched_id = window.items.get(local).map(|j| j.id.clone());
+                        // Pin the cursor to the match itself, then
+                        // apply the window — `sync_cursor_from_id`
+                        // will land the numeric cursor on it.
+                        self.pinned_job_id = matched_id.clone();
+                        self.list_states[tab.idx()].cursor_id = matched_id;
+                        self.list_states[tab.idx()].follow_bottom = false;
+                        self.apply_job_window(tab, window);
+                        if self.viewport_height > 0 {
+                            let ls = &mut self.list_states[tab.idx()];
+                            let half = self.viewport_height / 2;
+                            ls.scroll_pos = ls.cursor.saturating_sub(half);
+                        }
+                        self.active_tab = tab;
+                    }
+                    None => {
+                        // No match found, or Locate returned "anchor
+                        // gone." Either way, drop the pin so the user
+                        // isn't chasing a ghost.
+                        self.pinned_job_id = None;
+                    }
+                }
             }
             Event::ServerDisconnected => {
                 self.status = ConnectionStatus::Disconnected;
@@ -527,15 +944,55 @@ impl App {
         false
     }
 
-    /// Apply a JobWindow snapshot to the corresponding list.
+    /// Apply a JobWindow snapshot to the corresponding list. Updates
+    /// buffer, `first_position`, and `total`; re-derives the numeric
+    /// `cursor` from the (authoritative) `cursor_id` so drift under
+    /// churn resolves.
     fn apply_job_window(&mut self, tab: Tab, window: JobWindow) {
         let ls = &mut self.list_states[tab.idx()];
-        ls.buffer_offset = window.offset;
-        ls.last_subscribe = None; // Allow new prefetch after data arrives.
+        ls.buffer_offset = window.first_position;
+        ls.total = window.total;
+        ls.last_subscribe = None;
+        // Response landed — reopen the prefetch throttle. The rate
+        // limit exists to prevent spam *within* the request/response
+        // cycle; the natural round-trip cadence is our real ceiling.
+        ls.last_prefetch_at = None;
         match tab {
             Tab::Ready => self.ready_jobs = window.items,
             Tab::InFlight => self.in_flight_jobs = window.items,
             Tab::Scheduled => self.scheduled_jobs = window.items,
+        }
+        self.sync_cursor_from_id(tab);
+    }
+
+    /// Sync the numeric cursor to `pinned_job_id`'s current position
+    /// in the buffer — but **only** when the user has actively pinned
+    /// via search (`/`, `n`, `N`).
+    ///
+    /// For plain scroll navigation the cursor is a numeric *depth*
+    /// that should stay put when the buffer's contents shift
+    /// underneath. Vim's model: cursor sits at row N of the viewport,
+    /// row N's content may change as items shift, but the cursor row
+    /// itself doesn't move. Pulling the cursor onto a specific job
+    /// every buffer update is what makes it appear to "jump around"
+    /// under heavy churn.
+    ///
+    /// `follow_bottom` (from `G`) is handled by `apply_follow_bottom`
+    /// clamping the numeric cursor to `total - 1` — no id chase
+    /// needed there either.
+    fn sync_cursor_from_id(&mut self, tab: Tab) {
+        let Some(id) = self.pinned_job_id.clone() else {
+            return;
+        };
+        let buf: &[AdminJob] = match tab {
+            Tab::Ready => &self.ready_jobs,
+            Tab::InFlight => &self.in_flight_jobs,
+            Tab::Scheduled => &self.scheduled_jobs,
+        };
+        if let Some(local) = buf.iter().position(|j| j.id == id) {
+            let ls = &mut self.list_states[tab.idx()];
+            ls.cursor = ls.buffer_offset + local;
+            ls.cursor_id = Some(id);
         }
     }
 
@@ -546,13 +1003,6 @@ impl App {
     /// scroll through the frozen snapshot. Returns `None` when there's
     /// nothing to navigate.
     fn cursor_bounds(&self) -> Option<(usize, usize)> {
-        if !self.paused {
-            let total = self.effective_total();
-            if total == 0 {
-                return None;
-            }
-            return Some((0, total - 1));
-        }
         let tab = self.active_tab;
         let ls = &self.list_states[tab.idx()];
         let buffer_size = match tab {
@@ -563,7 +1013,22 @@ impl App {
         if buffer_size == 0 {
             return None;
         }
-        Some((ls.buffer_offset, ls.buffer_offset + buffer_size - 1))
+        let buffer_lo = ls.buffer_offset;
+        let buffer_hi = ls.buffer_offset + buffer_size - 1;
+        if self.paused {
+            return Some((buffer_lo, buffer_hi));
+        }
+        // Live: the cursor is bounded by (a) what exists on the server
+        // and (b) what we currently have in the buffer. Scrolling past
+        // the buffered range would render empty rows until the prefetch
+        // response arrives; instead we clamp here, fire the prefetch,
+        // and let the cursor advance once the new items are in hand.
+        let total = self.effective_total();
+        if total == 0 {
+            return None;
+        }
+        let max = (total - 1).min(buffer_hi);
+        Some((buffer_lo, max))
     }
 
     /// Clamp cursor/scroll positions and apply follow-bottom tracking.
@@ -585,6 +1050,11 @@ impl App {
                 Some(c) => raw_total.min(c),
                 None => raw_total,
             };
+            let buffer_size = match tab {
+                Tab::Ready => self.ready_jobs.len(),
+                Tab::InFlight => self.in_flight_jobs.len(),
+                Tab::Scheduled => self.scheduled_jobs.len(),
+            };
             let ls = &mut self.list_states[tab.idx()];
 
             if total == 0 {
@@ -592,6 +1062,10 @@ impl App {
                 ls.scroll_pos = 0;
                 continue;
             }
+
+            // Remember the pre-clamp viewport row so we can preserve it
+            // if we end up dragging the cursor upward below.
+            let prev_visual_row = ls.cursor.saturating_sub(ls.scroll_pos);
 
             // Follow-bottom: stick cursor to end.
             if ls.follow_bottom {
@@ -603,9 +1077,44 @@ impl App {
                 ls.cursor = total - 1;
             }
 
-            // Clamp scroll_pos so cursor stays visible.
+            // Clamp cursor to the buffered range too: parking on an
+            // unloaded row would render empties until the prefetch
+            // response arrives. Keep the cursor at the buffer edge and
+            // let it advance once the new items land.
+            let buffer_hi = ls.buffer_offset + buffer_size;
+            let cursor_was_clamped_down = buffer_size > 0 && ls.cursor >= buffer_hi;
+            if cursor_was_clamped_down {
+                ls.cursor = buffer_hi - 1;
+            }
+
+            // Position the viewport so the cursor is visible.
+            //
+            // Under follow-bottom we always park the cursor at the
+            // last viewport row: as `total` shrinks (queue drains),
+            // this keeps the tail rows visible above the cursor
+            // instead of leaving a screenful of blank space below it
+            // (which is what happens if we naively pin `scroll_pos`
+            // to the cursor's numeric value).
+            //
+            // When we've had to drag the cursor upward because the
+            // buffer's tail was chewed away by JobChanged removals,
+            // keep the cursor at the same viewport row it was on
+            // before — otherwise the highlighted row visibly "jumps
+            // up" every time the buffer shrinks. `scroll_pos` slides
+            // up in lockstep with the cursor so the visual row is
+            // preserved.
+            //
+            // Otherwise we just clamp `scroll_pos` around the cursor
+            // in the usual bidirectional way.
             if self.viewport_height > 0 {
-                if ls.cursor < ls.scroll_pos {
+                if ls.follow_bottom {
+                    ls.scroll_pos = ls.cursor.saturating_sub(self.viewport_height - 1);
+                } else if cursor_was_clamped_down {
+                    ls.scroll_pos = ls
+                        .cursor
+                        .saturating_sub(prev_visual_row)
+                        .max(ls.buffer_offset);
+                } else if ls.cursor < ls.scroll_pos {
                     ls.scroll_pos = ls.cursor;
                 } else if ls.cursor >= ls.scroll_pos + self.viewport_height {
                     ls.scroll_pos = ls.cursor - self.viewport_height + 1;
@@ -614,7 +1123,33 @@ impl App {
         }
     }
 
+    /// Release a search pin. Called at the start of every explicit
+    /// navigation action so `follow_pinned_job` doesn't drag the
+    /// cursor back to the pinned row on the next tick.
+    fn release_pin(&mut self) {
+        self.pinned_job_id = None;
+        self.pinned_locate_pending = false;
+    }
+
+    /// Sync `cursor_id` to whichever row currently sits under the
+    /// numeric cursor. Called at the end of every explicit scroll so
+    /// a subsequent buffer refresh doesn't drag the cursor back to
+    /// whatever `cursor_id` was left over from a prior search — that
+    /// would produce the "snap back to the pinned row" bug when
+    /// scrolling past the buffer edge.
+    fn refresh_cursor_id_from_position(&mut self, tab: Tab) {
+        let ls = &mut self.list_states[tab.idx()];
+        let buf: &[AdminJob] = match tab {
+            Tab::Ready => &self.ready_jobs,
+            Tab::InFlight => &self.in_flight_jobs,
+            Tab::Scheduled => &self.scheduled_jobs,
+        };
+        let local = ls.cursor.checked_sub(ls.buffer_offset);
+        ls.cursor_id = local.and_then(|i| buf.get(i)).map(|j| j.id.clone());
+    }
+
     fn scroll_up(&mut self) {
+        self.release_pin();
         let Some((min, _)) = self.cursor_bounds() else {
             return;
         };
@@ -626,13 +1161,17 @@ impl App {
             ls.scroll_pos = ls.cursor;
         }
         ls.follow_bottom = false;
+        let tab = self.active_tab;
+        self.refresh_cursor_id_from_position(tab);
         self.maybe_prefetch();
     }
 
     fn scroll_down(&mut self) {
+        self.release_pin();
         let Some((_, max)) = self.cursor_bounds() else {
             return;
         };
+        let total = self.effective_total();
         let ls = &mut self.list_states[self.active_tab.idx()];
         if ls.cursor < max {
             ls.cursor += 1;
@@ -640,13 +1179,18 @@ impl App {
         if self.viewport_height > 0 && ls.cursor >= ls.scroll_pos + self.viewport_height {
             ls.scroll_pos = ls.cursor - self.viewport_height + 1;
         }
-        // `follow_bottom` only makes sense while live — paused scrolling
-        // never wants the cursor pulled toward the server-side bottom.
-        ls.follow_bottom = !self.paused && ls.cursor == max;
+        // `follow_bottom` only makes sense while live and only when
+        // the cursor has genuinely reached the server-side tail —
+        // stopping at the buffer edge because prefetch hasn't landed
+        // yet shouldn't turn on follow-bottom mid-list.
+        ls.follow_bottom = !self.paused && total > 0 && ls.cursor == total - 1;
+        let tab = self.active_tab;
+        self.refresh_cursor_id_from_position(tab);
         self.maybe_prefetch();
     }
 
     fn page_up(&mut self) {
+        self.release_pin();
         let Some((min, _)) = self.cursor_bounds() else {
             return;
         };
@@ -660,27 +1204,34 @@ impl App {
             ls.scroll_pos = ls.cursor;
         }
         ls.follow_bottom = false;
+        let tab = self.active_tab;
+        self.refresh_cursor_id_from_position(tab);
         self.maybe_prefetch();
     }
 
     fn page_down(&mut self) {
+        self.release_pin();
         let Some((_, max)) = self.cursor_bounds() else {
             return;
         };
         if self.viewport_height == 0 {
             return;
         }
+        let total = self.effective_total();
         let ls = &mut self.list_states[self.active_tab.idx()];
         let jump = self.viewport_height.saturating_sub(1).max(1);
         ls.cursor = (ls.cursor + jump).min(max);
         if ls.cursor >= ls.scroll_pos + self.viewport_height {
             ls.scroll_pos = ls.cursor - self.viewport_height + 1;
         }
-        ls.follow_bottom = !self.paused && ls.cursor == max;
+        ls.follow_bottom = !self.paused && total > 0 && ls.cursor == total - 1;
+        let tab = self.active_tab;
+        self.refresh_cursor_id_from_position(tab);
         self.maybe_prefetch();
     }
 
     fn go_to_start(&mut self) {
+        self.release_pin();
         let Some((min, _)) = self.cursor_bounds() else {
             return;
         };
@@ -688,10 +1239,19 @@ impl App {
         ls.cursor = min;
         ls.scroll_pos = min;
         ls.follow_bottom = false;
-        self.maybe_prefetch();
+        // Clear cursor_id so sync_cursor_from_id derives it from the
+        // freshly-arriving Head window rather than trying to preserve
+        // whatever the cursor was on before.
+        ls.cursor_id = None;
+        let tab = self.active_tab;
+        let limit = self.viewport_height.saturating_mul(3).max(1);
+        // `g` explicitly asks for the head, not a depth-anchored
+        // window. Bypass the usual `anchor_for_prefetch` heuristic.
+        self.send_subscribe(tab, SubscribeAnchor::Head, limit);
     }
 
     fn go_to_end(&mut self) {
+        self.release_pin();
         let Some((_, max)) = self.cursor_bounds() else {
             return;
         };
@@ -703,7 +1263,15 @@ impl App {
             ls.scroll_pos = 0;
         }
         ls.follow_bottom = !self.paused;
-        self.maybe_prefetch();
+        // Clear cursor_id — sync_cursor_from_id will re-derive it
+        // (from `buf.last()` since follow_bottom is set).
+        ls.cursor_id = None;
+        let tab = self.active_tab;
+        let limit = self.viewport_height.saturating_mul(3).max(1);
+        // `G` explicitly asks for the tail. Under drain, subsequent
+        // `maybe_prefetch` calls will use `Offset(cursor - vh)` and
+        // clamp naturally.
+        self.send_subscribe(tab, SubscribeAnchor::Tail, limit);
     }
 }
 
@@ -815,16 +1383,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: default_server(),
             ready: JobWindow {
-                offset: 0,
                 items: vec![job("r1", 0, None)],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![job("w1", 0, Some(100))],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![job("s1", 0, None)],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1145,16 +1719,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv.clone(),
             ready: JobWindow {
-                offset: 100,
                 items: (100..160).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+                first_position: 100,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
         app.handle_event(Event::GoToEnd);
@@ -1169,16 +1749,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv,
             ready: JobWindow {
-                offset: 969,
                 items: vec![],
+                first_position: 969,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1238,16 +1824,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv,
             ready: JobWindow {
-                offset: 0,
                 items: vec![job("snap", 0, None)],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1286,16 +1878,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv,
             ready: JobWindow {
-                offset: 100,
                 items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+                first_position: 100,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1322,16 +1920,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv,
             ready: JobWindow {
-                offset: 100,
                 items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+                first_position: 100,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1354,16 +1958,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv,
             ready: JobWindow {
-                offset: 100,
                 items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+                first_position: 100,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1391,16 +2001,22 @@ mod tests {
         app.handle_event(Event::ServerJobSnapshot {
             server: srv.clone(),
             ready: JobWindow {
-                offset: 100,
                 items: (100..120).map(|i| job(&format!("j{i}"), 0, None)).collect(),
+                first_position: 100,
+                total: 0,
+                resolved_anchor: None,
             },
             in_flight: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
             scheduled: JobWindow {
-                offset: 0,
                 items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
             },
         });
 
@@ -1532,5 +2148,239 @@ mod tests {
             app.pending_delete.is_some(),
             "prompt should still be pending"
         );
+    }
+
+    // ── SearchPrompt.to_query ─────────────────────────────────────
+
+    #[test]
+    fn search_prompt_empty_is_empty_query() {
+        let prompt = SearchPrompt::default();
+        let q = prompt.to_query();
+        assert!(q.queues.is_empty());
+        assert!(q.types.is_empty());
+    }
+
+    #[test]
+    fn search_prompt_queue_and_type_from_fields() {
+        let mut prompt = SearchPrompt::default();
+        prompt.type_input = "send_welcome".into();
+        prompt.queue_input = "emails".into();
+        let q = prompt.to_query();
+        assert_eq!(q.queues, vec!["emails".to_string()]);
+        assert_eq!(q.types, vec!["send_welcome".to_string()]);
+    }
+
+    #[test]
+    fn search_prompt_splits_on_comma_and_whitespace() {
+        let mut prompt = SearchPrompt::default();
+        prompt.queue_input = "emails, billing  reports".into();
+        let q = prompt.to_query();
+        assert_eq!(
+            q.queues,
+            vec![
+                "emails".to_string(),
+                "billing".to_string(),
+                "reports".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn search_prompt_ignores_empty_tokens() {
+        let mut prompt = SearchPrompt::default();
+        prompt.type_input = " , ,send, ".into();
+        let q = prompt.to_query();
+        assert_eq!(q.types, vec!["send".to_string()]);
+    }
+
+    // ── search flow end-to-end ────────────────────────────────────
+
+    fn search_char_key(c: char) -> crossterm::event::KeyEvent {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn search_open_sets_input_state() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::SearchOpen);
+        assert!(app.search_input.is_some());
+    }
+
+    #[test]
+    fn search_cancel_clears_input_without_running_search() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::SearchOpen);
+        for c in "abc".chars() {
+            app.handle_event(Event::SearchKey(search_char_key(c)));
+        }
+        app.handle_event(Event::SearchCancel);
+        assert!(app.search_input.is_none());
+        assert!(app.search_query.is_none());
+    }
+
+    #[test]
+    fn search_submit_captures_query() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::SearchOpen);
+        // Default active field is Type — type "welcome", switch to
+        // Queue, type "emails". Enter combines them.
+        for c in "welcome".chars() {
+            app.handle_event(Event::SearchKey(search_char_key(c)));
+        }
+        app.handle_event(Event::SearchFieldSwitch);
+        for c in "emails".chars() {
+            app.handle_event(Event::SearchKey(search_char_key(c)));
+        }
+        app.handle_event(Event::SearchSubmit);
+        assert!(app.search_input.is_none());
+        let q = app.search_query.expect("query should be captured");
+        assert_eq!(q.queues, vec!["emails".to_string()]);
+        assert_eq!(q.types, vec!["welcome".to_string()]);
+    }
+
+    #[test]
+    fn initial_search_anchor_uses_cursor_id_when_set() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.active_tab = Tab::Ready;
+        app.list_states[Tab::Ready.idx()].cursor_id = Some("j_current".into());
+        assert!(matches!(
+            app.anchor_for_initial_search(),
+            FindAnchor::JobId { ref id } if id == "j_current"
+        ));
+    }
+
+    #[test]
+    fn initial_search_anchor_falls_back_to_start_without_cursor_id() {
+        let app = App::new("127.0.0.1:8901".into());
+        assert!(matches!(app.anchor_for_initial_search(), FindAnchor::Start));
+    }
+
+    #[test]
+    fn step_anchor_prefers_pin_over_cursor_id() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.active_tab = Tab::Ready;
+        app.list_states[Tab::Ready.idx()].cursor_id = Some("j_cursor".into());
+        app.pinned_job_id = Some("j_pinned".into());
+        assert!(matches!(
+            app.anchor_for_step(),
+            FindAnchor::JobId { ref id } if id == "j_pinned"
+        ));
+    }
+
+    #[test]
+    fn step_anchor_falls_back_to_cursor_id_when_unpinned() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.active_tab = Tab::Ready;
+        app.list_states[Tab::Ready.idx()].cursor_id = Some("j_cursor".into());
+        assert!(matches!(
+            app.anchor_for_step(),
+            FindAnchor::JobId { ref id } if id == "j_cursor"
+        ));
+    }
+
+    #[test]
+    fn search_open_prefills_from_active_query() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.search_query = Some(SearchQuery {
+            queues: vec!["emails".into(), "billing".into()],
+            types: vec!["audit".into()],
+        });
+        app.handle_event(Event::SearchOpen);
+        let prompt = app.search_input.as_ref().expect("prompt should be open");
+        assert_eq!(prompt.type_input.value(), "audit");
+        assert_eq!(prompt.queue_input.value(), "emails, billing");
+    }
+
+    #[test]
+    fn search_open_without_active_query_starts_empty() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::SearchOpen);
+        let prompt = app.search_input.as_ref().expect("prompt should be open");
+        assert!(prompt.type_input.value().is_empty());
+        assert!(prompt.queue_input.value().is_empty());
+    }
+
+    #[test]
+    fn search_prompt_from_query_round_trip() {
+        let query = SearchQuery {
+            queues: vec!["a".into(), "b".into()],
+            types: vec!["x".into(), "y".into()],
+        };
+        let prompt = SearchPrompt::from_query(&query);
+        assert_eq!(prompt.to_query(), query);
+    }
+
+    #[test]
+    fn search_field_switch_toggles_active_field() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.handle_event(Event::SearchOpen);
+        assert_eq!(app.search_input.as_ref().unwrap().active, SearchField::Type);
+        app.handle_event(Event::SearchFieldSwitch);
+        assert_eq!(
+            app.search_input.as_ref().unwrap().active,
+            SearchField::Queue
+        );
+        app.handle_event(Event::SearchFieldSwitch);
+        assert_eq!(app.search_input.as_ref().unwrap().active, SearchField::Type);
+    }
+
+    #[test]
+    fn find_result_pins_job_and_snaps_cursor() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.active_tab = Tab::Ready;
+        app.viewport_height = 20;
+        // window.offset=1 → items[0] is at filtered position 1,
+        // items[2] at position 3. matched_position=3 must land on
+        // items[3 - offset] = items[2] = "target".
+        app.handle_event(Event::ServerFindResult {
+            server: default_server(),
+            list: ListName::Ready,
+            matched_position: Some(3),
+            window: JobWindow {
+                items: vec![
+                    job("a", 0, None),
+                    job("b", 0, None),
+                    job("target", 0, None),
+                    job("d", 0, None),
+                    job("e", 0, None),
+                ],
+                first_position: 1,
+                total: 0,
+                resolved_anchor: None,
+            },
+        });
+        assert_eq!(app.pinned_job_id.as_deref(), Some("target"));
+        let ls = &app.list_states[Tab::Ready.idx()];
+        assert_eq!(ls.cursor, 3);
+        assert_eq!(ls.buffer_offset, 1);
+    }
+
+    #[test]
+    fn find_result_none_clears_pin() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.pinned_job_id = Some("stale".into());
+        app.pinned_locate_pending = true;
+        app.handle_event(Event::ServerFindResult {
+            server: default_server(),
+            list: ListName::Ready,
+            matched_position: None,
+            window: JobWindow {
+                items: vec![],
+                first_position: 0,
+                total: 0,
+                resolved_anchor: None,
+            },
+        });
+        assert!(app.pinned_job_id.is_none());
+        assert!(!app.pinned_locate_pending);
+    }
+
+    #[test]
+    fn unpin_event_clears_pinned_job() {
+        let mut app = App::new("127.0.0.1:8901".into());
+        app.pinned_job_id = Some("some-id".into());
+        app.handle_event(Event::Unpin);
+        assert!(app.pinned_job_id.is_none());
     }
 }

--- a/src/commands/top/app.rs
+++ b/src/commands/top/app.rs
@@ -254,6 +254,13 @@ pub struct App {
     /// prompt is open so the reader forwards raw characters instead
     /// of interpreting shortcut keys.
     pub search_mode_flag: Option<InputModeFlag>,
+    /// Shared with the terminal input reader — set while a modal prompt
+    /// (currently just the delete confirmation) is open so the reader
+    /// forwards `q` as `Event::Quit` without self-terminating. The app
+    /// interprets Quit-in-modal as "cancel the modal" rather than
+    /// "exit the app", and killing the reader would strand the user
+    /// with no keyboard input for the rest of the session.
+    pub modal_mode_flag: Option<InputModeFlag>,
 }
 
 impl Clone for App {
@@ -285,6 +292,7 @@ impl Clone for App {
             pinned_job_id: self.pinned_job_id.clone(),
             pinned_locate_pending: self.pinned_locate_pending,
             search_mode_flag: self.search_mode_flag.clone(),
+            modal_mode_flag: self.modal_mode_flag.clone(),
         }
     }
 }
@@ -318,6 +326,7 @@ impl App {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         }
     }
 
@@ -329,8 +338,18 @@ impl App {
         self.search_mode_flag = Some(flag);
     }
 
+    pub fn set_modal_mode_flag(&mut self, flag: InputModeFlag) {
+        self.modal_mode_flag = Some(flag);
+    }
+
     fn set_search_mode(&self, on: bool) {
         if let Some(flag) = &self.search_mode_flag {
+            flag.store(on, Ordering::Release);
+        }
+    }
+
+    fn set_modal_mode(&self, on: bool) {
+        if let Some(flag) = &self.modal_mode_flag {
             flag.store(on, Ordering::Release);
         }
     }
@@ -580,6 +599,7 @@ impl App {
         let Some(id) = self.pending_delete.take() else {
             return;
         };
+        self.set_modal_mode(false);
         if let Some(tx) = &self.ws_tx {
             let msg = events::delete_job_message(id.clone());
             let _ = tx.try_send(msg);
@@ -587,6 +607,13 @@ impl App {
         self.ready_jobs.retain(|j| j.id != id);
         self.in_flight_jobs.retain(|j| j.id != id);
         self.scheduled_jobs.retain(|j| j.id != id);
+    }
+
+    /// Cancel the pending delete prompt and drop out of modal mode so
+    /// the terminal reader stops deferring `q` back to the app.
+    fn close_delete_prompt(&mut self) {
+        self.pending_delete = None;
+        self.set_modal_mode(false);
     }
 
     /// Apply server status fields from any message.
@@ -615,7 +642,12 @@ impl App {
                 // Quit while prompting cancels the prompt rather than
                 // exiting; a second `q` (or any other quit gesture) after
                 // cancellation will quit normally.
-                Event::CancelDelete | Event::Quit => self.pending_delete = None,
+                Event::CancelDelete | Event::Quit => self.close_delete_prompt(),
+                // `n` cancels the prompt (the help bar advertises "n No").
+                // The terminal reader unconditionally maps `n` to
+                // `SearchNext`, so we intercept it here. `N`
+                // (`SearchPrev`) gets the same treatment for symmetry.
+                Event::SearchNext | Event::SearchPrev => self.close_delete_prompt(),
                 _ => {}
             }
             return false;
@@ -703,6 +735,7 @@ impl App {
             Event::RequestDelete => {
                 if let Some(id) = self.selected_job_id() {
                     self.pending_delete = Some(id);
+                    self.set_modal_mode(true);
                 }
             }
             // Outside of an active prompt these are no-ops — the prompt
@@ -2087,6 +2120,59 @@ mod tests {
         let mut app = seed_ready_with_cursor("j1");
         app.handle_event(Event::RequestDelete);
         app.handle_event(Event::CancelDelete);
+        assert!(app.pending_delete.is_none());
+        assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
+    }
+
+    #[test]
+    fn opening_delete_prompt_sets_modal_flag() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        let mut app = seed_ready_with_cursor("j1");
+        let flag = Arc::new(AtomicBool::new(false));
+        app.set_modal_mode_flag(flag.clone());
+        app.handle_event(Event::RequestDelete);
+        assert!(flag.load(Ordering::Acquire), "modal flag must be set");
+    }
+
+    #[test]
+    fn cancelling_delete_prompt_clears_modal_flag() {
+        // The whole point of the flag is that the terminal reader can
+        // tell whether a `q` should self-terminate. Clearing it on
+        // every close path (Cancel, Quit, n/N, confirm) is what stops
+        // the reader from staying alive forever.
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        let mut app = seed_ready_with_cursor("j1");
+        let flag = Arc::new(AtomicBool::new(false));
+        app.set_modal_mode_flag(flag.clone());
+        app.handle_event(Event::RequestDelete);
+        app.handle_event(Event::Quit);
+        assert!(!flag.load(Ordering::Acquire), "modal flag must be cleared");
+        assert!(app.pending_delete.is_none());
+    }
+
+    #[test]
+    fn confirming_delete_clears_modal_flag() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        let mut app = seed_ready_with_cursor("j1");
+        let flag = Arc::new(AtomicBool::new(false));
+        app.set_modal_mode_flag(flag.clone());
+        app.handle_event(Event::RequestDelete);
+        app.handle_event(Event::ConfirmDelete);
+        assert!(!flag.load(Ordering::Acquire), "modal flag must be cleared");
+    }
+
+    #[test]
+    fn n_during_prompt_cancels_delete() {
+        // The terminal reader maps `n` unconditionally to SearchNext.
+        // The delete prompt must intercept that as a "No" gesture —
+        // otherwise the help bar's "n No" hint would silently lie.
+        let mut app = seed_ready_with_cursor("j1");
+        app.handle_event(Event::RequestDelete);
+        assert!(app.pending_delete.is_some());
+        app.handle_event(Event::SearchNext);
         assert!(app.pending_delete.is_none());
         assert_eq!(ids(&app.ready_jobs), vec!["j1"]);
     }

--- a/src/commands/top/events.rs
+++ b/src/commands/top/events.rs
@@ -6,10 +6,14 @@
 //! Merges terminal input and WebSocket network events into a single
 //! channel that the main event loop reads from.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tokio::sync::mpsc;
 
 use crate::api::admin::{
-    AdminEvent, AdminJob, AdminMessage, ClientMessage, JobChangeStatus, JobWindow, ServerStatus,
+    AdminEvent, AdminJob, AdminMessage, ClientMessage, Direction, FindAnchor, JobChangeStatus,
+    JobWindow, ListName, SearchQuery, ServerStatus,
 };
 
 /// Unified event type for the TUI event loop.
@@ -48,6 +52,30 @@ pub enum Event {
     CancelDelete,
     /// Suspend the process (Ctrl-Z).
     Suspend,
+    /// User pressed `/` — enter search input mode.
+    SearchOpen,
+    /// A key event while the search prompt is open. Forwarded verbatim
+    /// to the active field so `tui-input` can handle cursor motion,
+    /// backspace/delete, home/end etc. Special keys (Enter, Esc, Tab,
+    /// Ctrl-C) are diverted to their own events by the reader before
+    /// they reach this variant.
+    SearchKey(crossterm::event::KeyEvent),
+    /// Tab pressed while search input is active — switch between the
+    /// `Type` and `Queue` fields.
+    SearchFieldSwitch,
+    /// Enter pressed while search input is active — parse the query
+    /// and dispatch a forward `Find`.
+    SearchSubmit,
+    /// Esc pressed while search input is active — dismiss the prompt
+    /// without searching.
+    SearchCancel,
+    /// `n` — advance to the next match with the last-used query.
+    SearchNext,
+    /// `N` — step back to the previous match with the last-used query.
+    SearchPrev,
+    /// Esc outside of any modal prompt — clear a pinned search
+    /// result if one is active.
+    Unpin,
     /// Server connection attempt in progress.
     ServerConnecting,
     /// Server connection established.
@@ -68,6 +96,15 @@ pub enum Event {
         status: JobChangeStatus,
         job: Option<AdminJob>,
     },
+    /// Response to a `Find` request — search hit, backward search hit,
+    /// or `Locate` result for a pinned job. `matched_position: None`
+    /// means no match / anchor no longer exists.
+    ServerFindResult {
+        server: ServerStatus,
+        list: crate::api::admin::ListName,
+        matched_position: Option<usize>,
+        window: JobWindow,
+    },
     /// Server connection lost.
     ServerDisconnected,
 }
@@ -87,6 +124,14 @@ impl Event {
                 | Event::RequestDelete
                 | Event::ConfirmDelete
                 | Event::CancelDelete
+                | Event::SearchOpen
+                | Event::SearchKey(_)
+                | Event::SearchFieldSwitch
+                | Event::SearchSubmit
+                | Event::SearchCancel
+                | Event::SearchNext
+                | Event::SearchPrev
+                | Event::Unpin
         )
     }
 
@@ -104,76 +149,128 @@ impl Event {
     }
 }
 
+/// Shared mode flag between the App and the terminal reader. When set,
+/// the reader forwards raw character input as `SearchChar` events
+/// instead of interpreting keys as command shortcuts.
+pub type InputModeFlag = Arc<AtomicBool>;
+
 /// Spawn a blocking thread that reads terminal input events and sends
-/// them to the event channel.
-pub fn read_terminal_events(tx: mpsc::Sender<Event>) {
+/// them to the event channel. `search_mode` is toggled by the App when
+/// entering / leaving the `/` search input prompt — the reader routes
+/// keystrokes accordingly.
+pub fn read_terminal_events(tx: mpsc::Sender<Event>, search_mode: InputModeFlag) {
     tokio::task::spawn_blocking(move || {
         use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEventKind, KeyModifiers};
 
         loop {
             if let Ok(CtEvent::Key(key)) = event::read() {
-                if key.kind == KeyEventKind::Press {
-                    match (key.code, key.modifiers) {
-                        (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+
+                if search_mode.load(Ordering::Acquire) {
+                    // Search input mode: peel off Enter/Esc/Tab/Ctrl-C
+                    // as high-level prompt actions; forward everything
+                    // else as a raw `SearchKey` so the active `Input`
+                    // field can handle it (character insertion, cursor
+                    // motion, backspace, delete, home, end, etc.).
+                    match key.code {
+                        KeyCode::Enter => {
+                            let _ = tx.blocking_send(Event::SearchSubmit);
+                        }
+                        KeyCode::Esc => {
+                            let _ = tx.blocking_send(Event::SearchCancel);
+                        }
+                        KeyCode::Tab | KeyCode::BackTab => {
+                            let _ = tx.blocking_send(Event::SearchFieldSwitch);
+                        }
+                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            // Ctrl-C aborts the whole app even from
+                            // inside the prompt — matches the outer
+                            // shortcut so users don't get stuck.
                             let _ = tx.blocking_send(Event::Quit);
                             break;
                         }
-                        (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
-                            let _ = tx.blocking_send(Event::Suspend);
+                        _ => {
+                            let _ = tx.blocking_send(Event::SearchKey(key));
                         }
-                        (KeyCode::Tab, _) => {
-                            let _ = tx.blocking_send(Event::NextTab);
-                        }
-                        (KeyCode::BackTab, _) => {
-                            let _ = tx.blocking_send(Event::PrevTab);
-                        }
-                        (KeyCode::Right, _) => {
-                            let _ = tx.blocking_send(Event::ScrollRight);
-                        }
-                        (KeyCode::Left, _) => {
-                            let _ = tx.blocking_send(Event::ScrollLeft);
-                        }
-                        (KeyCode::Up, _) | (KeyCode::Char('k'), _) => {
-                            let _ = tx.blocking_send(Event::ScrollUp);
-                        }
-                        (KeyCode::Down, _) | (KeyCode::Char('j'), _) => {
-                            let _ = tx.blocking_send(Event::ScrollDown);
-                        }
-                        (KeyCode::PageUp, _) => {
-                            let _ = tx.blocking_send(Event::PageUp);
-                        }
-                        (KeyCode::PageDown, _) => {
-                            let _ = tx.blocking_send(Event::PageDown);
-                        }
-                        (KeyCode::Char('i'), _) => {
-                            let _ = tx.blocking_send(Event::ToggleDetail);
-                        }
-                        (KeyCode::Char('p'), _) => {
-                            let _ = tx.blocking_send(Event::TogglePause);
-                        }
-                        (KeyCode::Char('g'), _) => {
-                            let _ = tx.blocking_send(Event::GoToStart);
-                        }
-                        (KeyCode::Char('G'), _) => {
-                            let _ = tx.blocking_send(Event::GoToEnd);
-                        }
-                        (KeyCode::Char('D'), _) => {
-                            let _ = tx.blocking_send(Event::RequestDelete);
-                        }
-                        (KeyCode::Char('y'), _) => {
-                            let _ = tx.blocking_send(Event::ConfirmDelete);
-                        }
-                        (KeyCode::Char('n'), _) | (KeyCode::Esc, _) => {
-                            let _ = tx.blocking_send(Event::CancelDelete);
-                        }
-                        (KeyCode::Home, _) => {
-                            let _ = tx.blocking_send(Event::GoToStart);
-                        }
-                        (KeyCode::End, _) => {
-                            let _ = tx.blocking_send(Event::GoToEnd);
-                        }
-                        _ => {}
                     }
+                    continue;
+                }
+
+                match (key.code, key.modifiers) {
+                    (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        let _ = tx.blocking_send(Event::Quit);
+                        break;
+                    }
+                    (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
+                        let _ = tx.blocking_send(Event::Suspend);
+                    }
+                    (KeyCode::Tab, _) => {
+                        let _ = tx.blocking_send(Event::NextTab);
+                    }
+                    (KeyCode::BackTab, _) => {
+                        let _ = tx.blocking_send(Event::PrevTab);
+                    }
+                    (KeyCode::Right, _) => {
+                        let _ = tx.blocking_send(Event::ScrollRight);
+                    }
+                    (KeyCode::Left, _) => {
+                        let _ = tx.blocking_send(Event::ScrollLeft);
+                    }
+                    (KeyCode::Up, _) | (KeyCode::Char('k'), _) => {
+                        let _ = tx.blocking_send(Event::ScrollUp);
+                    }
+                    (KeyCode::Down, _) | (KeyCode::Char('j'), _) => {
+                        let _ = tx.blocking_send(Event::ScrollDown);
+                    }
+                    (KeyCode::PageUp, _) => {
+                        let _ = tx.blocking_send(Event::PageUp);
+                    }
+                    (KeyCode::PageDown, _) => {
+                        let _ = tx.blocking_send(Event::PageDown);
+                    }
+                    (KeyCode::Char('i'), _) => {
+                        let _ = tx.blocking_send(Event::ToggleDetail);
+                    }
+                    (KeyCode::Char('p'), _) => {
+                        let _ = tx.blocking_send(Event::TogglePause);
+                    }
+                    (KeyCode::Char('g'), _) => {
+                        let _ = tx.blocking_send(Event::GoToStart);
+                    }
+                    (KeyCode::Char('G'), _) => {
+                        let _ = tx.blocking_send(Event::GoToEnd);
+                    }
+                    (KeyCode::Char('D'), _) => {
+                        let _ = tx.blocking_send(Event::RequestDelete);
+                    }
+                    (KeyCode::Char('y'), _) => {
+                        let _ = tx.blocking_send(Event::ConfirmDelete);
+                    }
+                    (KeyCode::Char('/'), _) => {
+                        let _ = tx.blocking_send(Event::SearchOpen);
+                    }
+                    (KeyCode::Char('n'), _) => {
+                        let _ = tx.blocking_send(Event::SearchNext);
+                    }
+                    (KeyCode::Char('N'), _) => {
+                        let _ = tx.blocking_send(Event::SearchPrev);
+                    }
+                    (KeyCode::Esc, _) => {
+                        // Multiplexed: cancel a delete prompt if one is
+                        // pending, otherwise unpin the current search
+                        // result. The App decides based on its state.
+                        let _ = tx.blocking_send(Event::CancelDelete);
+                        let _ = tx.blocking_send(Event::Unpin);
+                    }
+                    (KeyCode::Home, _) => {
+                        let _ = tx.blocking_send(Event::GoToStart);
+                    }
+                    (KeyCode::End, _) => {
+                        let _ = tx.blocking_send(Event::GoToEnd);
+                    }
+                    _ => {}
                 }
             }
         }
@@ -273,6 +370,16 @@ fn parse_ws_message(text: &str) -> Option<Event> {
             status,
             job,
         }),
+        AdminEvent::FindResult {
+            list,
+            matched_position,
+            window,
+        } => Some(Event::ServerFindResult {
+            server: msg.server,
+            list,
+            matched_position,
+            window,
+        }),
     }
 }
 
@@ -289,10 +396,32 @@ pub fn delete_job_message(id: String) -> String {
 }
 
 /// Serialize a subscribe message for sending over WebSocket.
-pub fn subscribe_message(list: crate::api::admin::ListName, offset: usize, limit: usize) -> String {
+pub fn subscribe_message(
+    list: crate::api::admin::ListName,
+    anchor: crate::api::admin::SubscribeAnchor,
+    limit: usize,
+) -> String {
     serde_json::to_string(&crate::api::admin::ClientMessage::Subscribe {
         list,
-        offset,
+        anchor,
+        limit,
+    })
+    .expect("ClientMessage serialization cannot fail")
+}
+
+/// Serialize a `Find` message for sending over WebSocket.
+pub fn find_message(
+    list: ListName,
+    anchor: FindAnchor,
+    direction: Direction,
+    query: SearchQuery,
+    limit: usize,
+) -> String {
+    serde_json::to_string(&ClientMessage::Find {
+        list,
+        anchor,
+        direction,
+        query,
         limit,
     })
     .expect("ClientMessage serialization cannot fail")
@@ -325,9 +454,9 @@ mod tests {
         let json = r#"{
             "server": {"version":"1.0.0","uptime_ms":5000,"tier":"pro","total_ready":1,"total_in_flight":1,"total_scheduled":1},
             "event": "job_snapshot",
-            "ready": {"offset":0,"items":[{"id":"r1","queue":"q","job_type":"t","priority":0,"ready_at":1000,"attempts":0}]},
-            "in_flight": {"offset":0,"items":[{"id":"w1","queue":"q","job_type":"t","priority":0,"ready_at":1000,"attempts":0,"dequeued_at":2000}]},
-            "scheduled": {"offset":0,"items":[{"id":"s1","queue":"q","job_type":"t","priority":0,"ready_at":5000,"attempts":0}]}
+            "ready": {"first_position":0,"total":1,"items":[{"id":"r1","queue":"q","job_type":"t","priority":0,"ready_at":1000,"attempts":0}]},
+            "in_flight": {"first_position":0,"total":1,"items":[{"id":"w1","queue":"q","job_type":"t","priority":0,"ready_at":1000,"attempts":0,"dequeued_at":2000}]},
+            "scheduled": {"first_position":0,"total":1,"items":[{"id":"s1","queue":"q","job_type":"t","priority":0,"ready_at":5000,"attempts":0}]}
         }"#;
         let event = parse_ws_message(json).unwrap();
 
@@ -440,5 +569,83 @@ mod tests {
     fn returns_none_for_unknown_event_type() {
         let json = r#"{"server":{"version":"1.0.0","uptime_ms":0,"tier":"free","total_ready":0,"total_in_flight":0,"total_scheduled":0},"event":"unknown","data":123}"#;
         assert!(parse_ws_message(json).is_none());
+    }
+
+    #[test]
+    fn parses_find_result_match() {
+        let json = r#"{
+            "server":{"version":"1.0.0","uptime_ms":0,"tier":"pro","total_ready":10,"total_in_flight":0,"total_scheduled":0},
+            "event":"find_result",
+            "list":"ready",
+            "matched_position": 3,
+            "window": {"first_position":1,"total":10,"items":[
+                {"id":"a","queue":"q","job_type":"t","priority":0,"ready_at":0,"attempts":0},
+                {"id":"b","queue":"q","job_type":"t","priority":0,"ready_at":0,"attempts":0},
+                {"id":"c","queue":"q","job_type":"t","priority":0,"ready_at":0,"attempts":0}
+            ]}
+        }"#;
+        let event = parse_ws_message(json).unwrap();
+        match event {
+            Event::ServerFindResult {
+                list,
+                matched_position,
+                window,
+                ..
+            } => {
+                assert!(matches!(list, ListName::Ready));
+                assert_eq!(matched_position, Some(3));
+                assert_eq!(window.first_position, 1);
+                assert_eq!(window.items.len(), 3);
+            }
+            _ => panic!("expected ServerFindResult"),
+        }
+    }
+
+    #[test]
+    fn parses_find_result_none() {
+        let json = r#"{
+            "server":{"version":"1.0.0","uptime_ms":0,"tier":"pro","total_ready":0,"total_in_flight":0,"total_scheduled":0},
+            "event":"find_result",
+            "list":"in_flight",
+            "window": {"first_position":0,"total":0,"items":[]}
+        }"#;
+        let event = parse_ws_message(json).unwrap();
+        match event {
+            Event::ServerFindResult {
+                matched_position,
+                window,
+                ..
+            } => {
+                assert_eq!(matched_position, None);
+                assert!(window.items.is_empty());
+            }
+            _ => panic!("expected ServerFindResult"),
+        }
+    }
+
+    #[test]
+    fn find_message_serializes_expected_shape() {
+        let msg = find_message(
+            ListName::Ready,
+            FindAnchor::JobId {
+                id: "job123".into(),
+            },
+            Direction::Forward,
+            SearchQuery {
+                queues: vec!["emails".into()],
+                types: vec!["send".into()],
+            },
+            60,
+        );
+        // Full-shape check via parse-back-to-value.
+        let v: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(v["type"], "find");
+        assert_eq!(v["list"], "ready");
+        assert_eq!(v["direction"], "forward");
+        assert_eq!(v["limit"], 60);
+        assert_eq!(v["anchor"]["kind"], "job_id");
+        assert_eq!(v["anchor"]["id"], "job123");
+        assert_eq!(v["query"]["queues"][0], "emails");
+        assert_eq!(v["query"]["types"][0], "send");
     }
 }

--- a/src/commands/top/events.rs
+++ b/src/commands/top/events.rs
@@ -158,7 +158,11 @@ pub type InputModeFlag = Arc<AtomicBool>;
 /// them to the event channel. `search_mode` is toggled by the App when
 /// entering / leaving the `/` search input prompt — the reader routes
 /// keystrokes accordingly.
-pub fn read_terminal_events(tx: mpsc::Sender<Event>, search_mode: InputModeFlag) {
+pub fn read_terminal_events(
+    tx: mpsc::Sender<Event>,
+    search_mode: InputModeFlag,
+    modal_mode: InputModeFlag,
+) {
     tokio::task::spawn_blocking(move || {
         use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEventKind, KeyModifiers};
 
@@ -201,7 +205,16 @@ pub fn read_terminal_events(tx: mpsc::Sender<Event>, search_mode: InputModeFlag)
                 match (key.code, key.modifiers) {
                     (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                         let _ = tx.blocking_send(Event::Quit);
-                        break;
+                        // In modal states (e.g. the delete confirmation
+                        // prompt) the app interprets Quit as "cancel
+                        // the modal", not "exit the app". Self-
+                        // terminating the reader here would kill key
+                        // input for the rest of the session. Stay alive
+                        // and let the app decide — the next non-modal
+                        // Quit will fall through and break as normal.
+                        if !modal_mode.load(Ordering::Acquire) {
+                            break;
+                        }
                     }
                     (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
                         let _ = tx.blocking_send(Event::Suspend);

--- a/src/commands/top/mod.rs
+++ b/src/commands/top/mod.rs
@@ -15,6 +15,8 @@ pub mod events;
 pub mod ui;
 
 use std::io;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use clap::Parser;
@@ -59,8 +61,12 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     // Channel for outbound WS messages from App to the WS task.
     let (ws_out_tx, ws_out_rx) = mpsc::channel::<String>(64);
 
+    // Shared flag so the App can put the terminal reader into search
+    // input mode when the user opens the `/` prompt.
+    let search_mode = Arc::new(AtomicBool::new(false));
+
     // Spawn terminal input reader (blocking, runs in a thread).
-    events::read_terminal_events(tx.clone());
+    events::read_terminal_events(tx.clone(), search_mode.clone());
 
     let host = args.admin.url.clone();
 
@@ -69,6 +75,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let mut app = App::new(host);
     app.set_ws_tx(ws_out_tx);
+    app.set_search_mode_flag(search_mode);
 
     // Main event loop — process events as they arrive, redraw on tick.
     let mut tick = tokio::time::interval(Duration::from_millis(args.refresh_rate));

--- a/src/commands/top/mod.rs
+++ b/src/commands/top/mod.rs
@@ -65,8 +65,15 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     // input mode when the user opens the `/` prompt.
     let search_mode = Arc::new(AtomicBool::new(false));
 
+    // Shared flag telling the reader that a modal prompt (currently
+    // just the delete confirmation) is open — while set, the reader
+    // still forwards `q` as `Event::Quit` but doesn't self-terminate.
+    // The app interprets Quit-in-modal as "cancel the modal"; killing
+    // the reader here would strand the user with no keyboard input.
+    let modal_mode = Arc::new(AtomicBool::new(false));
+
     // Spawn terminal input reader (blocking, runs in a thread).
-    events::read_terminal_events(tx.clone(), search_mode.clone());
+    events::read_terminal_events(tx.clone(), search_mode.clone(), modal_mode.clone());
 
     let host = args.admin.url.clone();
 
@@ -76,6 +83,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let mut app = App::new(host);
     app.set_ws_tx(ws_out_tx);
     app.set_search_mode_flag(search_mode);
+    app.set_modal_mode_flag(modal_mode);
 
     // Main event loop — process events as they arrive, redraw on tick.
     let mut tick = tokio::time::interval(Duration::from_millis(args.refresh_rate));

--- a/src/commands/top/ui/help_bar.rs
+++ b/src/commands/top/ui/help_bar.rs
@@ -30,23 +30,18 @@ pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
     // prompt — replaces the shortcuts entirely so the user is never in
     // doubt about what `y` and `n` will do.
     if let Some(id) = &app.pending_delete {
+        // Full red bar, white text. Keys (y / n) are bold; the job id
+        // is bold; everything else is regular white on red.
+        let base = Style::default().fg(Color::White).bg(Color::Red);
+        let strong = base.add_modifier(Modifier::BOLD);
         let prompt = Paragraph::new(Line::from(vec![
-            Span::styled(
-                " Delete job ",
-                Style::default().fg(Color::Black).bg(Color::LightRed),
-            ),
-            Span::styled(
-                id.as_str(),
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::LightRed)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("? ", Style::default().fg(Color::Black).bg(Color::LightRed)),
-            Span::styled("y", key_style),
-            Span::styled("Yes", label_style),
-            Span::styled(" n", key_style),
-            Span::styled("No", label_style),
+            Span::styled(" Delete job ", base),
+            Span::styled(id.as_str(), strong),
+            Span::styled("? ", base),
+            Span::styled("y", strong),
+            Span::styled(" Yes  ", base),
+            Span::styled("n", strong),
+            Span::styled(" No ", base),
         ]));
         frame.render_widget(prompt, area);
         return;

--- a/src/commands/top/ui/help_bar.rs
+++ b/src/commands/top/ui/help_bar.rs
@@ -2,8 +2,9 @@
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Bottom help bar — keyboard shortcut hints, the delete confirmation
-//! prompt (when active), and the "Resume to scroll further" hint at the
-//! edges of a paused/frozen buffer.
+//! prompt (when active), the `/` search prompt (with Type and Queue
+//! fields), and the "Resume to scroll further" hint at the edges of a
+//! paused/frozen buffer.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -11,11 +12,19 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::commands::top::app::{App, Tab};
+use crate::commands::top::app::{App, SearchField, SearchPrompt, Tab};
 
 pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
     let key_style = Style::default();
     let label_style = Style::default().fg(Color::Black).bg(Color::LightCyan);
+
+    // While the `/` search prompt is open the help bar becomes an
+    // input line with two labeled fields — Type and Queue. Tab switches
+    // between them.
+    if let Some(prompt) = &app.search_input {
+        render_search_prompt(prompt, frame, area);
+        return;
+    }
 
     // When a delete confirmation is pending, the help bar becomes a modal
     // prompt — replaces the shortcuts entirely so the user is never in
@@ -33,10 +42,10 @@ pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
                     .bg(Color::LightRed)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled("?  ", Style::default().fg(Color::Black).bg(Color::LightRed)),
-            Span::styled(" y ", key_style),
+            Span::styled("? ", Style::default().fg(Color::Black).bg(Color::LightRed)),
+            Span::styled("y", key_style),
             Span::styled("Yes", label_style),
-            Span::styled("  n ", key_style),
+            Span::styled(" n", key_style),
             Span::styled("No", label_style),
         ]));
         frame.render_widget(prompt, area);
@@ -50,26 +59,27 @@ pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
     // padding spaces and touch the neighbouring labels.
     let pause_label = if app.paused { "Resume" } else { "Pause" };
     let mut help_spans: Vec<Span> = vec![
-        Span::styled(" Tab ", key_style),
+        Span::raw(" "),
+        Span::styled("Tab", key_style),
         Span::styled("Change Tab", label_style),
-        Span::raw("  "),
+        Span::raw(" "),
     ];
     if app.paused {
         let crossed = Modifier::CROSSED_OUT;
         help_spans.push(Span::styled("i", key_style.add_modifier(crossed)));
-        help_spans.push(Span::raw(" "));
         help_spans.push(Span::styled("Info", label_style.add_modifier(crossed)));
     } else {
         help_spans.push(Span::styled("i", key_style));
-        help_spans.push(Span::raw(" "));
         help_spans.push(Span::styled("Info", label_style));
     }
     help_spans.extend([
-        Span::styled("  p ", key_style),
+        Span::styled(" p", key_style),
         Span::styled(pause_label, label_style),
-        Span::styled("  D ", key_style),
+        Span::styled(" /", key_style),
+        Span::styled("Find", label_style),
+        Span::styled(" D", key_style),
         Span::styled("Delete", label_style),
-        Span::styled("  q ", key_style),
+        Span::styled(" q", key_style),
         Span::styled("Quit", label_style),
     ]);
 
@@ -99,4 +109,98 @@ pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
 
     let help = Paragraph::new(Line::from(help_spans));
     frame.render_widget(help, area);
+}
+
+/// Minimum visual width reserved for each search field's value area.
+/// The field grows past this if the user types more than fits — but
+/// never shrinks below, so the two fields don't visually reflow as
+/// characters are added or removed.
+const SEARCH_FIELD_MIN_WIDTH: u16 = 20;
+
+/// Render the two-field search prompt (Type / Queue). The inactive
+/// field is dimmed; the active field gets the terminal cursor placed
+/// on it via `frame.set_cursor_position` (which yields a real blinking
+/// block cursor rather than injecting a `_` character that shifts the
+/// text as the user edits). Each field reserves at least
+/// `SEARCH_FIELD_MIN_WIDTH` columns of value area, padded with
+/// spaces, so the fields don't jiggle as the user types.
+fn render_search_prompt(prompt: &SearchPrompt, frame: &mut Frame, area: Rect) {
+    let banner_style = Style::default().fg(Color::Black).bg(Color::LightYellow);
+    let label_style = Style::default().fg(Color::LightYellow);
+    let active_value_style = Style::default().add_modifier(Modifier::BOLD);
+    let inactive_value_style = Style::default().fg(Color::DarkGray);
+
+    let mut spans: Vec<Span> = Vec::new();
+    let mut x: u16 = area.x;
+    let mut cursor_x: Option<u16> = None;
+
+    // Helper: push a span and advance the running x by its width.
+    let push = |spans: &mut Vec<Span>, x: &mut u16, span: Span<'static>| {
+        *x = x.saturating_add(span.width() as u16);
+        spans.push(span);
+    };
+
+    push(&mut spans, &mut x, Span::styled(" Search ", banner_style));
+    push(&mut spans, &mut x, Span::raw(" "));
+
+    for (field, label) in [
+        (SearchField::Type, "Type: "),
+        (SearchField::Queue, "Queue: "),
+    ] {
+        let is_active = prompt.active == field;
+        let input = match field {
+            SearchField::Type => &prompt.type_input,
+            SearchField::Queue => &prompt.queue_input,
+        };
+        let value = input.value();
+
+        push(&mut spans, &mut x, Span::styled(label, label_style));
+
+        let value_style = if is_active {
+            active_value_style
+        } else {
+            inactive_value_style
+        };
+        let value_width = if is_active {
+            value.chars().count() as u16
+        } else if value.is_empty() {
+            1 // rendered "…"
+        } else {
+            value.chars().count() as u16
+        };
+
+        if is_active {
+            // Record where the terminal cursor should land — one visual
+            // column per character before the cursor.
+            cursor_x = Some(x.saturating_add(input.visual_cursor() as u16));
+            push(
+                &mut spans,
+                &mut x,
+                Span::styled(value.to_string(), value_style),
+            );
+        } else if value.is_empty() {
+            push(&mut spans, &mut x, Span::styled("…", value_style));
+        } else {
+            push(
+                &mut spans,
+                &mut x,
+                Span::styled(value.to_string(), value_style),
+            );
+        }
+
+        // Pad the field to the minimum width so short values don't
+        // cause the next field to reflow. If the value already exceeds
+        // the minimum, the field just grows — no truncation.
+        let pad = SEARCH_FIELD_MIN_WIDTH.saturating_sub(value_width);
+        if pad > 0 {
+            push(&mut spans, &mut x, Span::raw(" ".repeat(pad as usize)));
+        }
+
+        push(&mut spans, &mut x, Span::raw("  "));
+    }
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    if let Some(cx) = cursor_x {
+        frame.set_cursor_position((cx, area.y));
+    }
 }

--- a/src/commands/top/ui/mod.rs
+++ b/src/commands/top/ui/mod.rs
@@ -209,6 +209,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         }
     }
 
@@ -331,6 +332,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
     }
@@ -364,6 +366,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
     }
@@ -488,6 +491,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         }
     }
 
@@ -599,6 +603,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
     }
@@ -632,6 +637,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
     }
@@ -687,6 +693,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 80, 20));
     }
@@ -742,6 +749,7 @@ mod tests {
             pinned_job_id: None,
             pinned_locate_pending: false,
             search_mode_flag: None,
+            modal_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 12));
     }

--- a/src/commands/top/ui/mod.rs
+++ b/src/commands/top/ui/mod.rs
@@ -204,6 +204,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         }
     }
 
@@ -226,6 +231,38 @@ mod tests {
         let mut app = new_app();
         app.status = ConnectionStatus::Connected;
         app.pending_delete = Some("j_abc123".into());
+        assert_ui_snapshot!(render_to_string(&app, 80, 10));
+    }
+
+    #[test]
+    fn render_search_prompt_empty() {
+        let mut app = new_app();
+        app.status = ConnectionStatus::Connected;
+        app.search_input = Some(crate::commands::top::app::SearchPrompt::default());
+        assert_ui_snapshot!(render_to_string(&app, 80, 10));
+    }
+
+    #[test]
+    fn render_search_prompt_with_typed_type_field() {
+        use crate::commands::top::app::SearchPrompt;
+        let mut app = new_app();
+        app.status = ConnectionStatus::Connected;
+        let mut prompt = SearchPrompt::default();
+        prompt.type_input = "send_welcome".into();
+        app.search_input = Some(prompt);
+        assert_ui_snapshot!(render_to_string(&app, 80, 10));
+    }
+
+    #[test]
+    fn render_search_prompt_active_queue_field() {
+        use crate::commands::top::app::{SearchField, SearchPrompt};
+        let mut app = new_app();
+        app.status = ConnectionStatus::Connected;
+        let mut prompt = SearchPrompt::default();
+        prompt.type_input = "send_welcome".into();
+        prompt.queue_input = "emails".into();
+        prompt.active = SearchField::Queue;
+        app.search_input = Some(prompt);
         assert_ui_snapshot!(render_to_string(&app, 80, 10));
     }
 
@@ -289,6 +326,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
     }
@@ -317,6 +359,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 60, 10));
     }
@@ -436,6 +483,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         }
     }
 
@@ -542,6 +594,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
     }
@@ -570,6 +627,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 8));
     }
@@ -620,6 +682,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 80, 20));
     }
@@ -670,6 +737,11 @@ mod tests {
             paused: false,
             pending_delete: None,
             ws_tx: None,
+            search_input: None,
+            search_query: None,
+            pinned_job_id: None,
+            pinned_locate_pending: false,
+            search_mode_flag: None,
         };
         assert_ui_snapshot!(render_to_string(&app, 120, 12));
     }

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_connected_with_server_info.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_connected_with_server_info.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1166
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_connecting.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1094
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_delete_prompt_replaces_help_bar.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_delete_prompt_replaces_help_bar.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 80, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
- Delete job j_abc123? yYes nNo
+ Delete job j_abc123? y Yes  n No

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_detail_panel.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1391
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 160, 30)"
 ---
   Zizq 0.1.0
@@ -32,4 +31,4 @@ expression: "render_to_string(&app, 160, 30)"
   Type                    generate_annual_report_email                             "to": "user@example.com",
   Priority                0                                                        "urgent": true
   Status                  in_flight                                              }
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_disconnected.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1194
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_disconnected_wide.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1447
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 120, 8)"
 ---
   Zizq 0.1.0
@@ -10,4 +9,4 @@ expression: "render_to_string(&app, 120, 8)"
 
 
    In-Flight   Ready   Scheduled
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_empty_ready_tab.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1419
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 120, 8)"
 ---
   Zizq 0.1.0
@@ -10,4 +9,4 @@ expression: "render_to_string(&app, 120, 8)"
 
   Depth[                                                                                                       0 jobs]
    In-Flight   Ready   Scheduled
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_free_tier_in_flight_tab_with_cap_message.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1547
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 120, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 120, 12)"
 
                                          Display is currently capped at 10 jobs.
                                        Upgrade to a pro license to see everything.
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_free_tier_ready_tab_with_cap_message.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1497
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 80, 20)"
 ---
   Zizq 0.1.0
@@ -22,4 +21,4 @@ expression: "render_to_string(&app, 80, 20)"
                      Display is currently capped at 10 jobs.
                    Upgrade to a pro license to see everything.
 
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1336
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
 70a2bb46e1f07a0c908d7a2bb40          0 default                  3s          1 ge
 70a1aa35d0e06b0b807c691aa30          0 billing               2m30s          3 ch
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1343
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
      ID   PRIORITY QUEUE              DURATION   ATTEMPTS TYPE
 7a2bb40          0 default                  3s          1 generate_annual_report
 691aa30          0 billing               2m30s          3 charge_subscription
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_narrow_scrolled_max.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1350
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
 UEUE              DURATION   ATTEMPTS TYPE
 efault                  3s          1 generate_annual_report_email
 illing               2m30s          3 charge_subscription
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_wide.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_in_flight_tab_wide.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1330
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                        DURATION   ATTEMPTS TYPE
 70a2bb46e1f07a0c908d7a2bb40          0 default                            3s          1 generate_annual_report_email
 70a1aa35d0e06b0b807c691aa30          0 billing                         2m30s          3 charge_subscription
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_paused_at_buffer_edge_shows_resume_hint.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_paused_at_buffer_edge_shows_resume_hint.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1119
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 90, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 90, 12)"
                          ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TYPE
                          j1          0 queue1                    -          0 type1
                          j2          0 queue1                    -          0 type1
- Tab Change Tab  i Info  p Resume  D Delete  q Quit   ↓ Resume to scroll further
+ TabChange Tab iInfo pResume /Find DDelete qQuit   ↓ Resume to scroll further

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_paused_shows_indicator_and_swaps_help_labels.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_paused_shows_indicator_and_swaps_help_labels.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1102
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 60, 10)"
 ---
   Zizq 0.1.0
@@ -12,4 +11,4 @@ expression: "render_to_string(&app, 60, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DU
- Tab Change Tab  i Info  p Resume  D Delete  q Quit
+ TabChange Tab iInfo pResume /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_ready_tab_narrow.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1324
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                 DELAY   ATTEMPTS TY
 70a3cc87a1f0890da08e8b3cc86          0 default                  5s          0 ge
 70a3dd47c2308a1fb09e9c4dd97          5 default                1m2s          2 se
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_ready_tab_wide.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1318
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                           DELAY   ATTEMPTS TYPE
 70a3cc87a1f0890da08e8b3cc86          0 default                            5s          0 generate_annual_report_email
 70a3dd47c2308a1fb09e9c4dd97          5 default                          1m2s          2 send_welcome_email
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_narrow.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1362
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 80, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 80, 12)"
                          ID   PRIORITY QUEUE                   DUE   ATTEMPTS TY
 70a4ee89f2f09a1eb0af9d5ee80          0 default               3m52s          0 se
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                  1h          1 ge
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_scheduled_tab_wide.snap
@@ -1,6 +1,5 @@
 ---
-source: src/commands/top/ui.rs
-assertion_line: 1356
+source: src/commands/top/ui/mod.rs
 expression: "render_to_string(&app, 160, 12)"
 ---
   Zizq 0.1.0
@@ -14,4 +13,4 @@ expression: "render_to_string(&app, 160, 12)"
                          ID   PRIORITY QUEUE                             DUE   ATTEMPTS TYPE
 70a4ee89f2f09a1eb0af9d5ee80          0 default                         3m52s          0 send_reminder_email
 70a5ff9a03f0ab1fc0b0ae6ff90          0 reports                            1h          1 generate_quarterly_report
- Tab Change Tab  i Info  p Pause  D Delete  q Quit
+ TabChange Tab iInfo pPause /Find DDelete qQuit

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_search_prompt_active_queue_field.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_search_prompt_active_queue_field.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 80, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
- Delete job j_abc123? yYes nNo
+ Search  Type: send_welcome          Queue: emails

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_search_prompt_empty.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_search_prompt_empty.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 80, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
- Delete job j_abc123? yYes nNo
+ Search  Type:                       Queue: …

--- a/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_search_prompt_with_typed_type_field.snap
+++ b/src/commands/top/ui/snapshots/zizq__commands__top__ui__tests__render_search_prompt_with_typed_type_field.snap
@@ -11,4 +11,4 @@ expression: "render_to_string(&app, 80, 10)"
 
    In-Flight   Ready   Scheduled
                          ID   PRIORITY QUEUE              DURATION   ATTEMPTS TY
- Delete job j_abc123? yYes nNo
+ Search  Type: send_welcome          Queue: …

--- a/src/store/find.rs
+++ b/src/store/find.rs
@@ -1,0 +1,746 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! `less`-style search over the in-memory Ready / InFlight / Scheduled
+//! indexes.
+//!
+//! `find_ready`, `find_in_flight`, and `find_scheduled` each walk their
+//! respective index in a single pass, resolve an optional anchor id to
+//! an absolute position, apply a queue+type predicate to each candidate,
+//! and return the first match with a window of surrounding items. The
+//! dashboard uses this to power `/`, `n`, `N`, and to re-locate a
+//! pinned job that has drifted out of the local buffer.
+//!
+//! Design notes:
+//!
+//! - **Race-free by construction.** Each walk operates on a consistent
+//!   iterator over the SkipMap / SkipSet — the client's cursor
+//!   position never has to survive a round-trip. The client anchors
+//!   by *job id*, not by numeric position, and the server resolves the
+//!   id at scan time.
+//! - **`Locate` direction.** The dashboard's row-sticky follow uses
+//!   `Locate` to ask "where is this id now?" without walking further.
+//!   Returns `None` when the id is no longer in the index (job
+//!   completed / requeued / removed) so the client can unpin.
+//! - **Anchor-not-found fallback.** For `Forward`, an unknown anchor
+//!   falls back to a walk from position 0. For `Backward`, from the
+//!   last position. For `Locate`, returns `None`. This makes searches
+//!   robust to the anchor job being processed between key press and
+//!   server receipt.
+
+use tokio::task;
+
+use super::keys::make_job_key;
+use super::store::Store;
+use super::types::{Job, StoreError};
+
+/// Direction of a `find_*` walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindDirection {
+    /// Skip the anchor, walk forward, return first match.
+    Forward,
+    /// Skip the anchor, walk backward, return first match.
+    Backward,
+    /// Return the anchor's current position without walking. Query is
+    /// ignored. Falls through to `None` when the anchor is not found.
+    Locate,
+}
+
+/// Anchor of a `list_window_*` request.
+///
+/// - `Around(id)`: follow a specific job id (search / pin).
+/// - `Offset(pos)`: numeric depth anchor for depth-based navigation
+///   (arrow keys, page down). Clamped to `max(0, total - limit)`
+///   when `pos >= total` so the client always gets tail items under
+///   drain instead of an empty window.
+/// - `Head` / `Tail`: natural start / end anchors.
+#[derive(Debug, Clone)]
+pub enum WindowAnchor {
+    Around(String),
+    Offset(usize),
+    Head,
+    Tail,
+}
+
+/// Fallback behaviour for `list_window_*` when an `Around` anchor id
+/// is not present in the list at scan time. See `api::admin::Fallback`
+/// for the wire-facing counterpart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowFallback {
+    Head,
+    Tail,
+    Nowhere,
+}
+
+/// A window returned by `list_window_*`. `first_position` is the
+/// 0-based position of `items[0]` in the underlying sorted list;
+/// `total` is the list's current length. `resolved_anchor` is
+/// `Some(id)` when the requested `Around` anchor was found (the
+/// window is centered on it), and `None` when the fallback was
+/// exercised.
+#[derive(Debug)]
+pub struct WindowOutcome {
+    pub items: Vec<Job>,
+    pub first_position: usize,
+    pub total: usize,
+    pub resolved_anchor: Option<String>,
+}
+
+/// A match returned by `find_*`. `position` is the item's absolute
+/// index within the underlying in-memory index at scan time.
+/// `window_offset` + `window_items` describe a page of surrounding
+/// items so the dashboard can render the match's neighbourhood
+/// without a separate `Subscribe` round-trip.
+#[derive(Debug)]
+pub struct FindOutcome {
+    pub matched_position: usize,
+    pub window_offset: usize,
+    pub window_items: Vec<Job>,
+}
+
+/// Test a metadata-hydrated `Job` against a queue/type predicate.
+/// Empty vectors mean "no constraint on this dimension." Values are
+/// matched as substrings (case-sensitive) so `audit` matches
+/// `audit.create`. Multiple values inside a vector are OR'd; different
+/// fields are AND'd.
+fn matches_query(queues: &[String], types: &[String], job: &Job) -> bool {
+    if !queues.is_empty() && !queues.iter().any(|q| job.queue.contains(q)) {
+        return false;
+    }
+    if !types.is_empty() && !types.iter().any(|t| job.job_type.contains(t)) {
+        return false;
+    }
+    true
+}
+
+/// Center a window of `limit` items around `matched_position`, clamped
+/// to `[0, total)`. Returns the `window_offset` to hand to the caller.
+fn window_offset_around(matched_position: usize, limit: usize, total: usize) -> usize {
+    let half = limit / 2;
+    let raw = matched_position.saturating_sub(half);
+    // Prefer to keep `limit` items in view: if the raw offset would
+    // leave the window straddling the tail, slide it up so items fill
+    // the window when possible.
+    let max_offset = total.saturating_sub(limit);
+    raw.min(max_offset)
+}
+
+impl Store {
+    /// Search the in-memory `ReadyIndex` for the first job matching
+    /// `queues` and `types` per `direction`, starting from `anchor_id`
+    /// (or the natural start/end when `None`). See module docs.
+    pub async fn find_ready(
+        &self,
+        anchor_id: Option<String>,
+        direction: FindDirection,
+        queues: Vec<String>,
+        types: Vec<String>,
+        limit: usize,
+    ) -> Result<Option<FindOutcome>, StoreError> {
+        let ready_index = self.ready_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            // Materialise the index into a Vec of ids so we can index
+            // by position for anchor lookup, walk in either direction,
+            // and build the window without re-walking. This is one
+            // allocation of `n * (u16 + String)` — acceptable for the
+            // Ready index (ephemeral, typically small).
+            let entries: Vec<(u16, String)> = ready_index.iter().collect();
+            walk_and_window(&ks, entries, anchor_id, direction, &queues, &types, limit)
+        })
+        .await?
+    }
+
+    /// Search the in-memory `InFlightIndex`. See `find_ready`.
+    pub async fn find_in_flight(
+        &self,
+        anchor_id: Option<String>,
+        direction: FindDirection,
+        queues: Vec<String>,
+        types: Vec<String>,
+        limit: usize,
+    ) -> Result<Option<FindOutcome>, StoreError> {
+        let in_flight_index = self.in_flight_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let entries: Vec<(u64, String)> = in_flight_index.iter().collect();
+            walk_and_window(&ks, entries, anchor_id, direction, &queues, &types, limit)
+        })
+        .await?
+    }
+
+    /// Search the in-memory `ScheduledIndex`. See `find_ready`.
+    pub async fn find_scheduled(
+        &self,
+        anchor_id: Option<String>,
+        direction: FindDirection,
+        queues: Vec<String>,
+        types: Vec<String>,
+        limit: usize,
+    ) -> Result<Option<FindOutcome>, StoreError> {
+        let scheduled_index = self.scheduled_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let entries: Vec<(u64, String)> = scheduled_index.iter().collect();
+            walk_and_window(&ks, entries, anchor_id, direction, &queues, &types, limit)
+        })
+        .await?
+    }
+
+    /// Return a window of jobs from the `ReadyIndex` anchored per
+    /// `anchor`. See `WindowAnchor` for anchor semantics and
+    /// `WindowFallback` for the "anchor not found" fallback.
+    pub async fn list_window_ready(
+        &self,
+        anchor: WindowAnchor,
+        fallback: WindowFallback,
+        limit: usize,
+    ) -> Result<WindowOutcome, StoreError> {
+        let ready_index = self.ready_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let entries: Vec<(u16, String)> = ready_index.iter().collect();
+            resolve_window(&ks, entries, anchor, fallback, limit)
+        })
+        .await?
+    }
+
+    /// Same shape as `list_window_ready` but over the `InFlightIndex`.
+    pub async fn list_window_in_flight(
+        &self,
+        anchor: WindowAnchor,
+        fallback: WindowFallback,
+        limit: usize,
+    ) -> Result<WindowOutcome, StoreError> {
+        let in_flight_index = self.in_flight_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let entries: Vec<(u64, String)> = in_flight_index.iter().collect();
+            resolve_window(&ks, entries, anchor, fallback, limit)
+        })
+        .await?
+    }
+
+    /// Same shape as `list_window_ready` but over the `ScheduledIndex`.
+    pub async fn list_window_scheduled(
+        &self,
+        anchor: WindowAnchor,
+        fallback: WindowFallback,
+        limit: usize,
+    ) -> Result<WindowOutcome, StoreError> {
+        let scheduled_index = self.scheduled_index.clone();
+        let ks = self.ks.clone();
+
+        task::spawn_blocking(move || {
+            let entries: Vec<(u64, String)> = scheduled_index.iter().collect();
+            resolve_window(&ks, entries, anchor, fallback, limit)
+        })
+        .await?
+    }
+}
+
+/// Shared window-resolution body used by all three `list_window_*`
+/// methods. Given a materialised list of `(sort_key, job_id)` tuples,
+/// resolves the anchor to a position, computes a window centered on
+/// it (or clamped to the head/tail per `fallback`), and hydrates the
+/// job records inside that window.
+fn resolve_window<K>(
+    ks: &super::store::Keyspaces,
+    entries: Vec<(K, String)>,
+    anchor: WindowAnchor,
+    fallback: WindowFallback,
+    limit: usize,
+) -> Result<WindowOutcome, StoreError> {
+    let total = entries.len();
+    if total == 0 {
+        return Ok(WindowOutcome {
+            items: Vec::new(),
+            first_position: 0,
+            total: 0,
+            resolved_anchor: None,
+        });
+    }
+
+    // Phase 1: resolve the anchor to a first_position for the window.
+    //
+    // `Around` centers the window on the anchor id.
+    // `Offset` uses the raw numeric offset as the window start,
+    //   clamped to the valid range.
+    // `Head` / `Tail` pin the window to the natural ends.
+    let (first_position, resolved_anchor, center_on_anchor) = match &anchor {
+        WindowAnchor::Head => (0, None, false),
+        WindowAnchor::Tail => (total.saturating_sub(limit), None, false),
+        WindowAnchor::Offset(offset) => {
+            let max_start = total.saturating_sub(limit);
+            ((*offset).min(max_start), None, false)
+        }
+        WindowAnchor::Around(id) => match entries.iter().position(|(_, jid)| jid == id) {
+            Some(pos) => (pos, Some(id.clone()), true),
+            None => match fallback {
+                WindowFallback::Head => (0, None, false),
+                WindowFallback::Tail => (total.saturating_sub(limit), None, false),
+                WindowFallback::Nowhere => {
+                    return Ok(WindowOutcome {
+                        items: Vec::new(),
+                        first_position: 0,
+                        total,
+                        resolved_anchor: None,
+                    });
+                }
+            },
+        },
+    };
+
+    // For `Around`, center the window on the resolved position; for
+    // `Head`/`Tail`/`Offset`, the first_position we just computed IS
+    // the window start.
+    let first_position = if center_on_anchor {
+        let half = limit / 2;
+        let raw_start = first_position.saturating_sub(half);
+        let max_start = total.saturating_sub(limit);
+        raw_start.min(max_start)
+    } else {
+        first_position
+    };
+    let end = (first_position + limit).min(total);
+
+    // Phase 3: hydrate.
+    let mut items = Vec::with_capacity(end - first_position);
+    for (_, id) in entries.iter().take(end).skip(first_position) {
+        if let Some(job) = load_job(ks, id)? {
+            items.push(job);
+        }
+    }
+
+    Ok(WindowOutcome {
+        items,
+        first_position,
+        total,
+        resolved_anchor,
+    })
+}
+
+/// Shared walk-and-window body over an already-materialised list of
+/// `(sort_key, job_id)` tuples. Generic over the sort key type so the
+/// three lists can share this implementation.
+fn walk_and_window<K>(
+    ks: &super::store::Keyspaces,
+    entries: Vec<(K, String)>,
+    anchor_id: Option<String>,
+    direction: FindDirection,
+    queues: &[String],
+    types: &[String],
+    limit: usize,
+) -> Result<Option<FindOutcome>, StoreError> {
+    let n = entries.len();
+    if n == 0 {
+        return Ok(None);
+    }
+
+    // Resolve anchor to a position (if any).
+    let anchor_position = match &anchor_id {
+        Some(id) => entries.iter().position(|(_, jid)| jid == id),
+        None => None,
+    };
+
+    // Phase 1: find the matched position.
+    let matched_position = match direction {
+        FindDirection::Locate => match anchor_position {
+            Some(pos) => Some(pos),
+            None => return Ok(None),
+        },
+        FindDirection::Forward => {
+            let start = match anchor_position {
+                Some(pos) => pos + 1,
+                // Anchor was requested but not found — fall back to
+                // walking from the start.
+                None => 0,
+            };
+            let mut found = None;
+            for i in start..n {
+                let (_, id) = &entries[i];
+                if let Some(job) = load_job(ks, id)? {
+                    if matches_query(queues, types, &job) {
+                        found = Some(i);
+                        break;
+                    }
+                }
+            }
+            found
+        }
+        FindDirection::Backward => {
+            let start = match anchor_position {
+                Some(pos) if pos > 0 => pos - 1,
+                Some(_) => return Ok(None), // pos = 0, nothing before it
+                // Anchor not found — fall back to walking from the end.
+                None => n - 1,
+            };
+            let mut found = None;
+            for i in (0..=start).rev() {
+                let (_, id) = &entries[i];
+                if let Some(job) = load_job(ks, id)? {
+                    if matches_query(queues, types, &job) {
+                        found = Some(i);
+                        break;
+                    }
+                }
+            }
+            found
+        }
+    };
+
+    // Phase 2: build a centered window around the match.
+    let Some(matched_position) = matched_position else {
+        return Ok(None);
+    };
+    let window_offset = window_offset_around(matched_position, limit, n);
+    let mut window_items = Vec::with_capacity(limit);
+    for i in window_offset..(window_offset + limit).min(n) {
+        let (_, id) = &entries[i];
+        if let Some(job) = load_job(ks, id)? {
+            window_items.push(job);
+        }
+    }
+
+    Ok(Some(FindOutcome {
+        matched_position,
+        window_offset,
+        window_items,
+    }))
+}
+
+/// Hydrate a job from the `jobs` keyspace by id. Returns `Ok(None)`
+/// when the job is not on disk (which can happen if the index
+/// contains an id that has already been removed — the caller just
+/// skips the entry).
+fn load_job(ks: &super::store::Keyspaces, id: &str) -> Result<Option<Job>, StoreError> {
+    let job_key = make_job_key(id);
+    match ks.data.get(&job_key)? {
+        Some(bytes) => Ok(Some(rmp_serde::from_slice(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::options::EnqueueOptions;
+    use crate::store::test_support::test_store;
+    use crate::time::now_millis;
+
+    /// Enqueue three ready jobs across two queues and two types so we
+    /// have a stable filter/order fixture:
+    ///
+    /// - `j_a` priority 10, queue=q1, type=t1
+    /// - `j_b` priority 20, queue=q2, type=t1
+    /// - `j_c` priority 30, queue=q1, type=t2
+    async fn fixture_three_ready() -> (crate::store::Store, [String; 3]) {
+        let store = test_store();
+        let now = now_millis();
+        let a = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t1", "q1", serde_json::json!(null)).priority(10),
+            )
+            .await
+            .unwrap()
+            .into_job();
+        let b = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t1", "q2", serde_json::json!(null)).priority(20),
+            )
+            .await
+            .unwrap()
+            .into_job();
+        let c = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t2", "q1", serde_json::json!(null)).priority(30),
+            )
+            .await
+            .unwrap()
+            .into_job();
+        (store, [a.id, b.id, c.id])
+    }
+
+    #[tokio::test]
+    async fn forward_from_start_returns_first_matching_queue() {
+        let (store, [_a, b, _c]) = fixture_three_ready().await;
+        let outcome = store
+            .find_ready(
+                None,
+                FindDirection::Forward,
+                vec!["q2".into()],
+                Vec::new(),
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("should find a match");
+        assert_eq!(outcome.matched_position, 1);
+        assert_eq!(
+            outcome.window_items[outcome.matched_position - outcome.window_offset].id,
+            b
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_skips_anchor_and_finds_next_match() {
+        let (store, [a, _b, c]) = fixture_three_ready().await;
+        // Anchor on j_a with query type=t2 should return j_c (index 2).
+        let outcome = store
+            .find_ready(
+                Some(a),
+                FindDirection::Forward,
+                Vec::new(),
+                vec!["t2".into()],
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("should find j_c");
+        assert_eq!(outcome.matched_position, 2);
+        assert_eq!(
+            outcome.window_items[outcome.matched_position - outcome.window_offset].id,
+            c
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_returns_none_when_no_match() {
+        let (store, _) = fixture_three_ready().await;
+        let outcome = store
+            .find_ready(
+                None,
+                FindDirection::Forward,
+                vec!["no-such-queue".into()],
+                Vec::new(),
+                10,
+            )
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+    }
+
+    #[tokio::test]
+    async fn forward_with_unknown_anchor_falls_back_to_start() {
+        let (store, [a, _b, _c]) = fixture_three_ready().await;
+        // Unknown anchor + queue=q1 should match j_a at position 0.
+        let outcome = store
+            .find_ready(
+                Some("nonexistent".into()),
+                FindDirection::Forward,
+                vec!["q1".into()],
+                Vec::new(),
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("should fall back and match j_a");
+        assert_eq!(outcome.matched_position, 0);
+        assert_eq!(outcome.window_items[0].id, a);
+    }
+
+    #[tokio::test]
+    async fn backward_from_anchor_finds_earlier_match() {
+        let (store, [_a, b, c]) = fixture_three_ready().await;
+        // Backward from j_c with type=t1 — the closest t1 walking
+        // backward from position 2 is j_b at position 1.
+        let outcome = store
+            .find_ready(
+                Some(c),
+                FindDirection::Backward,
+                Vec::new(),
+                vec!["t1".into()],
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("should find a t1 match before j_c");
+        assert_eq!(outcome.matched_position, 1);
+        let local = outcome.matched_position - outcome.window_offset;
+        assert_eq!(outcome.window_items[local].id, b);
+    }
+
+    #[tokio::test]
+    async fn substring_type_match_finds_prefixed_type() {
+        // audit.create, audit.delete, payment.process across three
+        // queues. Type: "audit" should match the first two.
+        let store = test_store();
+        let now = now_millis();
+        let a = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("audit.create", "emails", serde_json::json!(null)).priority(10),
+            )
+            .await
+            .unwrap()
+            .into_job()
+            .id;
+        let _b = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("audit.delete", "billing", serde_json::json!(null))
+                    .priority(20),
+            )
+            .await
+            .unwrap()
+            .into_job()
+            .id;
+        let _c = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("payment.process", "emails", serde_json::json!(null))
+                    .priority(30),
+            )
+            .await
+            .unwrap()
+            .into_job()
+            .id;
+
+        let outcome = store
+            .find_ready(
+                None,
+                FindDirection::Forward,
+                Vec::new(),
+                vec!["audit".into()],
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("substring `audit` should hit audit.create at position 0");
+        assert_eq!(outcome.matched_position, 0);
+        assert_eq!(outcome.window_items[0].id, a);
+    }
+
+    #[tokio::test]
+    async fn substring_and_across_type_and_queue() {
+        // Type: audit, Queue: emails — only the first job matches both.
+        let store = test_store();
+        let now = now_millis();
+        let a = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("audit.create", "emails", serde_json::json!(null)).priority(10),
+            )
+            .await
+            .unwrap()
+            .into_job()
+            .id;
+        // audit.delete on billing — matches type but not queue.
+        let _b = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("audit.delete", "billing", serde_json::json!(null))
+                    .priority(20),
+            )
+            .await
+            .unwrap()
+            .into_job()
+            .id;
+        // payment.process on emails — matches queue but not type.
+        let _c = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("payment.process", "emails", serde_json::json!(null))
+                    .priority(30),
+            )
+            .await
+            .unwrap()
+            .into_job()
+            .id;
+
+        let outcome = store
+            .find_ready(
+                None,
+                FindDirection::Forward,
+                vec!["emails".into()],
+                vec!["audit".into()],
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("only audit.create on emails matches both");
+        assert_eq!(outcome.matched_position, 0);
+        assert_eq!(outcome.window_items[0].id, a);
+    }
+
+    #[tokio::test]
+    async fn locate_returns_current_position_of_anchor() {
+        let (store, [_a, b, _c]) = fixture_three_ready().await;
+        let outcome = store
+            .find_ready(
+                Some(b.clone()),
+                FindDirection::Locate,
+                // Query is ignored under Locate.
+                vec!["irrelevant".into()],
+                Vec::new(),
+                10,
+            )
+            .await
+            .unwrap()
+            .expect("should locate j_b");
+        assert_eq!(outcome.matched_position, 1);
+        assert_eq!(
+            outcome.window_items[outcome.matched_position - outcome.window_offset].id,
+            b
+        );
+    }
+
+    #[tokio::test]
+    async fn locate_returns_none_when_anchor_gone() {
+        let (store, _) = fixture_three_ready().await;
+        let outcome = store
+            .find_ready(
+                Some("does-not-exist".into()),
+                FindDirection::Locate,
+                Vec::new(),
+                Vec::new(),
+                10,
+            )
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+    }
+
+    #[tokio::test]
+    async fn window_is_centered_on_match() {
+        let store = test_store();
+        let now = now_millis();
+        let mut ids = Vec::new();
+        for i in 0..10u16 {
+            let job = store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t1", "q1", serde_json::json!(null)).priority(i),
+                )
+                .await
+                .unwrap()
+                .into_job();
+            ids.push(job.id);
+        }
+        // Anchor at position 0, forward, query is trivial (matches all).
+        // First match after position 0 is position 1. Window limit 4 —
+        // centered gives offset = 1 - 2 = 0, items 0..4.
+        let outcome = store
+            .find_ready(
+                Some(ids[0].clone()),
+                FindDirection::Forward,
+                Vec::new(),
+                Vec::new(),
+                4,
+            )
+            .await
+            .unwrap()
+            .expect("should find next job");
+        assert_eq!(outcome.matched_position, 1);
+        assert_eq!(outcome.window_offset, 0);
+        assert_eq!(outcome.window_items.len(), 4);
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -6,6 +6,7 @@ mod cron;
 mod delete;
 mod enqueue;
 mod fail;
+mod find;
 mod group_committer;
 mod in_flight_index;
 mod keys;
@@ -33,6 +34,8 @@ pub use options::{
     JobFilter, ListErrorsOptions, ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
     RetentionConfigPatch,
 };
+
+pub use find::{FindDirection, FindOutcome, WindowAnchor, WindowFallback, WindowOutcome};
 
 pub use results::{BulkCompleteResult, EnqueueResult, ListErrorsPage, ListJobsPage};
 


### PR DESCRIPTION
This was a lot of work to get working in a way that feels right.

Pressing the `/` key inside of `zizq top` now brings up two text input fields for `Type:` and `Queue:`. Users can enter comma-separated values in these fields, and the query is sent over the websocket, which anchors the job list to the matching job. The cursor follows this job as the queue drains.

Pressing `n` or `N` searches for the next/previous matching job.

Manually scrolling (`PgUp`, `PgDn`, Up`, `Down`, `g`, `G`) unpins the job under the cursor and resumes scrolling normally.

This may need some refinement over the next few releases, but it works well enough to ship now.