### PR TITLE
Implement Batched Jobs (-> v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.6.0
+
+- Added **batched jobs** (Pro): a new `batch` field on enqueue
+  requests that accumulates multiple enqueues into a single pending
+  job's payload. Callers supply `batch.key` (identifies the batch),
+  `batch.when` (a jq predicate deciding whether to fold), and
+  `batch.fold` (a jq reducer producing the merged payload). Both
+  expressions run with `$existing` bound to the current pending
+  payload and `$new` bound to the incoming one. When `when` returns
+  truthy the payloads are merged in place at a fresh payload key
+  (preserving FIFO position); when falsy the existing batch seals
+  and a new pending job takes over. Once claimed, a batched job is
+  a normal job — workers see one merged payload and ack once.
+  Suited to downstream services that accept batched calls (APNs
+  push, SES bulk send, etc.) but whose callers enqueue one unit at
+  a time. The first enqueue's `when`/`fold` are stored on the job
+  and win for the whole batch — follow-up enqueues supply payload
+  against the existing config until seal. Enqueue responses gain a
+  `folded: true | false` field, symmetric with `duplicate`.
+  Combining `unique_key` and `batch` on a single enqueue is a 400.
+  Cron entries may carry a `batch` config; the fold logic runs at
+  fire time. Job reads (`GET /jobs`, `GET /jobs/{id}`, enqueue
+  responses) include the stored `batch` config so callers can
+  inspect exactly what `when`/`fold` the batch is running against.
+
 ## 0.5.1
 
 - Added `/` search to `zizq top`. Two labeled fields — Type and Queue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.1/zizq-0.5.1-linux-x86_64.tar.gz
-tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.0/zizq-0.6.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -57,7 +57,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.5.1
+Zizq 0.6.0
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.1/zizq-0.5.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.0/zizq-0.6.0-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -17,7 +17,7 @@ does almost all of the work.
 > Download:
 >
 > ```bash
-> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.5.1/zizq-0.5.1-linux-x86_64.tar.gz
+> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.0/zizq-0.6.0-linux-x86_64.tar.gz
 > ```
 
 ### 2. Extract it.
@@ -25,7 +25,7 @@ does almost all of the work.
 > Extract:
 >
 > ```bash
-> tar -xvzf zizq-0.5.1-linux-x86_64.tar.gz
+> tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
 > ```
 
 ### 3. Run it to start the server.
@@ -35,7 +35,7 @@ does almost all of the work.
 > ```bash
 > ./zizq serve
 > 
-> Zizq 0.5.1
+> Zizq 0.6.0
 > 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 > 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 > 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -531,13 +531,12 @@ async fn enqueue(
         );
     }
 
-    // Batched jobs are recognized but not yet implemented.
-    if enqueue_req.batch.is_some() {
+    if enqueue_req.unique_key.is_some() && enqueue_req.batch.is_some() {
         return respond(
             fmt,
-            StatusCode::NOT_IMPLEMENTED,
+            StatusCode::BAD_REQUEST,
             &ErrorResponse {
-                error: "batched jobs are not yet implemented".into(),
+                error: "unique_key and batch cannot be combined".into(),
             },
         );
     }
@@ -550,6 +549,19 @@ async fn enqueue(
             .read()
             .unwrap()
             .require(now_ms, crate::license::Feature::UniqueJobs)
+        {
+            return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+        }
+    }
+
+    // License check for batched jobs.
+    if enqueue_req.batch.is_some() {
+        let now_ms = (state.clock)();
+        if let Err(e) = state
+            .license
+            .read()
+            .unwrap()
+            .require(now_ms, crate::license::Feature::BatchedJobs)
         {
             return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
         }
@@ -584,6 +596,9 @@ async fn enqueue(
             }
         }
     }
+    if let Some(batch) = enqueue_req.batch {
+        opts = opts.batch(batch.into());
+    }
 
     let now = (state.clock)();
     match state
@@ -593,7 +608,7 @@ async fn enqueue(
         .and_then(Job::try_from_result)
     {
         Ok(mut job) => {
-            let status_code = if job.duplicate == Some(true) {
+            let status_code = if job.duplicate == Some(true) || job.folded == Some(true) {
                 StatusCode::OK
             } else {
                 StatusCode::CREATED
@@ -613,6 +628,11 @@ async fn enqueue(
             job.payload = None;
             respond(fmt, status_code, &job)
         }
+        Err(StoreError::InvalidOperation(msg)) => respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error: msg },
+        ),
         Err(e) => {
             tracing::error!(%e, "enqueue failed");
             respond(
@@ -634,6 +654,7 @@ async fn bulk_enqueue(
 ) -> Response {
     // Validate all jobs up front.
     let mut has_unique = false;
+    let mut has_batch = false;
     for (i, job) in req.jobs.iter().enumerate() {
         if let Err(msg) = validate_name("type", &job.job_type) {
             return respond(
@@ -677,11 +698,14 @@ async fn bulk_enqueue(
             has_unique = true;
         }
         if job.batch.is_some() {
+            has_batch = true;
+        }
+        if job.unique_key.is_some() && job.batch.is_some() {
             return respond(
                 fmt,
-                StatusCode::NOT_IMPLEMENTED,
+                StatusCode::BAD_REQUEST,
                 &ErrorResponse {
-                    error: format!("jobs[{i}]: batched jobs are not yet implemented"),
+                    error: format!("jobs[{i}]: unique_key and batch cannot be combined"),
                 },
             );
         }
@@ -695,6 +719,19 @@ async fn bulk_enqueue(
             .read()
             .unwrap()
             .require(now_ms, crate::license::Feature::UniqueJobs)
+        {
+            return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+        }
+    }
+
+    // License check for batched jobs (once for the whole batch).
+    if has_batch {
+        let now_ms = (state.clock)();
+        if let Err(e) = state
+            .license
+            .read()
+            .unwrap()
+            .require(now_ms, crate::license::Feature::BatchedJobs)
         {
             return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
         }
@@ -732,6 +769,9 @@ async fn bulk_enqueue(
                 // Already validated above.
                 opts = opts.unique_while(parse_unique_while(&unique_while).unwrap());
             }
+            if let Some(batch) = enqueue_req.batch {
+                opts = opts.batch(batch.into());
+            }
             opts
         })
         .collect();
@@ -739,8 +779,10 @@ async fn bulk_enqueue(
     let now = (state.clock)();
     match state.store.enqueue_bulk(now, opts).await {
         Ok(store_results) => {
-            let all_duplicates =
-                !store_results.is_empty() && store_results.iter().all(|r| r.is_duplicate());
+            let all_no_new_jobs = !store_results.is_empty()
+                && store_results
+                    .iter()
+                    .all(|r| r.is_duplicate() || r.is_folded());
             let jobs: Result<Vec<Job>, StoreError> = store_results
                 .into_iter()
                 .map(|r| {
@@ -751,7 +793,7 @@ async fn bulk_enqueue(
                 .collect();
             match jobs {
                 Ok(jobs) => {
-                    let status_code = if all_duplicates {
+                    let status_code = if all_no_new_jobs {
                         StatusCode::OK
                     } else {
                         StatusCode::CREATED
@@ -771,6 +813,11 @@ async fn bulk_enqueue(
                 }
             }
         }
+        Err(StoreError::InvalidOperation(msg)) => respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error: msg },
+        ),
         Err(e) => {
             tracing::error!(%e, "bulk enqueue failed");
             respond(
@@ -6772,6 +6819,138 @@ mod tests {
         assert!(!jobs[0]["duplicate"].as_bool().unwrap());
         assert!(jobs[1]["duplicate"].as_bool().unwrap());
         assert!(!jobs[2]["duplicate"].as_bool().unwrap());
+    }
+
+    // --- Batched jobs ---
+
+    fn batch_enqueue_body(payload: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "type": "push",
+            "queue": "q",
+            "payload": payload,
+            "batch": {
+                "key": "k",
+                "when": "true",
+                "fold": "$existing + $new",
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn batch_enqueue_returns_403_on_free_tier() {
+        let req = json_request("POST", "/jobs", &batch_enqueue_body(serde_json::json!([1])));
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(
+            body["error"].as_str().unwrap().contains("pro license"),
+            "error should mention pro license, got: {}",
+            body["error"]
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_enqueue_first_returns_201_and_folded_false() {
+        let req = json_request("POST", "/jobs", &batch_enqueue_body(serde_json::json!([1])));
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["folded"], false);
+    }
+
+    #[tokio::test]
+    async fn batch_enqueue_second_returns_200_and_folded_true() {
+        let app = pro_app();
+
+        let req1 = json_request("POST", "/jobs", &batch_enqueue_body(serde_json::json!([1])));
+        let res1 = app.clone().oneshot(req1).await.unwrap();
+        assert_eq!(res1.status(), StatusCode::CREATED);
+        let body1: serde_json::Value = serde_json::from_str(&response_body(res1).await).unwrap();
+
+        let req2 = json_request("POST", "/jobs", &batch_enqueue_body(serde_json::json!([2])));
+        let res2 = app.oneshot(req2).await.unwrap();
+        assert_eq!(res2.status(), StatusCode::OK);
+
+        let body2: serde_json::Value = serde_json::from_str(&response_body(res2).await).unwrap();
+        assert_eq!(body2["folded"], true);
+        assert_eq!(body2["id"], body1["id"]);
+    }
+
+    #[tokio::test]
+    async fn batch_and_unique_together_returns_400() {
+        let mut body = batch_enqueue_body(serde_json::json!([1]));
+        body["unique_key"] = serde_json::json!("u");
+
+        let req = json_request("POST", "/jobs", &body);
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("cannot be combined"),
+            "got: {}",
+            body["error"]
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_invalid_expression_returns_422() {
+        let body = serde_json::json!({
+            "type": "push",
+            "queue": "q",
+            "payload": [1],
+            "batch": {
+                "key": "k",
+                "when": ".[*]",
+                "fold": "$existing + $new",
+            }
+        });
+        let req = json_request("POST", "/jobs", &body);
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn bulk_batch_enqueue_returns_403_on_free_tier() {
+        let req = json_request(
+            "POST",
+            "/jobs/bulk",
+            &serde_json::json!({
+                "jobs": [ batch_enqueue_body(serde_json::json!([1])) ],
+            }),
+        );
+        let res = test_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn bulk_batch_folds_within_call() {
+        let req = json_request(
+            "POST",
+            "/jobs/bulk",
+            &serde_json::json!({
+                "jobs": [
+                    batch_enqueue_body(serde_json::json!([1])),
+                    batch_enqueue_body(serde_json::json!([2])),
+                    batch_enqueue_body(serde_json::json!([3])),
+                ],
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let jobs = body["jobs"].as_array().unwrap();
+        assert_eq!(jobs[0]["folded"], false);
+        assert_eq!(jobs[1]["folded"], true);
+        assert_eq!(jobs[2]["folded"], true);
+        assert_eq!(jobs[1]["id"], jobs[0]["id"]);
+        assert_eq!(jobs[2]["id"], jobs[0]["id"]);
     }
 
     // --- DELETE /jobs/{id} ---

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -2320,6 +2320,10 @@ fn validate_cron_entry(entry: CronEntryRequest) -> Result<store::CronEntryOption
         return Err("ready_at is not supported for cron entries".into());
     }
 
+    if entry.job.unique_key.is_some() && entry.job.batch.is_some() {
+        return Err("unique_key and batch cannot be combined".into());
+    }
+
     let unique_while = if let Some(ref s) = entry.job.unique_while {
         Some(parse_unique_while(s)?)
     } else {
@@ -2346,6 +2350,9 @@ fn validate_cron_entry(entry: CronEntryRequest) -> Result<store::CronEntryOption
     }
     if let Some(uw) = unique_while {
         opts = opts.unique_while(uw);
+    }
+    if let Some(batch) = entry.job.batch {
+        opts = opts.batch(batch.into());
     }
 
     Ok(store::CronEntryOptions {

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -6886,6 +6886,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn batch_folded_payload_visible_via_get() {
+        // Reproduces a user-reported scenario: fold two enqueues,
+        // then fetch the job via GET /jobs/{id} and verify the merged
+        // payload survives round-trip through the API.
+        let app = pro_app();
+
+        let make_body = |v| {
+            serde_json::json!({
+                "type": "audit.events",
+                "queue": "audit",
+                "batch": {
+                    "key": "audit.events",
+                    "when": "[$existing[], $new[]] | length <= 5",
+                    "fold": "$existing | . += $new",
+                },
+                "payload": v,
+            })
+        };
+
+        let req1 = json_request("POST", "/jobs", &make_body(serde_json::json!([{"a": 1}])));
+        let res1 = app.clone().oneshot(req1).await.unwrap();
+        assert_eq!(res1.status(), StatusCode::CREATED);
+        let body1: serde_json::Value = serde_json::from_str(&response_body(res1).await).unwrap();
+        let job_id = body1["id"].as_str().unwrap().to_string();
+
+        let req2 = json_request("POST", "/jobs", &make_body(serde_json::json!([{"a": 2}])));
+        let res2 = app.clone().oneshot(req2).await.unwrap();
+        assert_eq!(res2.status(), StatusCode::OK);
+        let body2: serde_json::Value = serde_json::from_str(&response_body(res2).await).unwrap();
+        assert_eq!(body2["folded"], true);
+        assert_eq!(body2["id"], serde_json::json!(job_id));
+
+        // Fetch via GET and verify the merged payload.
+        let get_req = json_request("GET", &format!("/jobs/{job_id}"), &serde_json::json!({}));
+        let get_res = app.oneshot(get_req).await.unwrap();
+        assert_eq!(get_res.status(), StatusCode::OK);
+        let get_body: serde_json::Value =
+            serde_json::from_str(&response_body(get_res).await).unwrap();
+        assert_eq!(get_body["payload"], serde_json::json!([{"a": 1}, {"a": 2}]));
+
+        // Also verify the stored batch config is visible on the response
+        // — critical for debugging "first-wins" surprises.
+        assert_eq!(get_body["batch"]["key"], "audit.events");
+        assert_eq!(
+            get_body["batch"]["when"],
+            "[$existing[], $new[]] | length <= 5"
+        );
+        assert_eq!(get_body["batch"]["fold"], "$existing | . += $new");
+    }
+
+    #[tokio::test]
     async fn batch_and_unique_together_returns_400() {
         let mut body = batch_enqueue_body(serde_json::json!([1]));
         body["unique_key"] = serde_json::json!("u");

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -531,6 +531,17 @@ async fn enqueue(
         );
     }
 
+    // Batched jobs are recognized but not yet implemented.
+    if enqueue_req.batch.is_some() {
+        return respond(
+            fmt,
+            StatusCode::NOT_IMPLEMENTED,
+            &ErrorResponse {
+                error: "batched jobs are not yet implemented".into(),
+            },
+        );
+    }
+
     // License check for unique jobs.
     if enqueue_req.unique_key.is_some() {
         let now_ms = (state.clock)();
@@ -664,6 +675,15 @@ async fn bulk_enqueue(
         }
         if job.unique_key.is_some() {
             has_unique = true;
+        }
+        if job.batch.is_some() {
+            return respond(
+                fmt,
+                StatusCode::NOT_IMPLEMENTED,
+                &ErrorResponse {
+                    error: format!("jobs[{i}]: batched jobs are not yet implemented"),
+                },
+            );
         }
     }
 

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -345,6 +345,13 @@ pub struct Job {
     /// Only present on enqueue responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub folded: Option<bool>,
+
+    /// Batching configuration stored on this job. The first enqueue's
+    /// `when`/`fold` are the ones that apply for the life of the batch,
+    /// so exposing them on reads lets callers inspect exactly what's
+    /// being evaluated rather than guessing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<BatchConfig>,
 }
 
 /// Convert a store job to an HTTP job, failing if the status byte is invalid.
@@ -410,6 +417,7 @@ impl Job {
             unique_while,
             duplicate,
             folded,
+            batch: job.batch.map(Into::into),
         })
     }
 }

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -340,6 +340,11 @@ pub struct Job {
     /// Only present on enqueue responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duplicate: Option<bool>,
+
+    /// Whether this enqueue was folded into an existing pending batched job.
+    /// Only present on enqueue responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub folded: Option<bool>,
 }
 
 /// Convert a store job to an HTTP job, failing if the status byte is invalid.
@@ -347,27 +352,33 @@ impl TryFrom<store::Job> for Job {
     type Error = StoreError;
 
     fn try_from(job: store::Job) -> Result<Self, Self::Error> {
-        Self::from_store_job(job, None)
+        Self::from_store_job(job, None, None)
     }
 }
 
 impl Job {
-    /// Convert an enqueue result (created or duplicate) into an HTTP job.
+    /// Convert an enqueue result into an HTTP job.
     ///
-    /// Sets the `duplicate` flag based on the result variant so the API
-    /// response can distinguish new jobs from deduplication matches.
+    /// Sets the `duplicate` and `folded` flags based on the result variant
+    /// so the API response can distinguish new jobs from deduplication
+    /// matches and from fold-into-existing-batch outcomes.
     pub fn try_from_result(result: store::EnqueueResult) -> Result<Self, StoreError> {
         let is_duplicate = result.is_duplicate();
+        let is_folded = result.is_folded();
         let job = result.into_job();
-        Self::from_store_job(job, Some(is_duplicate))
+        Self::from_store_job(job, Some(is_duplicate), Some(is_folded))
     }
 
     /// Shared conversion from a store job to an HTTP job.
     ///
     /// Maps compact storage field names and u8 enums to the descriptive
-    /// HTTP representation. The `duplicate` flag is `None` for normal
-    /// lookups and `Some(bool)` for enqueue responses.
-    fn from_store_job(job: store::Job, duplicate: Option<bool>) -> Result<Self, StoreError> {
+    /// HTTP representation. The `duplicate` and `folded` flags are `None`
+    /// for normal lookups and `Some(bool)` for enqueue responses.
+    fn from_store_job(
+        job: store::Job,
+        duplicate: Option<bool>,
+        folded: Option<bool>,
+    ) -> Result<Self, StoreError> {
         let unique_while = job.unique.as_ref().map(|uc| match uc.scope {
             0 => "queued".to_string(),
             1 => "active".to_string(),
@@ -398,6 +409,7 @@ impl Job {
             unique_key: job.unique.map(|uc| uc.key),
             unique_while,
             duplicate,
+            folded,
         })
     }
 }
@@ -496,6 +508,11 @@ pub struct EnqueueRequest {
     /// Only valid when `unique_key` is present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_while: Option<String>,
+
+    /// Batching configuration. When present, this enqueue may be folded
+    /// into an existing pending job sharing the same `batch.key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<BatchConfig>,
 }
 
 /// Request shape for bulk job enqueue.
