### PR TITLE
By-pass Batched Jobs When Scheduled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   fire time. Job reads (`GET /jobs`, `GET /jobs/{id}`, enqueue
   responses) include the stored `batch` config so callers can
   inspect exactly what `when`/`fold` the batch is running against.
+  Scheduled batched enqueues (`ready_at > now`) opt out of the fold
+  path — they persist as normal scheduled jobs with `batch`
+  metadata for observability, but no fold happens across a
+  `ready_at` boundary in either direction. Fold semantics remain
+  strictly immediate-Ready <-> immediate-Ready.
 
 ## 0.5.1
 

--- a/src/store/enqueue/apply.rs
+++ b/src/store/enqueue/apply.rs
@@ -56,7 +56,11 @@ pub(in crate::store) fn apply_enqueue(
     // returned `None` means "fall through to create a new job" — either
     // no existing batch, or the predicate failed and the existing batch
     // was sealed in this tx.
-    if p.job.batch.is_some() {
+    //
+    // Gated on `batch_idx_key` rather than `job.batch` because
+    // scheduled batched enqueues carry `batch` metadata but no index
+    // key (they opt out of folding — see `prepare_enqueue`).
+    if p.batch_idx_key.is_some() {
         if let Some(folded) = try_apply_fold(tx, ks, p)? {
             return Ok(folded);
         }
@@ -125,9 +129,12 @@ fn try_apply_fold(
         ))
     })?;
 
-    if !matches!(existing_status, JobStatus::Ready | JobStatus::Scheduled) {
-        // Index entry outlived the batch's pending state (should be
-        // cleaned up by claim/delete; treat defensively).
+    if existing_status != JobStatus::Ready {
+        // Only immediate-ready jobs are foldable. Scheduled jobs opt
+        // out of batching so that folds never cross a `ready_at`
+        // boundary — otherwise the fold would silently discard one
+        // side's schedule. Other statuses (in-flight, completed,
+        // dead) indicate a stale index entry that we clean up.
         tx.remove(&ks.index, batch_idx_key);
         return Ok(None);
     }

--- a/src/store/enqueue/mod.rs
+++ b/src/store/enqueue/mod.rs
@@ -1325,4 +1325,129 @@ mod tests {
         assert!(r2.is_folded());
         assert_eq!(r2.job().payload, Some(serde_json::json!([1, 2])));
     }
+
+    // --- Batched jobs: interaction with scheduling ---
+
+    #[tokio::test]
+    async fn batch_scheduled_enqueue_does_not_fold_into_immediate() {
+        let store = test_store();
+        let now = now_millis();
+        let future = now + 60_000;
+
+        // Immediate batched job first — creates the batch head.
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        assert!(!r1.is_folded());
+
+        // Scheduled batched enqueue with same key must NOT fold —
+        // otherwise it'd silently promote to immediate (its
+        // `ready_at` would be discarded).
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2]))
+                    .ready_at(future)
+                    .batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        assert!(!r2.is_folded());
+        assert_ne!(r2.job().id, r1.job().id);
+        assert_eq!(r2.job().status, u8::from(JobStatus::Scheduled));
+        assert_eq!(r2.job().ready_at, future);
+    }
+
+    #[tokio::test]
+    async fn batch_immediate_enqueue_does_not_fold_into_scheduled() {
+        let store = test_store();
+        let now = now_millis();
+        let future = now + 60_000;
+
+        // Scheduled batched job first.
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1]))
+                    .ready_at(future)
+                    .batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        assert!(!r1.is_folded());
+        assert_eq!(r1.job().status, u8::from(JobStatus::Scheduled));
+
+        // Immediate enqueue with same key must NOT fold — otherwise
+        // the immediate work would inherit the scheduled `ready_at`
+        // and get silently delayed.
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2])).batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        assert!(!r2.is_folded());
+        assert_ne!(r2.job().id, r1.job().id);
+        assert_eq!(r2.job().status, u8::from(JobStatus::Ready));
+    }
+
+    #[tokio::test]
+    async fn batch_two_scheduled_enqueues_do_not_fold() {
+        let store = test_store();
+        let now = now_millis();
+        let future = now + 60_000;
+
+        let r1 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1]))
+                    .ready_at(future)
+                    .batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+        let r2 = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([2]))
+                    .ready_at(future)
+                    .batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+
+        assert!(!r1.is_folded());
+        assert!(!r2.is_folded());
+        assert_ne!(r1.job().id, r2.job().id);
+    }
+
+    #[tokio::test]
+    async fn batch_scheduled_enqueue_persists_batch_metadata() {
+        // Even though scheduled batched jobs opt out of folding, the
+        // `batch` config is still recorded on the job for
+        // observability — the class-level intent shouldn't disappear
+        // just because scheduling happens to skip the fold path.
+        let store = test_store();
+        let now = now_millis();
+        let future = now + 60_000;
+
+        let r = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("push", "q", serde_json::json!([1]))
+                    .ready_at(future)
+                    .batch(append_batch("k")),
+            )
+            .await
+            .unwrap();
+
+        let fetched = store.get_job(now, &r.job().id).await.unwrap().unwrap();
+        assert!(fetched.batch.is_some(), "batch metadata should persist");
+        assert_eq!(fetched.batch.as_ref().unwrap().key, "k");
+    }
 }

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -91,17 +91,31 @@ pub(in crate::store) fn prepare_enqueue(
 
     let payload_bytes = rmp_serde::to_vec_named(&opts.payload)?;
 
+    // Scheduled batched enqueues opt out of the fold path entirely.
+    // Folding two enqueues with different `ready_at` values would
+    // silently promote a scheduled job to immediate (or vice versa)
+    // since the fold preserves the existing job's schedule and
+    // discards the incoming one's — a footgun that's easier to
+    // disallow than explain. The Job's `batch` metadata is still set
+    // for observability, but no batch index entry is inserted and the
+    // scheduled job is not eligible to be folded into.
+    let batchable_now = opts.batch.is_some() && !scheduled;
+
     // Pre-compute a fresh payload key id for the merged-payload target
     // if this enqueue ends up folding. Discarded when the enqueue
     // instead creates a new job, so the created job's on-disk shape
     // matches a non-batched job (payload at `P\0<job_id>`, no
     // `payload_key` field on the metadata).
-    let fold_payload_key_id = if opts.batch.is_some() {
+    let fold_payload_key_id = if batchable_now {
         Some(scru128::new_string())
     } else {
         None
     };
-    let batch_idx_key = opts.batch.as_ref().map(|cfg| make_batch_key(&cfg.key));
+    let batch_idx_key = if batchable_now {
+        opts.batch.as_ref().map(|cfg| make_batch_key(&cfg.key))
+    } else {
+        None
+    };
 
     let job = Job {
         id: id.clone(),


### PR DESCRIPTION
Batched Jobs does not interoperate well (that is, in a way that makes any sense) with scheduling.

A job that is scheduled in the future should never have immediate jobs folded into it, and one that is immediate (or earlier) should not have future scheduled jobs folded into it.

The only logical solution to this is to exclude jobs that are scheduled from participating in folding. We *could* fold them when promoting from scheduled -> ready, but this is a lossy operation. The job ID was already returned when the job was scheduled, and it would simply disappear as it gets folded into another job, so that's quite confusing.

Callers can simply enqueue a point-in-time batched job when the scheduled job executes instead.