@@ -566,6 +583,46 @@ impl From<store::BackoffConfig> for BackoffConfig {
             exponent: b.exponent,
             base_ms: b.base_ms,
             jitter_ms: b.jitter_ms,
+        }
+    }
+}
+
+/// Client-facing batching configuration.
+///
+/// Mirrors `store::BatchConfig` with the same three fields; kept as a
+/// separate type so the HTTP schema can evolve independently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchConfig {
+    /// Identifies the batch. Only one pending batch may exist per key at
+    /// a time on a given queue.
+    pub key: String,
+
+    /// jq predicate deciding whether to fold this enqueue into the
+    /// existing pending batch (`true`) or seal it and start a new batch
+    /// (`false`). Runs against `$existing` and `$new`.
+    pub when: String,
+
+    /// jq expression producing the merged payload when `when` returns
+    /// true. Runs against `$existing` and `$new`.
+    pub fold: String,
+}
+
+impl From<BatchConfig> for store::BatchConfig {
+    fn from(b: BatchConfig) -> Self {
+        Self {
+            key: b.key,
+            when: b.when,
+            fold: b.fold,
+        }
+    }
+}
+
+impl From<store::BatchConfig> for BatchConfig {
+    fn from(b: store::BatchConfig) -> Self {
+        Self {
+            key: b.key,
+            when: b.when,
+            fold: b.fold,
         }
     }
 }
@@ -1157,6 +1214,7 @@ impl CronEntryResponse {
                 retention: entry.job.retention.map(Into::into),
                 unique_key: entry.job.unique_key,
                 unique_while,
+                batch: entry.job.batch.map(Into::into),
             },
             next_enqueue_at: entry.next_enqueue_at,
             last_enqueue_at: entry.last_enqueue_at,

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -482,6 +482,37 @@ mod tests {
     }
 
     #[test]
+    fn eval_fold_pipe_into_compound_assign() {
+        // User-reported expression: `$existing | . += $new`.
+        // Should produce $existing + $new (array concat).
+        let expr = BatchExpr::compile("true", "$existing | . += $new").unwrap();
+        let out = expr
+            .eval_fold(&json!([{"a": 1}]), &json!([{"a": 2}]))
+            .unwrap();
+        assert_eq!(out, json!([{"a": 1}, {"a": 2}]));
+    }
+
+    #[test]
+    fn eval_fold_pipe_into_array_constructor_using_input() {
+        // User-reported expression: `$existing | [.[], $new[]]`.
+        let expr = BatchExpr::compile("true", "$existing | [.[], $new[]]").unwrap();
+        let out = expr
+            .eval_fold(&json!([{"a": 1}]), &json!([{"a": 2}]))
+            .unwrap();
+        assert_eq!(out, json!([{"a": 1}, {"a": 2}]));
+    }
+
+    #[test]
+    fn eval_fold_array_constructor_from_both_vars() {
+        // User-reported expression: `$existing | [$existing[], $new[]]`.
+        let expr = BatchExpr::compile("true", "$existing | [$existing[], $new[]]").unwrap();
+        let out = expr
+            .eval_fold(&json!([{"a": 1}]), &json!([{"a": 2}]))
+            .unwrap();
+        assert_eq!(out, json!([{"a": 1}, {"a": 2}]));
+    }
+
+    #[test]
     fn eval_fold_preserves_integer_precision() {
         let expr = BatchExpr::compile("true", "9007199254740993").unwrap();
         // 2^53 + 1 cannot be represented exactly as an f64, so a naive

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,497 @@
+// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! jq-style expression evaluation for batched jobs.
+//!
+//! Batched jobs carry two jq expressions: a `when` predicate deciding
+//! whether to fold a new enqueue into an existing pending batch, and a
+//! `fold` reducer producing the merged payload. Both expressions run with
+//! `$existing` bound to the current pending payload and `$new` bound to
+//! the incoming payload; neither expression consumes a piped input.
+
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{Compiler, Ctx, Vars, data, unwrap_valr};
+use jaq_json::{Num, Val};
+
+/// Compiled `when` and `fold` expressions ready for repeated evaluation.
+pub struct BatchExpr {
+    when_expr: String,
+    fold_expr: String,
+    when: jaq_core::Filter<data::JustLut<Val>>,
+    fold: jaq_core::Filter<data::JustLut<Val>>,
+}
+
+impl BatchExpr {
+    /// The original `when` expression string.
+    pub fn when_expression(&self) -> &str {
+        &self.when_expr
+    }
+
+    /// The original `fold` expression string.
+    pub fn fold_expression(&self) -> &str {
+        &self.fold_expr
+    }
+}
+
+impl std::fmt::Debug for BatchExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchExpr")
+            .field("when", &self.when_expr)
+            .field("fold", &self.fold_expr)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BatchExpr {
+    /// Compile both `when` and `fold` expressions.
+    ///
+    /// Both expressions are compiled with `$existing` and `$new` declared
+    /// as global variables. Errors from either expression are surfaced as
+    /// a single human-readable string.
+    pub fn compile(when_expr: &str, fold_expr: &str) -> Result<Self, String> {
+        let when = compile_one(when_expr).map_err(|e| format!("when: {e}"))?;
+        let fold = compile_one(fold_expr).map_err(|e| format!("fold: {e}"))?;
+        Ok(Self {
+            when_expr: when_expr.to_string(),
+            fold_expr: fold_expr.to_string(),
+            when,
+            fold,
+        })
+    }
+
+    /// Evaluate the `when` predicate.
+    ///
+    /// Returns `true` if the first output is truthy (not `false`, not
+    /// `null`). No output, runtime errors, or a leading falsy value all
+    /// return `false`, matching the conservative semantics used for
+    /// payload filters.
+    pub fn eval_when(&self, existing: &serde_json::Value, new: &serde_json::Value) -> bool {
+        let (Some(existing_val), Some(new_val)) = (to_val(existing), to_val(new)) else {
+            return false;
+        };
+        let ctx =
+            Ctx::<data::JustLut<Val>>::new(&self.when.lut, Vars::new([existing_val, new_val]));
+
+        // `when` and `fold` are expected to be self-contained expressions
+        // that operate on `$existing`/`$new` rather than a piped input.
+        // Passing `Val::Null` as the input matches jq's behaviour of
+        // running a top-level expression against the implicit null input
+        // when no data is piped in.
+        self.when
+            .id
+            .run((ctx, Val::Null))
+            .map(unwrap_valr)
+            .next()
+            .and_then(Result::ok)
+            .map(|v| is_truthy(&v))
+            .unwrap_or(false)
+    }
+
+    /// Evaluate the `fold` reducer, returning the merged payload.
+    ///
+    /// Returns an error if the expression fails at runtime, produces no
+    /// output, or produces more than one output. A reducer must yield
+    /// exactly one merged payload; a multi-output expression indicates a
+    /// misuse of jq that would silently lose data if we picked one.
+    pub fn eval_fold(
+        &self,
+        existing: &serde_json::Value,
+        new: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let existing_val = to_val(existing)
+            .ok_or_else(|| "existing payload could not be interpreted as JSON".to_string())?;
+        let new_val = to_val(new)
+            .ok_or_else(|| "new payload could not be interpreted as JSON".to_string())?;
+
+        let ctx =
+            Ctx::<data::JustLut<Val>>::new(&self.fold.lut, Vars::new([existing_val, new_val]));
+
+        let mut iter = self.fold.id.run((ctx, Val::Null)).map(unwrap_valr);
+        let first = iter
+            .next()
+            .ok_or_else(|| "fold expression produced no output".to_string())?
+            .map_err(|e| format!("fold expression failed at runtime: {e}"))?;
+
+        if iter.next().is_some() {
+            return Err("fold expression produced more than one output".to_string());
+        }
+
+        val_to_json(&first)
+    }
+}
+
+/// Structural conversion from a jaq `Val` to a `serde_json::Value`.
+///
+/// `jaq_json::Val` is a JSON superset — it can hold non-UTF-8 byte
+/// strings, non-string object keys, and arbitrary-precision numbers
+/// that don't fit into JSON. Each of those cases becomes a hard error
+/// rather than silent lossy coercion. Everything else walks
+/// structurally.
+///
+/// Swap this out for a `serde::Serialize`-based path if `jaq-json` ever
+/// grows one.
+fn val_to_json(v: &Val) -> Result<serde_json::Value, String> {
+    match v {
+        Val::Null => Ok(serde_json::Value::Null),
+        Val::Bool(b) => Ok(serde_json::Value::Bool(*b)),
+        Val::Num(n) => num_to_number(n).map(serde_json::Value::Number),
+        Val::BStr(bytes) => bytes_to_string(bytes, "byte string"),
+        Val::TStr(bytes) => bytes_to_string(bytes, "text string"),
+        Val::Arr(vec) => {
+            let items: Result<Vec<_>, _> = vec.iter().map(val_to_json).collect();
+            items.map(serde_json::Value::Array)
+        }
+        Val::Obj(map) => {
+            let mut obj = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map.iter() {
+                let key = object_key(k)?;
+                obj.insert(key, val_to_json(v)?);
+            }
+            Ok(serde_json::Value::Object(obj))
+        }
+    }
+}
+
+fn bytes_to_string(bytes: &[u8], kind: &str) -> Result<serde_json::Value, String> {
+    std::str::from_utf8(bytes)
+        .map(|s| serde_json::Value::String(s.to_string()))
+        .map_err(|e| format!("{kind} is not valid UTF-8: {e}"))
+}
+
+fn object_key(v: &Val) -> Result<String, String> {
+    match v {
+        Val::BStr(bytes) | Val::TStr(bytes) => std::str::from_utf8(bytes)
+            .map(str::to_string)
+            .map_err(|e| format!("object key is not valid UTF-8: {e}")),
+        other => Err(format!(
+            "object key is not a string (got {})",
+            type_name(other)
+        )),
+    }
+}
+
+fn type_name(v: &Val) -> &'static str {
+    match v {
+        Val::Null => "null",
+        Val::Bool(_) => "bool",
+        Val::Num(_) => "number",
+        Val::BStr(_) | Val::TStr(_) => "string",
+        Val::Arr(_) => "array",
+        Val::Obj(_) => "object",
+    }
+}
+
+fn num_to_number(n: &Num) -> Result<serde_json::Number, String> {
+    match n {
+        Num::Int(i) => Ok(serde_json::Number::from(*i)),
+        Num::BigInt(bi) => {
+            // Round-trip via a decimal string to avoid depending on
+            // num_traits directly. serde_json's parser reads bare
+            // integers into a Number without loss when they fit i64/u64;
+            // wider values may lose precision or fail depending on
+            // features — surface any failure as a hard error rather
+            // than silently coercing.
+            parse_number_str(&bi.to_string(), "big integer")
+        }
+        Num::Float(f) => serde_json::Number::from_f64(*f).ok_or_else(|| {
+            format!("floating-point value {f} is not representable in JSON (NaN or Infinity)")
+        }),
+        Num::Dec(s) => parse_number_str(s, "decimal number"),
+    }
+}
+
+fn parse_number_str(s: &str, kind: &str) -> Result<serde_json::Number, String> {
+    match serde_json::from_str::<serde_json::Value>(s) {
+        Ok(serde_json::Value::Number(n)) => Ok(n),
+        Ok(other) => Err(format!(
+            "{kind} \"{s}\" parses to a non-numeric JSON value: {other}"
+        )),
+        Err(e) => Err(format!("{kind} \"{s}\" is not representable in JSON: {e}")),
+    }
+}
+
+fn compile_one(expression: &str) -> Result<jaq_core::Filter<data::JustLut<Val>>, String> {
+    let arena = Arena::default();
+    let loader = Loader::new(
+        jaq_core::defs()
+            .chain(jaq_std::defs())
+            .chain(jaq_json::defs()),
+    );
+
+    let modules = loader
+        .load(
+            &arena,
+            File {
+                path: (),
+                code: expression,
+            },
+        )
+        .map_err(format_load_errors)?;
+
+    Compiler::default()
+        .with_funs(
+            jaq_core::funs()
+                .chain(jaq_std::funs())
+                .chain(jaq_json::funs()),
+        )
+        .with_global_vars(["$existing", "$new"])
+        .compile(modules)
+        .map_err(format_compile_errors)
+}
+
+fn to_val(v: &serde_json::Value) -> Option<Val> {
+    serde_json::from_value::<Val>(v.clone()).ok()
+}
+
+fn is_truthy(v: &Val) -> bool {
+    !matches!(v, Val::Bool(false) | Val::Null)
+}
+
+fn format_load_errors(
+    errs: Vec<(jaq_core::load::File<&str, ()>, jaq_core::load::Error<&str>)>,
+) -> String {
+    use jaq_core::load::Error;
+
+    let mut messages = Vec::new();
+    for (_, err) in &errs {
+        match err {
+            Error::Io(_) => {
+                messages.push("unexpected I/O error".to_string());
+            }
+            Error::Lex(lexes) => {
+                for (expected, got) in lexes {
+                    messages.push(format!("expected {}, got \"{}\"", expected.as_str(), got));
+                }
+            }
+            Error::Parse(parses) => {
+                for (expected, got) in parses {
+                    if got.is_empty() {
+                        messages.push(format!("expected {}", expected.as_str()));
+                    } else {
+                        messages.push(format!("expected {}, got \"{}\"", expected.as_str(), got));
+                    }
+                }
+            }
+        }
+    }
+
+    if messages.is_empty() {
+        "invalid expression".to_string()
+    } else {
+        messages.join("; ")
+    }
+}
+
+fn format_compile_errors(
+    errs: Vec<(
+        jaq_core::load::File<&str, ()>,
+        Vec<(&str, jaq_core::compile::Undefined)>,
+    )>,
+) -> String {
+    let mut messages = Vec::new();
+    for (_, es) in &errs {
+        for (name, undef) in es {
+            messages.push(format!("undefined {} \"{}\"", undef.as_str(), name));
+        }
+    }
+
+    if messages.is_empty() {
+        "failed to compile expression".to_string()
+    } else {
+        messages.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn compile_simple_expressions() {
+        BatchExpr::compile("true", "$existing").unwrap();
+    }
+
+    #[test]
+    fn compile_reports_when_expression_errors() {
+        let err = BatchExpr::compile(".[*]", "$existing").unwrap_err();
+        assert!(err.starts_with("when: "), "got: {err}");
+    }
+
+    #[test]
+    fn compile_reports_fold_expression_errors() {
+        let err = BatchExpr::compile("true", ".[*]").unwrap_err();
+        assert!(err.starts_with("fold: "), "got: {err}");
+    }
+
+    #[test]
+    fn compile_allows_existing_and_new_globals() {
+        BatchExpr::compile(
+            "($existing.items | length) < 3",
+            "$existing | .items += $new.items",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn compile_rejects_undefined_globals() {
+        let err = BatchExpr::compile("$bogus", "$existing").unwrap_err();
+        assert!(
+            err.contains("undefined") && err.contains("bogus"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn eval_when_true_literal() {
+        let expr = BatchExpr::compile("true", "$existing").unwrap();
+        assert!(expr.eval_when(&json!({}), &json!({})));
+    }
+
+    #[test]
+    fn eval_when_false_literal() {
+        let expr = BatchExpr::compile("false", "$existing").unwrap();
+        assert!(!expr.eval_when(&json!({}), &json!({})));
+    }
+
+    #[test]
+    fn eval_when_uses_existing_variable() {
+        let expr = BatchExpr::compile("($existing.items | length) < 3", "$existing").unwrap();
+        assert!(expr.eval_when(&json!({"items": [1, 2]}), &json!({})));
+        assert!(!expr.eval_when(&json!({"items": [1, 2, 3]}), &json!({})));
+    }
+
+    #[test]
+    fn eval_when_uses_new_variable() {
+        let expr = BatchExpr::compile("$new.ok == true", "$existing").unwrap();
+        assert!(expr.eval_when(&json!({}), &json!({"ok": true})));
+        assert!(!expr.eval_when(&json!({}), &json!({"ok": false})));
+    }
+
+    #[test]
+    fn eval_when_null_output_is_false() {
+        let expr = BatchExpr::compile("null", "$existing").unwrap();
+        assert!(!expr.eval_when(&json!({}), &json!({})));
+    }
+
+    #[test]
+    fn eval_when_runtime_error_is_false() {
+        // Indexing a number is a jq runtime error.
+        let expr = BatchExpr::compile("$existing[0]", "$existing").unwrap();
+        assert!(!expr.eval_when(&json!(42), &json!({})));
+    }
+
+    #[test]
+    fn eval_fold_concatenates_arrays() {
+        let expr = BatchExpr::compile("true", "$existing + $new").unwrap();
+        let out = expr.eval_fold(&json!([1, 2]), &json!([3, 4])).unwrap();
+        assert_eq!(out, json!([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn eval_fold_appends_into_nested_field() {
+        let expr = BatchExpr::compile("true", "$existing | .items += $new.items").unwrap();
+        let out = expr
+            .eval_fold(&json!({"items": [1]}), &json!({"items": [2, 3]}))
+            .unwrap();
+        assert_eq!(out, json!({"items": [1, 2, 3]}));
+    }
+
+    #[test]
+    fn eval_fold_last_wins() {
+        let expr = BatchExpr::compile("true", "$new").unwrap();
+        let out = expr.eval_fold(&json!({"a": 1}), &json!({"b": 2})).unwrap();
+        assert_eq!(out, json!({"b": 2}));
+    }
+
+    #[test]
+    fn eval_fold_runtime_error_returns_err() {
+        // `.a + .b` on non-object inputs errors at runtime.
+        let expr = BatchExpr::compile("true", "$existing.a + $new.b").unwrap();
+        let err = expr.eval_fold(&json!(1), &json!(2)).unwrap_err();
+        assert!(err.contains("runtime"), "got: {err}");
+    }
+
+    #[test]
+    fn eval_fold_rejects_multiple_outputs() {
+        // The `,` operator emits multiple values; a reducer must produce
+        // exactly one, so this is an error rather than a silent pick.
+        let expr = BatchExpr::compile("true", "$existing, $new").unwrap();
+        let err = expr
+            .eval_fold(&json!("first"), &json!("second"))
+            .unwrap_err();
+        assert!(err.contains("more than one output"), "got: {err}");
+    }
+
+    #[test]
+    fn eval_fold_dedup_via_unique() {
+        let expr = BatchExpr::compile(
+            "true",
+            "$existing | .device_ids = (.device_ids + $new.device_ids | unique)",
+        )
+        .unwrap();
+        let out = expr
+            .eval_fold(
+                &json!({"device_ids": ["a", "b"]}),
+                &json!({"device_ids": ["b", "c"]}),
+            )
+            .unwrap();
+        assert_eq!(out, json!({"device_ids": ["a", "b", "c"]}));
+    }
+
+    #[test]
+    fn eval_fold_preserves_integer_precision() {
+        let expr = BatchExpr::compile("true", "9007199254740993").unwrap();
+        // 2^53 + 1 cannot be represented exactly as an f64, so a naive
+        // format-and-reparse path could round-trip it as 9007199254740992.
+        let out = expr.eval_fold(&json!({}), &json!({})).unwrap();
+        assert_eq!(out, json!(9007199254740993_i64));
+    }
+
+    #[test]
+    fn eval_fold_preserves_negative_integer_precision() {
+        let expr = BatchExpr::compile("true", "-9007199254740993").unwrap();
+        let out = expr.eval_fold(&json!({}), &json!({})).unwrap();
+        assert_eq!(out, json!(-9007199254740993_i64));
+    }
+
+    #[test]
+    fn eval_fold_preserves_nested_objects_and_arrays() {
+        let expr = BatchExpr::compile("true", "$existing + $new").unwrap();
+        let out = expr
+            .eval_fold(
+                &json!({"a": [1, 2], "b": {"c": "d"}}),
+                &json!({"e": null, "f": true}),
+            )
+            .unwrap();
+        assert_eq!(
+            out,
+            json!({"a": [1, 2], "b": {"c": "d"}, "e": null, "f": true})
+        );
+    }
+
+    #[test]
+    fn eval_fold_preserves_null_and_boolean_variants() {
+        let expr = BatchExpr::compile("true", "[$existing, $new, null, false]").unwrap();
+        let out = expr.eval_fold(&json!(true), &json!(null)).unwrap();
+        assert_eq!(out, json!([true, null, null, false]));
+    }
+
+    #[test]
+    fn expressions_are_reusable() {
+        let expr = BatchExpr::compile(
+            "($existing.items | length) < 3",
+            "$existing | .items += $new.items",
+        )
+        .unwrap();
+
+        assert!(expr.eval_when(&json!({"items": [1]}), &json!({"items": [2]})));
+        let out = expr
+            .eval_fold(&json!({"items": [1]}), &json!({"items": [2]}))
+            .unwrap();
+        assert_eq!(out, json!({"items": [1, 2]}));
+
+        // Reuse against different inputs.
+        assert!(!expr.eval_when(&json!({"items": [1, 2, 3]}), &json!({"items": [4]})));
+    }
+}

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -87,6 +87,48 @@ impl BatchExpr {
             .unwrap_or(false)
     }
 
+    /// Dry-run both expressions against `payload` bound as both
+    /// `$existing` and `$new` to surface shape errors at enqueue time
+    /// rather than at first fold.
+    ///
+    /// Compile-time errors are caught by `compile`; this catches the
+    /// runtime shape errors that only manifest against actual data
+    /// (`.field` on the wrong type, `length` on an unsupported value,
+    /// etc.). Returns `Err` if either expression errors, or if `fold`
+    /// produces zero or multiple outputs. The boolean output of `when`
+    /// is not consulted — only whether it evaluates without error.
+    pub fn dry_run(&self, payload: &serde_json::Value) -> Result<(), String> {
+        self.try_eval_when(payload, payload)
+            .map_err(|e| format!("when: {e}"))?;
+        self.eval_fold(payload, payload)
+            .map(|_| ())
+            .map_err(|e| format!("fold: {e}"))
+    }
+
+    /// Fallible variant of `eval_when` used only by `dry_run`. Runtime
+    /// callers use `eval_when`, which folds runtime errors into `false`
+    /// so a broken predicate never blocks a fresh enqueue from creating
+    /// a new batch.
+    fn try_eval_when(
+        &self,
+        existing: &serde_json::Value,
+        new: &serde_json::Value,
+    ) -> Result<bool, String> {
+        let existing_val = to_val(existing)
+            .ok_or_else(|| "existing payload could not be interpreted as JSON".to_string())?;
+        let new_val = to_val(new)
+            .ok_or_else(|| "new payload could not be interpreted as JSON".to_string())?;
+
+        let ctx =
+            Ctx::<data::JustLut<Val>>::new(&self.when.lut, Vars::new([existing_val, new_val]));
+
+        match self.when.id.run((ctx, Val::Null)).map(unwrap_valr).next() {
+            None => Ok(false),
+            Some(Ok(v)) => Ok(is_truthy(&v)),
+            Some(Err(e)) => Err(format!("expression failed at runtime: {e}")),
+        }
+    }
+
     /// Evaluate the `fold` reducer, returning the merged payload.
     ///
     /// Returns an error if the expression fails at runtime, produces no
@@ -475,6 +517,49 @@ mod tests {
         let expr = BatchExpr::compile("true", "[$existing, $new, null, false]").unwrap();
         let out = expr.eval_fold(&json!(true), &json!(null)).unwrap();
         assert_eq!(out, json!([true, null, null, false]));
+    }
+
+    #[test]
+    fn dry_run_accepts_shape_compatible_expressions() {
+        let expr = BatchExpr::compile(
+            "($existing.items | length) < 3",
+            "$existing | .items += $new.items",
+        )
+        .unwrap();
+        expr.dry_run(&json!({"items": [1]})).unwrap();
+    }
+
+    #[test]
+    fn dry_run_rejects_shape_incompatible_when() {
+        // Indexing an array with a string field errors in jq. Missing
+        // *object* keys silently return null, so this uses an array
+        // payload to force the error.
+        let expr = BatchExpr::compile("$existing.items == null", "$existing").unwrap();
+        let err = expr.dry_run(&json!([1, 2])).unwrap_err();
+        assert!(err.starts_with("when: "), "got: {err}");
+    }
+
+    #[test]
+    fn dry_run_rejects_shape_incompatible_fold() {
+        // Array indexing with a string key errors in jq.
+        let expr = BatchExpr::compile("true", "$existing | .foo += $new.foo").unwrap();
+        let err = expr.dry_run(&json!([1, 2])).unwrap_err();
+        assert!(err.starts_with("fold: "), "got: {err}");
+    }
+
+    #[test]
+    fn dry_run_rejects_multi_output_fold() {
+        let expr = BatchExpr::compile("true", "$existing, $new").unwrap();
+        let err = expr.dry_run(&json!({})).unwrap_err();
+        assert!(err.starts_with("fold: "), "got: {err}");
+    }
+
+    #[test]
+    fn dry_run_accepts_false_predicate() {
+        // A `when` that always returns false is legal — it just means the
+        // batch always seals rather than folds. Dry-run should still pass.
+        let expr = BatchExpr::compile("false", "$existing + $new").unwrap();
+        expr.dry_run(&json!([1])).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 pub const BACKUP_ARCHIVE_PREFIX: &str = "zizq-root";
 
 pub mod api;
+pub mod batch;
 pub mod commands;
 pub mod filter;
 pub mod license;

--- a/src/license.rs
+++ b/src/license.rs
@@ -69,6 +69,9 @@ pub enum Feature {
     UniqueJobs,
     /// Cron scheduling — periodic job enqueue from cron expressions.
     CronScheduling,
+    /// Batched jobs — fold subsequent enqueues into a pending job's
+    /// payload via `when`/`fold` jq expressions.
+    BatchedJobs,
 }
 
 impl Feature {
@@ -81,6 +84,7 @@ impl Feature {
             Feature::MutualTls => Tier::Pro,
             Feature::UniqueJobs => Tier::Pro,
             Feature::CronScheduling => Tier::Pro,
+            Feature::BatchedJobs => Tier::Pro,
         }
     }
 }
@@ -94,6 +98,7 @@ impl std::fmt::Display for Feature {
             Feature::MutualTls => write!(f, "mutual TLS"),
             Feature::UniqueJobs => write!(f, "unique jobs"),
             Feature::CronScheduling => write!(f, "cron scheduling"),
+            Feature::BatchedJobs => write!(f, "batched jobs"),
         }
     }
 }

--- a/src/store/cron/ops.rs
+++ b/src/store/cron/ops.rs
@@ -13,7 +13,9 @@ use std::ops::Bound;
 use fjall::{Readable, Slice};
 use tokio::task;
 
-use super::super::enqueue::{apply_enqueue, finalize_enqueue, prepare_enqueue};
+use super::super::enqueue::{
+    apply_enqueue, finalize_enqueue, prepare_enqueue, validate_batch_config,
+};
 use super::super::keys::RecordKind;
 use super::super::options::{CronEntryOptions, ReplaceCronGroupOptions};
 use super::super::store::{Store, StoreEvent};
@@ -46,12 +48,17 @@ impl Store {
             let group_key = make_cron_group_key(&group);
             let prefix = make_cron_group_prefix(&group);
 
-            // Validate all cron expressions before acquiring the write lock.
+            // Validate all cron expressions and batch configs before
+            // acquiring the write lock.
             let mut computed_next: Vec<Option<u64>> = Vec::with_capacity(entries.len());
             for input in &entries {
                 // Validates the expression; None means no future occurrences.
                 let next = cron_next_after(&input.expression, now, input.timezone.as_deref())?;
                 computed_next.push(next);
+
+                if let Some(ref cfg) = input.job.batch {
+                    validate_batch_config(cfg, &input.job.payload)?;
+                }
             }
 
             // Acquire the single-writer lock. All reads within this scope
@@ -275,6 +282,10 @@ impl Store {
             // Validate the cron expression before acquiring the write lock.
             let next_enqueue_at = cron_next_after(&opts.expression, now, opts.timezone.as_deref())?;
 
+            if let Some(ref cfg) = opts.job.batch {
+                validate_batch_config(cfg, &opts.job.payload)?;
+            }
+
             let group_key = make_cron_group_key(&group);
             let entry_key = make_cron_entry_key(&group, &opts.name);
 
@@ -341,6 +352,10 @@ impl Store {
 
         task::spawn_blocking(move || -> Result<CronEntry, StoreError> {
             let next_enqueue_at = cron_next_after(&opts.expression, now, opts.timezone.as_deref())?;
+
+            if let Some(ref cfg) = opts.job.batch {
+                validate_batch_config(cfg, &opts.job.payload)?;
+            }
 
             let group_key = make_cron_group_key(&group);
             let entry_key = make_cron_entry_key(&group, &opts.name);
@@ -955,6 +970,7 @@ mod tests {
         CronEntryOptions, EnqueueOptions, ListJobsOptions, ReplaceCronGroupOptions,
     };
     use super::super::super::test_support::test_store;
+    use crate::store::StoreError;
     use crate::time::now_millis;
 
     /// Fixed timestamp for cron tests: 2023-11-14 22:13:20 UTC.
@@ -1948,5 +1964,129 @@ mod tests {
         let (group, entries) = store.get_cron_group("default").await.unwrap().unwrap();
         assert!(!group.paused);
         assert!(entries.is_empty());
+    }
+
+    // --- Batched cron entries: enqueue-time validation ---
+
+    fn cron_entry_with_batch(
+        name: &str,
+        payload: serde_json::Value,
+        cfg: crate::store::BatchConfig,
+    ) -> CronEntryOptions {
+        CronEntryOptions {
+            name: name.to_string(),
+            expression: "0 * * * *".to_string(),
+            timezone: None,
+            paused: None,
+            job: EnqueueOptions::new("t", "q", payload).batch(cfg),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_cron_entry_rejects_invalid_batch_expression() {
+        let store = test_store();
+        let bad = crate::store::BatchConfig {
+            key: "k".into(),
+            when: ".[*]".into(),
+            fold: "$existing + $new".into(),
+        };
+
+        let err = store
+            .add_cron_entry(
+                "default",
+                cron_entry_with_batch("e1", serde_json::json!([1]), bad),
+                CRON_NOW,
+            )
+            .await
+            .err()
+            .expect("expected InvalidOperation");
+        assert!(matches!(err, StoreError::InvalidOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn add_cron_entry_rejects_batch_dry_run_shape_error() {
+        let store = test_store();
+        let cfg = crate::store::BatchConfig {
+            key: "k".into(),
+            when: "true".into(),
+            fold: "$existing | .items += $new.items".into(),
+        };
+
+        let err = store
+            .add_cron_entry(
+                "default",
+                cron_entry_with_batch("e1", serde_json::json!([1, 2]), cfg),
+                CRON_NOW,
+            )
+            .await
+            .err()
+            .expect("expected InvalidOperation from dry-run");
+        let msg = match err {
+            StoreError::InvalidOperation(m) => m,
+            other => panic!("expected InvalidOperation, got {other:?}"),
+        };
+        assert!(msg.contains("dry-run"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn put_cron_entry_rejects_invalid_batch_expression() {
+        let store = test_store();
+        let bad = crate::store::BatchConfig {
+            key: "k".into(),
+            when: ".[*]".into(),
+            fold: "$existing + $new".into(),
+        };
+
+        let err = store
+            .put_cron_entry(
+                "default",
+                cron_entry_with_batch("e1", serde_json::json!([1]), bad),
+                CRON_NOW,
+            )
+            .await
+            .err()
+            .expect("expected InvalidOperation");
+        assert!(matches!(err, StoreError::InvalidOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_rejects_invalid_batch_expression() {
+        let store = test_store();
+        let bad = crate::store::BatchConfig {
+            key: "k".into(),
+            when: ".[*]".into(),
+            fold: "$existing + $new".into(),
+        };
+
+        let opts = ReplaceCronGroupOptions {
+            paused: None,
+            entries: vec![cron_entry_with_batch("e1", serde_json::json!([1]), bad)],
+        };
+        let err = store
+            .replace_cron_group("default", opts, CRON_NOW)
+            .await
+            .err()
+            .expect("expected InvalidOperation");
+        assert!(matches!(err, StoreError::InvalidOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn add_cron_entry_accepts_valid_batch_expression() {
+        let store = test_store();
+        let cfg = crate::store::BatchConfig {
+            key: "k".into(),
+            when: "true".into(),
+            fold: "$existing + $new".into(),
+        };
+
+        let entry = store
+            .add_cron_entry(
+                "default",
+                cron_entry_with_batch("e1", serde_json::json!([1]), cfg),
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert!(entry.job.batch.is_some());
     }
 }

--- a/src/store/delete.rs
+++ b/src/store/delete.rs
@@ -280,6 +280,7 @@ pub(super) struct JobDeletion {
     status_key: Vec<u8>,
     queue_key: Vec<u8>,
     type_key: Vec<u8>,
+    payload_key: Vec<u8>,
     purge_key: Option<Vec<u8>>,
     error_keys: Vec<Vec<u8>>,
     unique_idx_key: Option<Vec<u8>>,
@@ -293,6 +294,7 @@ pub(super) fn prepare_job_deletion(job: &Job, status: JobStatus, ks: &Keyspaces)
         status_key: make_status_key(status, id),
         queue_key: make_queue_key(&job.queue, id),
         type_key: make_type_key(&job.job_type, id),
+        payload_key: make_payload_key(job.payload_key()),
         purge_key: job.purge_at.map(|purge_at| make_purge_key(purge_at, id)),
         error_keys: error_keys(ks, id).collect(),
         unique_idx_key: job.unique.as_ref().map(|uc| make_unique_key(&uc.key)),
@@ -306,7 +308,7 @@ pub(super) fn apply_job_deletion(
     ks: &Keyspaces,
 ) {
     tx.remove(&ks.data, &make_job_key(&del.id));
-    tx.remove_weak(&ks.data, &make_payload_key(&del.id));
+    tx.remove_weak(&ks.data, &del.payload_key);
     tx.remove(&ks.index, &del.status_key);
     tx.remove_weak(&ks.index, &del.queue_key);
     tx.remove_weak(&ks.index, &del.type_key);

--- a/src/store/delete.rs
+++ b/src/store/delete.rs
@@ -13,8 +13,8 @@
 use tokio::task;
 
 use super::keys::{
-    error_keys, make_job_key, make_payload_key, make_purge_key, make_queue_key, make_status_key,
-    make_type_key, make_unique_key,
+    error_keys, make_batch_key, make_job_key, make_payload_key, make_purge_key, make_queue_key,
+    make_status_key, make_type_key, make_unique_key,
 };
 use super::options::BulkDeleteOptions;
 use super::scan::{JobStream, apply_filters, build_id_stream, filter_needs_payload};
@@ -284,6 +284,7 @@ pub(super) struct JobDeletion {
     purge_key: Option<Vec<u8>>,
     error_keys: Vec<Vec<u8>>,
     unique_idx_key: Option<Vec<u8>>,
+    batch_idx_key: Option<Vec<u8>>,
 }
 
 /// Collect all keys needed to delete a job. No tx required.
@@ -298,6 +299,7 @@ pub(super) fn prepare_job_deletion(job: &Job, status: JobStatus, ks: &Keyspaces)
         purge_key: job.purge_at.map(|purge_at| make_purge_key(purge_at, id)),
         error_keys: error_keys(ks, id).collect(),
         unique_idx_key: job.unique.as_ref().map(|uc| make_unique_key(&uc.key)),
+        batch_idx_key: job.batch.as_ref().map(|bc| make_batch_key(&bc.key)),
     }
 }
 
@@ -322,6 +324,16 @@ pub(super) fn apply_job_deletion(
     if let Some(ref unique_key) = del.unique_idx_key {
         let job_id = del.id.as_bytes();
         let _ = tx.fetch_update(&ks.index, unique_key, |v| match v {
+            Some(v) if v.as_ref() == job_id => None,
+            other => other.cloned(),
+        });
+    }
+
+    // Same pattern for the batch index: only remove if it still points
+    // at this job. A subsequent seal may have already replaced it.
+    if let Some(ref batch_key) = del.batch_idx_key {
+        let job_id = del.id.as_bytes();
+        let _ = tx.fetch_update(&ks.index, batch_key, |v| match v {
             Some(v) if v.as_ref() == job_id => None,
             other => other.cloned(),
         });

--- a/src/store/enqueue/apply.rs
+++ b/src/store/enqueue/apply.rs
@@ -3,11 +3,16 @@
 
 //! Write-tx phase of enqueue: apply pre-built `PreparedEnqueue` values to
 //! an open transaction, with unique-conflict detection (cross-batch via
-//! the index, intra-batch via a `HashMap`).
+//! the index, intra-batch via a `HashMap`) and batched-job fold/seal
+//! logic.
 
 use std::collections::HashMap;
 
-use super::super::keys::make_job_key;
+use fjall::Readable;
+
+use crate::batch::BatchExpr;
+
+use super::super::keys::{make_job_key, make_payload_key};
 use super::super::results::EnqueueResult;
 use super::super::store::Keyspaces;
 use super::super::types::{Job, JobStatus, StoreError};
@@ -46,6 +51,17 @@ pub(in crate::store) fn apply_enqueue(
         }
     }
 
+    // Try to fold this enqueue into an existing pending batched job.
+    // A returned `Folded(_)` short-circuits the normal insert; a
+    // returned `None` means "fall through to create a new job" — either
+    // no existing batch, or the predicate failed and the existing batch
+    // was sealed in this tx.
+    if p.job.batch.is_some() {
+        if let Some(folded) = try_apply_fold(tx, ks, p)? {
+            return Ok(folded);
+        }
+    }
+
     tx.insert(&ks.data, &p.job_key, &p.meta_bytes);
     tx.insert(&ks.data, &p.payload_key, &p.payload_bytes);
     tx.insert(&ks.index, &p.queue_key, b"");
@@ -56,7 +72,134 @@ pub(in crate::store) fn apply_enqueue(
         tx.insert(&ks.index, idx_key, p.job.id.as_bytes());
     }
 
+    if let Some(ref idx_key) = p.batch_idx_key {
+        tx.insert(&ks.index, idx_key, p.job.id.as_bytes());
+    }
+
     Ok(EnqueueResult::Created(p.job.clone()))
+}
+
+/// Attempt to fold `p` into an existing pending batched job.
+///
+/// Returns `Ok(Some(Folded(_)))` when the incoming payload was merged
+/// into an existing pending job (its payload is rewritten in place at a
+/// fresh payload key, keeping FIFO position).
+///
+/// Returns `Ok(None)` when the caller should fall through to normal
+/// insertion. That covers three cases: no existing entry for this
+/// batch key, an existing entry pointing at a job that's no longer
+/// pending (stale — cleaned up here), or an existing pending batch
+/// whose `when` predicate returned false (sealed here so a fresh job
+/// takes over).
+fn try_apply_fold(
+    tx: &mut fjall::SingleWriterWriteTx<'_>,
+    ks: &Keyspaces,
+    p: &PreparedEnqueue,
+) -> Result<Option<EnqueueResult>, StoreError> {
+    let batch_idx_key = p
+        .batch_idx_key
+        .as_ref()
+        .expect("batched enqueue must carry batch_idx_key");
+
+    // Read-your-writes: sees inserts from earlier ops in this same tx.
+    let Some(existing_id_bytes) = tx.get(&ks.index, batch_idx_key)? else {
+        return Ok(None);
+    };
+
+    let existing_id = std::str::from_utf8(&existing_id_bytes).map_err(|e| {
+        StoreError::Corruption(format!("batch index value is not valid UTF-8: {e}"))
+    })?;
+    let existing_job_key = make_job_key(existing_id);
+
+    let Some(existing_meta_bytes) = tx.get(&ks.data, &existing_job_key)? else {
+        // Stale index entry pointing at a job that's been deleted.
+        tx.remove(&ks.index, batch_idx_key);
+        return Ok(None);
+    };
+
+    let existing_meta: Job = rmp_serde::from_slice(&existing_meta_bytes)?;
+    let existing_status = JobStatus::try_from(existing_meta.status).map_err(|_| {
+        StoreError::Corruption(format!(
+            "job {} has unrecognized status byte",
+            existing_meta.id
+        ))
+    })?;
+
+    if !matches!(existing_status, JobStatus::Ready | JobStatus::Scheduled) {
+        // Index entry outlived the batch's pending state (should be
+        // cleaned up by claim/delete; treat defensively).
+        tx.remove(&ks.index, batch_idx_key);
+        return Ok(None);
+    }
+
+    let existing_cfg = existing_meta.batch.as_ref().ok_or_else(|| {
+        StoreError::Corruption(format!(
+            "batched-index target job {} has no batch config",
+            existing_meta.id
+        ))
+    })?;
+
+    // Compile using the *existing* job's stored expressions (first-wins).
+    let expr = BatchExpr::compile(&existing_cfg.when, &existing_cfg.fold).map_err(|e| {
+        StoreError::Corruption(format!(
+            "job {} has invalid stored batch expression: {e}",
+            existing_meta.id
+        ))
+    })?;
+
+    // Hydrate the existing payload from wherever it currently lives.
+    let existing_payload_key = make_payload_key(existing_meta.payload_key());
+    let existing_payload_bytes = tx.get(&ks.data, &existing_payload_key)?.ok_or_else(|| {
+        StoreError::Corruption(format!(
+            "batched job {} has no payload record",
+            existing_meta.id
+        ))
+    })?;
+    let existing_payload: serde_json::Value = rmp_serde::from_slice(&existing_payload_bytes)?;
+
+    let new_payload =
+        p.job.payload.as_ref().ok_or_else(|| {
+            StoreError::Internal("prepared enqueue is missing its payload".into())
+        })?;
+
+    if !expr.eval_when(&existing_payload, new_payload) {
+        // Seal: the current pending job becomes a normal pending job
+        // (no more folds against it). Remove the index entry so the
+        // caller creates a fresh batched job that takes over.
+        tx.remove(&ks.index, batch_idx_key);
+        return Ok(None);
+    }
+
+    let merged = expr
+        .eval_fold(&existing_payload, new_payload)
+        .map_err(|e| StoreError::InvalidOperation(format!("batch fold failed: {e}")))?;
+
+    // Rewrite the existing job's payload at a fresh key, then update
+    // its metadata to point at the new key, then remove the old
+    // payload — all in this tx. `remove_weak` keeps each payload
+    // key write-once/delete-once from the perspective of its own
+    // lifecycle.
+    let new_payload_id = p
+        .fold_payload_key_id
+        .as_ref()
+        .expect("batched enqueue must carry a fold_payload_key_id");
+    let new_payload_key = make_payload_key(new_payload_id);
+    let new_payload_bytes = rmp_serde::to_vec_named(&merged)?;
+
+    let mut updated_meta = existing_meta.clone();
+    updated_meta.payload_key = Some(new_payload_id.clone());
+    updated_meta.payload = None;
+    let updated_meta_bytes = rmp_serde::to_vec_named(&updated_meta)?;
+
+    tx.insert(&ks.data, &new_payload_key, &new_payload_bytes);
+    tx.insert(&ks.data, &existing_job_key, &updated_meta_bytes);
+    tx.remove_weak(&ks.data, &existing_payload_key);
+
+    // Return the updated metadata with the merged payload hydrated for
+    // the caller (matches the shape of `Created(_)` responses which
+    // carry the payload).
+    updated_meta.payload = Some(merged);
+    Ok(Some(EnqueueResult::Folded(updated_meta)))
 }
 
 /// Apply a batch of prepared enqueues to an open write transaction with

--- a/src/store/enqueue/batcher.rs
+++ b/src/store/enqueue/batcher.rs
@@ -205,14 +205,15 @@ fn process_batch(
 
     // Skip the commit when every result was a duplicate —
     // `apply_enqueue` makes zero tx writes in that case so committing
-    // would be wasteful. Mirrors the single-enqueue fast path.
-    let created = results
+    // would be wasteful. `Folded(_)` writes to the tx too, so it also
+    // counts as "needs commit".
+    let writes = results
         .iter()
-        .filter(|r| matches!(r, EnqueueResult::Created(_)))
+        .filter(|r| !matches!(r, EnqueueResult::Duplicate(_)))
         .count();
-    let duplicate = jobs_count - created;
+    let duplicate = jobs_count - writes;
 
-    if created > 0 {
+    if writes > 0 {
         if let Err(e) = ks.commit(tx, ks.enqueue_commit_mode) {
             tracing::error!(
                 ops = ops_count,
@@ -229,7 +230,7 @@ fn process_batch(
         tracing::debug!(
             ops = ops_count,
             jobs = jobs_count,
-            created,
+            writes,
             duplicate,
             "enqueue auto-batcher: committed batch"
         );

--- a/src/store/enqueue/mod.rs
+++ b/src/store/enqueue/mod.rs
@@ -17,7 +17,7 @@ mod prepare;
 pub(in crate::store) use apply::apply_enqueue;
 pub(super) use batcher::EnqueueBatcher;
 pub(in crate::store) use finalize::finalize_enqueue;
-pub(in crate::store) use prepare::{PreparedEnqueue, prepare_enqueue};
+pub(in crate::store) use prepare::{PreparedEnqueue, prepare_enqueue, validate_batch_config};
 
 use tokio::task;
 
@@ -1234,6 +1234,35 @@ mod tests {
             matches!(err, super::super::types::StoreError::InvalidOperation(_)),
             "expected InvalidOperation, got {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn batch_dry_run_rejects_shape_incompatible_expression() {
+        let store = test_store();
+        let now = now_millis();
+
+        // The `fold` indexes the payload with a field access — jq errors
+        // when the payload is an array (compile succeeds, so this only
+        // surfaces via dry-run).
+        let cfg = BatchConfig {
+            key: "k".into(),
+            when: "true".into(),
+            fold: "$existing | .items += $new.items".into(),
+        };
+
+        let err = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1, 2])).batch(cfg),
+            )
+            .await
+            .err()
+            .expect("expected InvalidOperation from dry-run");
+        let msg = match err {
+            super::super::types::StoreError::InvalidOperation(m) => m,
+            other => panic!("expected InvalidOperation, got {other:?}"),
+        };
+        assert!(msg.contains("dry-run"), "got: {msg}");
     }
 
     #[tokio::test]

--- a/src/store/enqueue/mod.rs
+++ b/src/store/enqueue/mod.rs
@@ -111,8 +111,18 @@ mod tests {
     use super::super::results::EnqueueResult;
     use super::super::store::StoreEvent;
     use super::super::test_support::{test_store, test_store_with_retention};
-    use super::super::types::{BackoffConfig, Job, JobStatus, RetentionConfig, UniqueWhile};
+    use super::super::types::{
+        BackoffConfig, BatchConfig, Job, JobStatus, RetentionConfig, UniqueWhile,
+    };
     use crate::time::now_millis;
+
+    fn append_batch(key: &str) -> BatchConfig {
+        BatchConfig {
+            key: key.to_string(),
+            when: "true".to_string(),
+            fold: "$existing + $new".to_string(),
+        }
+    }
 
     #[tokio::test]
     async fn enqueue_returns_job_with_id() {
@@ -936,5 +946,354 @@ mod tests {
             .unwrap();
         assert!(r2.is_duplicate());
         assert_eq!(r2.job().id, r1.job().id);
+    }
+
+    // --- Batched jobs ---
+
+    #[tokio::test]
+    async fn batch_first_enqueue_creates_new_job() {
+        let store = test_store();
+        let now = now_millis();
+
+        let r = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+
+        assert!(!r.is_folded());
+        assert!(!r.is_duplicate());
+        assert_eq!(r.job().payload, Some(serde_json::json!([1])));
+    }
+
+    #[tokio::test]
+    async fn batch_second_enqueue_folds_into_existing() {
+        let store = test_store();
+        let now = now_millis();
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2, 3]))
+                    .batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+
+        assert!(!r1.is_folded());
+        assert!(r2.is_folded());
+        assert_eq!(r2.job().id, r1.job().id);
+        assert_eq!(r2.job().payload, Some(serde_json::json!([1, 2, 3])));
+    }
+
+    #[tokio::test]
+    async fn batch_fold_preserves_fifo_position() {
+        let store = test_store();
+        let now = now_millis();
+
+        // Enqueue a batched job, then a normal job, then fold into the batched.
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("other", "q", serde_json::json!("later")),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+
+        // FIFO: batched job (r1) should be taken before r2, even after fold.
+        let t1 = store
+            .take_next_job(now, &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(t1.id, r1.job().id);
+        assert_eq!(t1.payload, Some(serde_json::json!([1, 2])));
+
+        let t2 = store
+            .take_next_job(now, &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(t2.id, r2.job().id);
+    }
+
+    #[tokio::test]
+    async fn batch_seal_when_predicate_false_starts_new_job() {
+        let store = test_store();
+        let now = now_millis();
+
+        let seal_when_two = BatchConfig {
+            key: "k".into(),
+            when: "($existing | length) < 2".into(),
+            fold: "$existing + $new".into(),
+        };
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1]))
+                    .batch(seal_when_two.clone()),
+            )
+            .await
+            .unwrap();
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2]))
+                    .batch(seal_when_two.clone()),
+            )
+            .await
+            .unwrap();
+        // r2 folds (existing = [1], length 1 < 2). Now r1's payload is [1, 2].
+        assert!(r2.is_folded());
+
+        let r3 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([3])).batch(seal_when_two),
+            )
+            .await
+            .unwrap();
+        // r3 predicate: existing = [1, 2], length 2 is NOT < 2 → seal, new job.
+        assert!(!r3.is_folded());
+        assert_ne!(r3.job().id, r1.job().id);
+        assert_eq!(r3.job().payload, Some(serde_json::json!([3])));
+    }
+
+    #[tokio::test]
+    async fn batch_folds_persist_across_get_job() {
+        let store = test_store();
+        let now = now_millis();
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+
+        let fetched = store.get_job(now, &r1.job().id).await.unwrap().unwrap();
+        assert_eq!(fetched.payload, Some(serde_json::json!([1, 2])));
+    }
+
+    #[tokio::test]
+    async fn batch_take_closes_batch_so_next_enqueue_creates_new() {
+        let store = test_store();
+        store.rebuild_indexes().await.unwrap();
+        let now = now_millis();
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        let taken = store
+            .take_next_job(now, &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(taken.id, r1.job().id);
+
+        // Subsequent enqueue for the same key must NOT fold into the
+        // in-flight job — it starts a fresh batch.
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        assert!(!r2.is_folded());
+        assert_ne!(r2.job().id, r1.job().id);
+    }
+
+    #[tokio::test]
+    async fn batch_delete_pending_lets_next_enqueue_create_new() {
+        let store = test_store();
+        let now = now_millis();
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        store.delete_job(&r1.job().id).await.unwrap();
+
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        assert!(!r2.is_folded());
+        assert_ne!(r2.job().id, r1.job().id);
+    }
+
+    #[tokio::test]
+    async fn batch_different_keys_do_not_fold() {
+        let store = test_store();
+        let now = now_millis();
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("a")),
+            )
+            .await
+            .unwrap();
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(append_batch("b")),
+            )
+            .await
+            .unwrap();
+
+        assert!(!r1.is_folded());
+        assert!(!r2.is_folded());
+        assert_ne!(r1.job().id, r2.job().id);
+    }
+
+    #[tokio::test]
+    async fn batch_and_unique_together_is_rejected() {
+        let store = test_store();
+        let now = now_millis();
+
+        let err = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1]))
+                    .unique_key("u")
+                    .batch(append_batch("k")),
+            )
+            .await
+            .err()
+            .expect("expected InvalidOperation error");
+        assert!(
+            matches!(err, super::super::types::StoreError::InvalidOperation(_)),
+            "expected InvalidOperation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_invalid_expression_is_rejected_at_enqueue() {
+        let store = test_store();
+        let now = now_millis();
+
+        let bad = BatchConfig {
+            key: "k".into(),
+            when: ".[*]".into(), // invalid syntax
+            fold: "$existing + $new".into(),
+        };
+
+        let err = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(bad),
+            )
+            .await
+            .err()
+            .expect("expected InvalidOperation error");
+        assert!(
+            matches!(err, super::super::types::StoreError::InvalidOperation(_)),
+            "expected InvalidOperation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_bulk_folds_within_single_call() {
+        let store = test_store();
+        let now = now_millis();
+
+        let results = store
+            .enqueue_bulk(
+                now,
+                vec![
+                    EnqueueOptions::new("push", "q", serde_json::json!([1]))
+                        .batch(append_batch("k")),
+                    EnqueueOptions::new("push", "q", serde_json::json!([2]))
+                        .batch(append_batch("k")),
+                    EnqueueOptions::new("push", "q", serde_json::json!([3]))
+                        .batch(append_batch("k")),
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert!(!results[0].is_folded());
+        assert!(results[1].is_folded());
+        assert!(results[2].is_folded());
+        assert_eq!(results[1].job().id, results[0].job().id);
+        assert_eq!(results[2].job().id, results[0].job().id);
+        assert_eq!(results[2].job().payload, Some(serde_json::json!([1, 2, 3])));
+    }
+
+    #[tokio::test]
+    async fn batch_existing_config_wins_over_new() {
+        let store = test_store();
+        let now = now_millis();
+
+        let cfg_a = append_batch("k");
+        let cfg_b = BatchConfig {
+            key: "k".into(),
+            when: "false".into(), // If this won, everything would seal.
+            fold: "$new".into(),
+        };
+
+        store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(cfg_a.clone()),
+            )
+            .await
+            .unwrap();
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(cfg_b),
+            )
+            .await
+            .unwrap();
+
+        // Existing's `when: true` applies, so this folds.
+        assert!(r2.is_folded());
+        assert_eq!(r2.job().payload, Some(serde_json::json!([1, 2])));
     }
 }

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -5,8 +5,11 @@
 //! `EnqueueOptions` without touching the database. Used both by the
 //! enqueue auto-batcher and by `cron::promote_cron_entry`.
 
+use crate::batch::BatchExpr;
+
 use super::super::keys::{
-    make_job_key, make_payload_key, make_queue_key, make_status_key, make_type_key, make_unique_key,
+    make_batch_key, make_job_key, make_payload_key, make_queue_key, make_status_key, make_type_key,
+    make_unique_key,
 };
 use super::super::options::EnqueueOptions;
 use super::super::types::{Job, JobStatus, StoreError, UniqueConstraint, UniqueWhile};
@@ -27,6 +30,14 @@ pub(in crate::store) struct PreparedEnqueue {
     pub(super) status_key: Vec<u8>,
     pub(super) type_key: Vec<u8>,
     pub(super) unique_idx_key: Option<Vec<u8>>,
+    /// `B\0<batch.key>` for batched enqueues (`Some`). When the fold path
+    /// is not taken, this is inserted pointing at the newly created job.
+    pub(super) batch_idx_key: Option<Vec<u8>>,
+    /// Pre-computed scru128 for the merged payload key if this enqueue
+    /// ends up folding into an existing batched job. Discarded (i.e.
+    /// unused) if the enqueue creates a new job instead, so first-time
+    /// batched jobs stay on-disk identical to normal jobs.
+    pub(super) fold_payload_key_id: Option<String>,
 }
 
 /// Build a `PreparedEnqueue` from `EnqueueOptions` and the current time.
@@ -36,6 +47,17 @@ pub(in crate::store) fn prepare_enqueue(
     opts: EnqueueOptions,
     now: u64,
 ) -> Result<PreparedEnqueue, StoreError> {
+    if opts.unique_key.is_some() && opts.batch.is_some() {
+        return Err(StoreError::InvalidOperation(
+            "unique_key and batch cannot be combined".into(),
+        ));
+    }
+
+    if let Some(ref cfg) = opts.batch {
+        BatchExpr::compile(&cfg.when, &cfg.fold)
+            .map_err(|e| StoreError::InvalidOperation(format!("batch expression: {e}")))?;
+    }
+
     let unique_while_scope = match (opts.unique_key.as_ref(), opts.unique_while) {
         (Some(_), Some(scope)) => Some(scope),
         (Some(_), None) => Some(UniqueWhile::Queued),
@@ -52,6 +74,18 @@ pub(in crate::store) fn prepare_enqueue(
     };
 
     let payload_bytes = rmp_serde::to_vec_named(&opts.payload)?;
+
+    // Pre-compute a fresh payload key id for the merged-payload target
+    // if this enqueue ends up folding. Discarded when the enqueue
+    // instead creates a new job, so the created job's on-disk shape
+    // matches a non-batched job (payload at `P\0<job_id>`, no
+    // `payload_key` field on the metadata).
+    let fold_payload_key_id = if opts.batch.is_some() {
+        Some(scru128::new_string())
+    } else {
+        None
+    };
+    let batch_idx_key = opts.batch.as_ref().map(|cfg| make_batch_key(&cfg.key));
 
     let job = Job {
         id: id.clone(),
@@ -74,7 +108,7 @@ pub(in crate::store) fn prepare_enqueue(
             scope: unique_while_scope.unwrap_or(UniqueWhile::Queued) as u8,
         }),
         payload_key: None,
-        batch: None,
+        batch: opts.batch,
     };
 
     let mut meta = job.clone();
@@ -88,6 +122,8 @@ pub(in crate::store) fn prepare_enqueue(
         status_key: make_status_key(status, &id),
         type_key: make_type_key(&job.job_type, &id),
         unique_idx_key: job.unique.as_ref().map(|uc| make_unique_key(&uc.key)),
+        batch_idx_key,
+        fold_payload_key_id,
         job,
         meta_bytes,
         payload_bytes,

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -74,6 +74,7 @@ pub(in crate::store) fn prepare_enqueue(
             scope: unique_while_scope.unwrap_or(UniqueWhile::Queued) as u8,
         }),
         payload_key: None,
+        batch: None,
     };
 
     let mut meta = job.clone();

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -73,6 +73,7 @@ pub(in crate::store) fn prepare_enqueue(
             key: k,
             scope: unique_while_scope.unwrap_or(UniqueWhile::Queued) as u8,
         }),
+        payload_key: None,
     };
 
     let mut meta = job.clone();
@@ -81,7 +82,7 @@ pub(in crate::store) fn prepare_enqueue(
 
     Ok(PreparedEnqueue {
         job_key: make_job_key(&id),
-        payload_key: make_payload_key(&id),
+        payload_key: make_payload_key(job.payload_key()),
         queue_key: make_queue_key(&job.queue, &id),
         status_key: make_status_key(status, &id),
         type_key: make_type_key(&job.job_type, &id),

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -12,7 +12,24 @@ use super::super::keys::{
     make_unique_key,
 };
 use super::super::options::EnqueueOptions;
-use super::super::types::{Job, JobStatus, StoreError, UniqueConstraint, UniqueWhile};
+use super::super::types::{BatchConfig, Job, JobStatus, StoreError, UniqueConstraint, UniqueWhile};
+
+/// Validate a batched-job configuration against a sample payload.
+///
+/// Compiles the `when`/`fold` expressions and dry-runs them with the
+/// supplied payload bound as both `$existing` and `$new`. Callable from
+/// any point that receives a `BatchConfig` from the caller (enqueue,
+/// cron entry creation, cron group replacement) so bad expressions
+/// surface up-front rather than at first fold.
+pub(in crate::store) fn validate_batch_config(
+    cfg: &BatchConfig,
+    payload: &serde_json::Value,
+) -> Result<(), StoreError> {
+    let expr = BatchExpr::compile(&cfg.when, &cfg.fold)
+        .map_err(|e| StoreError::InvalidOperation(format!("batch expression: {e}")))?;
+    expr.dry_run(payload)
+        .map_err(|e| StoreError::InvalidOperation(format!("batch dry-run: {e}")))
+}
 
 /// Pre-computed data for inserting a job into the store.
 ///
@@ -54,8 +71,7 @@ pub(in crate::store) fn prepare_enqueue(
     }
 
     if let Some(ref cfg) = opts.batch {
-        BatchExpr::compile(&cfg.when, &cfg.fold)
-            .map_err(|e| StoreError::InvalidOperation(format!("batch expression: {e}")))?;
+        validate_batch_config(cfg, &opts.payload)?;
     }
 
     let unique_while_scope = match (opts.unique_key.as_ref(), opts.unique_while) {

--- a/src/store/fail.rs
+++ b/src/store/fail.rs
@@ -579,7 +579,7 @@ mod tests {
         let job = enqueue_and_take(&store).await;
 
         // Verify payload exists before kill.
-        let payload_key = make_payload_key(&job.id);
+        let payload_key = make_payload_key(job.payload_key());
         assert!(store.ks.data.inner().get(&payload_key).unwrap().is_some());
 
         let mut opts = test_failure_opts();

--- a/src/store/keys.rs
+++ b/src/store/keys.rs
@@ -31,6 +31,7 @@ pub(super) enum RecordKind {
 #[repr(u8)]
 pub(super) enum IndexKind {
     PurgeAt = b'A',
+    Batch = b'B',
     Queue = b'Q',
     Status = b'S',
     Type = b'T',
@@ -108,6 +109,19 @@ pub(super) fn make_unique_key(unique_key: &str) -> Vec<u8> {
     key.push(IndexKind::Unique as u8);
     key.push(0);
     key.extend_from_slice(unique_key.as_bytes());
+    key
+}
+
+/// Build a batch index key: `B\0{batch_key}`.
+///
+/// The value stored under this key is the job id of the current pending
+/// batched job for that batch key. Removed when the batch is sealed,
+/// claimed (Ready -> InFlight), or the pending job is deleted.
+pub(super) fn make_batch_key(batch_key: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(2 + batch_key.len());
+    key.push(IndexKind::Batch as u8);
+    key.push(0);
+    key.extend_from_slice(batch_key.as_bytes());
     key
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -51,6 +51,6 @@ pub use store::{Store, StoreEvent};
 pub use cron::{CronEntry, CronGroup};
 
 pub use types::{
-    BackoffConfig, CommitMode, EnvConfigError, ErrorRecord, Job, JobStatus, RetentionConfig,
-    ScanDirection, StoreError, UniqueConstraint, UniqueWhile,
+    BackoffConfig, BatchConfig, CommitMode, EnvConfigError, ErrorRecord, Job, JobStatus,
+    RetentionConfig, ScanDirection, StoreError, UniqueConstraint, UniqueWhile,
 };

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::filter::PayloadFilter;
 
-use super::types::{BackoffConfig, JobStatus, RetentionConfig, ScanDirection, UniqueWhile};
+use super::types::{
+    BackoffConfig, BatchConfig, JobStatus, RetentionConfig, ScanDirection, UniqueWhile,
+};
 
 /// Predicate that selects which jobs an operation acts on.
 ///
@@ -431,6 +433,13 @@ pub struct EnqueueOptions {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_while: Option<UniqueWhile>,
+
+    /// Batching configuration. When set, the store attempts to fold this
+    /// enqueue into an existing pending job sharing the same batch key.
+    #[serde(rename = "B")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<BatchConfig>,
 }
 
 impl EnqueueOptions {
@@ -452,6 +461,7 @@ impl EnqueueOptions {
             retention: None,
             unique_key: None,
             unique_while: None,
+            batch: None,
         }
     }
 
@@ -499,6 +509,12 @@ impl EnqueueOptions {
     /// Set the uniqueness scope and return `self`.
     pub fn unique_while(mut self, scope: UniqueWhile) -> Self {
         self.unique_while = Some(scope);
+        self
+    }
+
+    /// Set the batching configuration and return `self`.
+    pub fn batch(mut self, batch: BatchConfig) -> Self {
+        self.batch = Some(batch);
         self
     }
 }

--- a/src/store/read.rs
+++ b/src/store/read.rs
@@ -45,7 +45,7 @@ impl Store {
             }
 
             // Hydrate the payload from the data keyspace.
-            let payload_key = make_payload_key(&id);
+            let payload_key = make_payload_key(job.payload_key());
             if let Some(payload_bytes) = ks.data.get(&payload_key)? {
                 job.payload = Some(rmp_serde::from_slice(&payload_bytes)?);
             }

--- a/src/store/results.rs
+++ b/src/store/results.rs
@@ -38,13 +38,17 @@ pub enum EnqueueResult {
     Created(Job),
     /// The job was a duplicate of an existing job in a conflicting state.
     Duplicate(Job),
+    /// The enqueue was folded into an existing pending batched job. The
+    /// returned job is the batch's job (whose payload now reflects the
+    /// merged result).
+    Folded(Job),
 }
 
 impl EnqueueResult {
     /// Return a reference to the underlying job regardless of variant.
     pub fn job(&self) -> &Job {
         match self {
-            EnqueueResult::Created(j) | EnqueueResult::Duplicate(j) => j,
+            EnqueueResult::Created(j) | EnqueueResult::Duplicate(j) | EnqueueResult::Folded(j) => j,
         }
     }
 
@@ -53,10 +57,15 @@ impl EnqueueResult {
         matches!(self, EnqueueResult::Duplicate(_))
     }
 
+    /// Return `true` if this enqueue was folded into an existing batched job.
+    pub fn is_folded(&self) -> bool {
+        matches!(self, EnqueueResult::Folded(_))
+    }
+
     /// Consume the result and return the underlying job.
     pub fn into_job(self) -> Job {
         match self {
-            EnqueueResult::Created(j) | EnqueueResult::Duplicate(j) => j,
+            EnqueueResult::Created(j) | EnqueueResult::Duplicate(j) | EnqueueResult::Folded(j) => j,
         }
     }
 }

--- a/src/store/scan.rs
+++ b/src/store/scan.rs
@@ -589,7 +589,7 @@ impl<'a, R: Readable> Iterator for JobStream<'a, R> {
                 }
 
                 if *needs_payload {
-                    let payload_key = make_payload_key(&job.id);
+                    let payload_key = make_payload_key(job.payload_key());
                     match reader.get(*data_ks, &payload_key) {
                         Ok(Some(pb)) => match rmp_serde::from_slice(&pb) {
                             Ok(v) => job.payload = Some(v),
@@ -612,7 +612,7 @@ impl<'a, R: Readable> Iterator for JobStream<'a, R> {
             } => loop {
                 let entry = entries.next()?;
 
-                let (key, value) = match entry.into_inner() {
+                let (_key, value) = match entry.into_inner() {
                     Ok(kv) => kv,
                     Err(e) => return Some(Err(e.into())),
                 };
@@ -629,9 +629,7 @@ impl<'a, R: Readable> Iterator for JobStream<'a, R> {
                 }
 
                 if *needs_payload {
-                    // Swap J tag for P tag to look up payload.
-                    let mut payload_key = key.to_vec();
-                    payload_key[0] = RecordKind::Payload as u8;
+                    let payload_key = make_payload_key(job.payload_key());
                     match reader.get(*data_ks, &payload_key) {
                         Ok(Some(pb)) => match rmp_serde::from_slice(&pb) {
                             Ok(v) => job.payload = Some(v),

--- a/src/store/take.rs
+++ b/src/store/take.rs
@@ -220,7 +220,7 @@ impl Store {
                 // 5. Hydrate phase — read payloads for all committed jobs.
                 let hydrate_start = std::time::Instant::now();
                 for pre in &mut valid {
-                    let payload_key = make_payload_key(&pre.job_id);
+                    let payload_key = make_payload_key(pre.job.payload_key());
                     if let Some(payload_bytes) = ks.data.get(&payload_key)? {
                         pre.job.payload = Some(rmp_serde::from_slice(&payload_bytes)?);
                     }

--- a/src/store/take.rs
+++ b/src/store/take.rs
@@ -18,7 +18,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use fjall::Slice;
 use tokio::task;
 
-use super::keys::{make_job_key, make_payload_key, make_status_key, make_unique_key};
+use super::keys::{
+    make_batch_key, make_job_key, make_payload_key, make_status_key, make_unique_key,
+};
 use super::store::{Store, StoreEvent};
 use super::types::{Job, JobStatus, StoreError, UniqueWhile};
 
@@ -182,6 +184,19 @@ impl Store {
                                 other => other.cloned(),
                             })?;
                         }
+                    }
+
+                    // Batched jobs close their batch on claim: no more
+                    // folds can target this job. Remove the index entry
+                    // only if it still points at *this* job — a prior
+                    // seal may have already replaced it with a fresh
+                    // batch.
+                    if let Some(ref bc) = pre.job.batch {
+                        let job_id = pre.job_id.as_bytes();
+                        tx.fetch_update(&ks.index, &make_batch_key(&bc.key), |v| match v {
+                            Some(v) if v.as_ref() == job_id => None,
+                            other => other.cloned(),
+                        })?;
                     }
                 }
 

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -187,6 +187,33 @@ impl UniqueConstraint {
     }
 }
 
+/// Batching configuration for a job.
+///
+/// When a job is enqueued with `batch`, subsequent enqueues sharing the same
+/// `key` may be folded into it: the `when` jq predicate decides whether to
+/// fold, and the `fold` jq expression produces the merged payload. Both
+/// expressions run against `$existing` (the current pending job's payload)
+/// and `$new` (the incoming payload). The first enqueue's `when`/`fold`
+/// wins — subsequent enqueues supply payload against the existing
+/// configuration until the batch is sealed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchConfig {
+    /// Identifies the batch. Only one pending batch may exist per key at a
+    /// time.
+    #[serde(rename = "k")]
+    pub key: String,
+
+    /// jq predicate. When it evaluates truthy, the new payload is folded
+    /// into the existing pending job. When falsy, the existing batch is
+    /// sealed and a fresh pending job is created.
+    #[serde(rename = "w")]
+    pub when: String,
+
+    /// jq expression producing the merged payload when `when` returns true.
+    #[serde(rename = "f")]
+    pub fold: String,
+}
+
 /// A job stored in the queue keyspace.
 ///
 /// Jobs are identified using scru128 because it is time-sequenced and high
@@ -308,6 +335,15 @@ pub struct Job {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload_key: Option<String>,
+
+    /// Batching configuration. When set, subsequent enqueues sharing this
+    /// batch key may fold their payloads into this job's payload until the
+    /// batch is sealed (predicate fails) or the job transitions to
+    /// InFlight.
+    #[serde(rename = "B")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<BatchConfig>,
 }
 
 impl Job {

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -295,6 +295,30 @@ pub struct Job {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique: Option<UniqueConstraint>,
+
+    /// Address of this job's payload record in the data keyspace.
+    ///
+    /// When `None`, the payload lives at `P\0<job_id>` (default for jobs
+    /// that never mutate their payload). When `Some`, the payload lives
+    /// at `P\0<payload_key>` — used by features that need to rewrite a
+    /// pending job's payload without moving its queue position, so that
+    /// each individual payload record remains write-once/delete-once and
+    /// `remove_weak` stays valid.
+    #[serde(rename = "k")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_key: Option<String>,
+}
+
+impl Job {
+    /// Returns the identifier used to construct this job's payload key.
+    ///
+    /// Falls back to the job id for jobs that don't have a distinct
+    /// `payload_key` set, so existing storage layouts continue to work
+    /// unchanged.
+    pub(crate) fn payload_key(&self) -> &str {
+        self.payload_key.as_deref().unwrap_or(&self.id)
+    }
 }
 
 /// Retention configuration for completed and dead jobs.


### PR DESCRIPTION
Easiest to review commit-by-commit, this change brings in a long-desired feature: batched jobs.

Often when operating at scale, projects need to coalesce multiple units of work into one larger batch unit of work. For example, rather than sending push notifications one at a time through APNS, it is more efficient to batch up multiple notifications and send them in a single request. Writing such machinery by hand can be a pain. This is something the job queue should be able to do for you.

Under a pro license, Zizq now supports taking many individually enqueued jobs and coalescing them together into a single job. It works in a similar way to unique jobs, which does enqueue-time deduplication of jobs based on a unique key. Batched jobs does enqueue-time coalescing of jobs based on a batch key and a couple of `jq` expressions.

```sh
http POST http://localhost:7890/jobs --raw '{
    "queue": "audit",
    "type": "audit.events",
    "batch": {
      "key": "audit.events",
      "when": "[$existing[], $new[]] | length <= 5",
      "fold": "[$existing[], $new[]]"
    },
    "payload": [{
        "occurred_at": "'"$(date -Iseconds)"'",
        "actor": "user_1234",
        "resource": "acct_5678",
        "text": "Account closed"
    }]
}'
```

In the above example the enqueued job is a micro-batch of 1 audit event. The job specifies a batch key specific to this job type, and it specifies `when` and `fold` jq expressions.

The `when` expression is a predicate. As long as this job remains queued, any subsequently enqueued job with the same batch key will evaluate the `when` expression, with `$existing` set to the already-queued job's payload, and `$new` set to the new job's payload. If the expression returns truthy, the payload of the existing job is replaced with the result of the `fold` expression. In this case, a new array combining the two payloads together.

```sh
http POST http://localhost:7890/jobs --raw '{
    "queue": "audit",
    "type": "audit.events",
    "batch": {
      "key": "audit.events",
      "when": "[$existing[], $new[]] | length <= 5",
      "fold": "[$existing[], $new[]]"
    },
    "payload": [{
        "occurred_at": "'"$(date -Iseconds)"'",
        "actor": "user_5678",
        "resource": "acct_9012",
        "text": "Account closed"
    }]
}'
```

The resulting state would be a single job with whatever `id` the first enqueue produced, and the payload set to the combination of the two jobs (i.e. a two-element array).

This would continue on subsequent enqueues using the same batch key until the array has 5 elements. Any subsequent enqueues fail the predicate and enqueue a new job, starting a new batch accumulating up to 5 elements itself.

This low-level `jq` expression machinery is intended to be abstracted away by client libraries. In theory the expression can be as complex as it needs to be to access nested keys, join strings together, perform uniqueness/filtering operations etc.

By default batching continues to operate until the job is dequeued. Various strategies can be used to implement alternative behaviours, such as combining with scheduled jobs to implement a "linger" approach (jobs wait for up to N seconds to accumulate more data), or a bucketing based approach by varying the batch key. The options are quite open-ended.

This feature does not combine with unique jobs. Attempting to make a job both a unique job and a batched job is nonsensical and produces a 400 error.