### PR TITLE
Fix Bug with Backoff Curve Formula.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.1
+
+- Fixed a units error in the retry backoff formula where the
+  `attempts^exponent` term was treated as milliseconds instead of
+  seconds. With the shipped defaults this silently shortened the
+  total retry window from the intended ~25 days to under 4 hours,
+  so a transient production incident could exhaust all retries
+  within a single outage rather than spanning multiple days. Added
+  a pinning test that asserts the total retry window with the
+  default configuration stays within a 24-26 day band, so a future
+  regression on the same axis is caught in CI.
+
 ## 0.6.0
 
 - Added **batched jobs** (Pro): a new `batch` field on enqueue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.0/zizq-0.6.0-linux-x86_64.tar.gz
-tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.1/zizq-0.6.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -58,7 +58,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.6.0
+Zizq 0.6.1
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/backoff.md
+++ b/docs/cli/src/backoff.md
@@ -38,7 +38,7 @@ Where:
 
 * `t` is the delay to apply before retrying
 * `B` is the base delay applied to all retries
-* `a` is the number of previous attempts
+* `a` is the number of attempts so far (including the current failure)
 * `E` is the backoff exponent (optionally fractional)
 * `J` is a random jitter used to spread retries
 
@@ -55,8 +55,8 @@ E = 4
 J = 30s
 ```
 
-This gives just under 4 days of total retry time before the job is eventually
-moved to the `dead` list.
+This gives approximately 25 days of total retry time before the job is
+eventually moved to the `dead` list.
 
 ## Adjusting the Backoff Curve
 
@@ -68,7 +68,7 @@ retry could occur anywhere within the band.
 
 > [!TIP]
 > Adjust the exponent very gradually. A change from `4.0` to `4.2` is enough to
-> change the total retry time from approx. 4 days to approx 7 days.
+> stretch the total retry time from ~25 days to ~40 days.
 
 <style>
   #backoff-chart-container {
@@ -129,6 +129,26 @@ retry could occur anywhere within the band.
     white-space: nowrap;
     z-index: 10;
   }
+
+  .bc-mode {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1em;
+    margin-top: 0.8em;
+    font-size: 0.9em;
+  }
+
+  .bc-mode-label {
+    color: var(--zizq-text-secondary);
+  }
+
+  .bc-mode label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    cursor: pointer;
+  }
 </style>
 
 <div id="backoff-chart-container">
@@ -154,6 +174,11 @@ retry could occur anywhere within the band.
     <canvas id="bc-canvas">
     </canvas>
     <div id="bc-tooltip"></div>
+  </div>
+  <div class="bc-mode">
+    <span class="bc-mode-label">Y-axis:</span>
+    <label><input type="radio" name="bc-mode" value="cumulative" checked> Cumulative</label>
+    <label><input type="radio" name="bc-mode" value="per-attempt"> Per attempt</label>
   </div>
 </div>
 

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.0/zizq-0.6.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.1/zizq-0.6.1-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/cli/theme/backoff-chart.js
+++ b/docs/cli/theme/backoff-chart.js
@@ -6,6 +6,17 @@
   const ctx = canvas.getContext('2d');
   const tooltip = $('bc-tooltip');
 
+  // Mode toggle: switches the y-axis between per-attempt delay and running
+  // cumulative total. Defaults to cumulative so the total retry window is
+  // the first thing readers see — per-attempt hides the true scale.
+  document.querySelectorAll('input[name="bc-mode"]').forEach(function(el) {
+    el.addEventListener('change', draw);
+  });
+  function currentMode() {
+    const sel = document.querySelector('input[name="bc-mode"]:checked');
+    return sel ? sel.value : 'cumulative';
+  }
+
   // Full detail: 3d20h9m41s
   function fmtDur(sec) {
     if (sec < 0) sec = 0;
@@ -64,9 +75,12 @@
   }
 
   function computeCurves(p) {
+    // Matches the server's compute_backoff formula: for attempts a=1..N,
+    // delay = B + a^E + a * rand(0..J). Uses 1-indexed attempts so the
+    // first retry gets a real exponent term rather than zero.
     const min = [], max = [], cumMin = [], cumMax = [];
     let totalMin = 0, totalMax = 0;
-    for (let a = 0; a < p.N; a++) {
+    for (let a = 1; a <= p.N; a++) {
       const base = p.B + Math.pow(a, p.E);
       const lo = base;
       const hi = base + a * p.J;
@@ -93,7 +107,13 @@
     const W = rect.width, H = rect.height;
 
     const curves = computeCurves(p);
-    const yMax = Math.max(curves.max[curves.max.length - 1] || 1, 1);
+    // Pick which pair of curves to plot on the y-axis based on the toggle.
+    // Cumulative uses running totals; per-attempt uses the raw min/max delay
+    // for each individual retry. Tooltip content covers both regardless.
+    const mode = currentMode();
+    const plotMin = mode === 'cumulative' ? curves.cumMin : curves.min;
+    const plotMax = mode === 'cumulative' ? curves.cumMax : curves.max;
+    const yMax = Math.max(plotMax[plotMax.length - 1] || 1, 1);
 
     // Layout
     const padL = 56, padR = 16, padT = 16, padB = 36;
@@ -145,8 +165,8 @@
 
     // Fill between curves
     ctx.beginPath();
-    for (let i = 0; i < p.N; i++) ctx.lineTo(xPos(i), yPos(curves.min[i]));
-    for (let i = p.N - 1; i >= 0; i--) ctx.lineTo(xPos(i), yPos(curves.max[i]));
+    for (let i = 0; i < p.N; i++) ctx.lineTo(xPos(i), yPos(plotMin[i]));
+    for (let i = p.N - 1; i >= 0; i--) ctx.lineTo(xPos(i), yPos(plotMax[i]));
     ctx.closePath();
     ctx.fillStyle = accent;
     ctx.globalAlpha = 0.15;
@@ -155,14 +175,14 @@
 
     // Min line
     ctx.beginPath();
-    for (let i = 0; i < p.N; i++) ctx.lineTo(xPos(i), yPos(curves.min[i]));
+    for (let i = 0; i < p.N; i++) ctx.lineTo(xPos(i), yPos(plotMin[i]));
     ctx.strokeStyle = accent;
     ctx.lineWidth = 2;
     ctx.stroke();
 
     // Max line
     ctx.beginPath();
-    for (let i = 0; i < p.N; i++) ctx.lineTo(xPos(i), yPos(curves.max[i]));
+    for (let i = 0; i < p.N; i++) ctx.lineTo(xPos(i), yPos(plotMax[i]));
     ctx.strokeStyle = accent2;
     ctx.lineWidth = 2;
     ctx.stroke();
@@ -182,23 +202,31 @@
       ctx.globalAlpha = 1;
 
       // Dots
-      [curves.min[idx], curves.max[idx]].forEach((v, vi) => {
+      [plotMin[idx], plotMax[idx]].forEach((v, vi) => {
         ctx.beginPath();
         ctx.arc(sx, yPos(v), 4, 0, Math.PI * 2);
         ctx.fillStyle = vi === 0 ? accent : accent2;
         ctx.fill();
       });
 
-      // Tooltip (full detail + cumulative)
+      // Tooltip: primary line matches the current mode; the other view
+      // stays visible below so scrubbing gives both numbers at once.
+      const primary = mode === 'cumulative'
+        ? { label: 'Cumulative', min: curves.cumMin[idx], max: curves.cumMax[idx] }
+        : { label: 'This retry', min: curves.min[idx],    max: curves.max[idx] };
+      const secondary = mode === 'cumulative'
+        ? { label: 'This retry', min: curves.min[idx],    max: curves.max[idx] }
+        : { label: 'Cumulative', min: curves.cumMin[idx], max: curves.cumMax[idx] };
+
       tooltip.style.display = 'block';
       tooltip.innerHTML =
         '<strong>Attempt ' + (idx + 1) + '</strong><br>' +
-        '<span style="color:' + accent + '">Min:</span> ' + fmtDur(curves.min[idx]) + '<br>' +
-        '<span style="color:' + accent2 + '">Max:</span> ' + fmtDur(curves.max[idx]) + '<br>' +
-        '<span style="opacity:0.7">Total: ' + fmtDur(curves.cumMin[idx]) +
-        ' – ' + fmtDur(curves.cumMax[idx]) + '</span>';
+        '<span style="color:' + accent + '">' + primary.label + ' min:</span> ' + fmtDur(primary.min) + '<br>' +
+        '<span style="color:' + accent2 + '">' + primary.label + ' max:</span> ' + fmtDur(primary.max) + '<br>' +
+        '<span style="opacity:0.7">' + secondary.label + ': ' + fmtDur(secondary.min) +
+        ' – ' + fmtDur(secondary.max) + '</span>';
 
-      let tx = sx + 12, ty = yPos((curves.min[idx] + curves.max[idx]) / 2) - 30;
+      let tx = sx + 12, ty = yPos((plotMin[idx] + plotMax[idx]) / 2) - 30;
       if (tx + 140 > W) tx = sx - 140;
       if (ty < 0) ty = 4;
       tooltip.style.left = tx + 'px';

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -17,7 +17,7 @@ does almost all of the work.
 > Download:
 >
 > ```bash
-> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.0/zizq-0.6.0-linux-x86_64.tar.gz
+> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.1/zizq-0.6.1-linux-x86_64.tar.gz
 > ```
 
 ### 2. Extract it.
@@ -25,7 +25,7 @@ does almost all of the work.
 > Extract:
 >
 > ```bash
-> tar -xvzf zizq-0.6.0-linux-x86_64.tar.gz
+> tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
 > ```
 
 ### 3. Run it to start the server.
@@ -35,7 +35,7 @@ does almost all of the work.
 > ```bash
 > ./zizq serve
 > 
-> Zizq 0.6.0
+> Zizq 0.6.1
 > 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 > 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 > 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -3539,7 +3539,7 @@ mod tests {
         let router = app(state.clone());
 
         // Enqueue with a custom backoff: exponent=1, base_ms=200, jitter=0.
-        // Backoff for attempt 1: 1^1 + 200 = 201ms.
+        // Backoff for attempt 1: 1^1 * 1000 + 200 = 1200ms.
         let req = json_request(
             "POST",
             "/jobs",
@@ -3579,8 +3579,8 @@ mod tests {
         let ready_at = job["ready_at"].as_u64().unwrap();
         assert_eq!(
             ready_at,
-            now + 201,
-            "ready_at should use per-job backoff (1^1 + 200 = 201ms), not server default",
+            now + 1200,
+            "ready_at should use per-job backoff (1^1 * 1000 + 200 = 1200ms), not server default",
         );
     }
 
@@ -5876,7 +5876,8 @@ mod tests {
     #[tokio::test]
     async fn failure_applies_default_backoff() {
         // Use a known backoff config with zero jitter so the result is
-        // deterministic: delay = attempts^exponent + base_ms = 1^2 + 500 = 501.
+        // deterministic: delay = attempts^exponent * 1000 + base_ms
+        //                     = 1^2 * 1000 + 500 = 1500.
         let mut config = store::StorageConfig::default();
         config.default_backoff = store::BackoffConfig {
             exponent: 2.0,
@@ -5905,7 +5906,7 @@ mod tests {
             .unwrap();
 
         // Fail the job — the handler reads (state.clock)() which returns
-        // our fixed `now`, so ready_at = now + 501 exactly.
+        // our fixed `now`, so ready_at = now + 1500 exactly.
         let req = json_request(
             "POST",
             &format!("/jobs/{job_id}/failure"),
@@ -5918,12 +5919,12 @@ mod tests {
         assert_eq!(job["status"], "scheduled");
 
         // With exponent=2, base_ms=500, jitter=0, attempts=1:
-        // delay = 1^2 + 500 = 501ms
+        // delay = 1^2 * 1000 + 500 = 1500ms
         let ready_at = job["ready_at"].as_u64().unwrap();
         assert_eq!(
             ready_at,
-            now + 501,
-            "ready_at should be exactly now + 501ms (backoff for attempt 1)",
+            now + 1500,
+            "ready_at should be exactly now + 1500ms (backoff for attempt 1)",
         );
     }
 

--- a/src/store/fail.rs
+++ b/src/store/fail.rs
@@ -245,7 +245,11 @@ impl Store {
 
 /// Compute the backoff delay in milliseconds for a given attempt count.
 ///
-/// Formula: `delay_ms = attempts^exponent + base_ms + rand(0..jitter_ms) * (attempts + 1)`
+/// Formula: `delay_ms = attempts^exponent * 1000 + base_ms + rand(0..jitter_ms) * attempts`
+///
+/// The exponent term is scaled to ms so the curve grows on a human timescale.
+/// With defaults (exponent=4, base=15s, jitter=30s, retry_limit=25) the total
+/// retry window is roughly 25 days.
 ///
 /// The jitter component scales linearly with the attempt count so that
 /// later retries spread further apart, reducing collision likelihood when
@@ -254,14 +258,15 @@ fn compute_backoff(attempts: u32, backoff: &BackoffConfig) -> u64 {
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hasher};
 
-    let base_delay = (attempts as f32).powf(backoff.exponent) + backoff.base_ms as f32;
+    let base_delay =
+        (attempts as f64).powf(backoff.exponent as f64) * 1000.0 + backoff.base_ms as f64;
 
     // Cheap random value using the same approach as rand_id() in http.rs.
     let rand_frac = (RandomState::new().build_hasher().finish() as f64) / (u64::MAX as f64); // 0.0..1.0
 
-    let jitter = rand_frac * backoff.jitter_ms as f64 * (attempts as f64 + 1.0);
+    let jitter = rand_frac * backoff.jitter_ms as f64 * attempts as f64;
 
-    (base_delay as f64 + jitter) as u64
+    (base_delay + jitter) as u64
 }
 
 #[cfg(test)]
@@ -288,12 +293,12 @@ mod tests {
             jitter_ms: 0,
         };
 
-        // attempts=1: 1^2 + 100 = 101
-        assert_eq!(compute_backoff(1, &backoff), 101);
-        // attempts=2: 2^2 + 100 = 104
-        assert_eq!(compute_backoff(2, &backoff), 104);
-        // attempts=3: 3^2 + 100 = 109
-        assert_eq!(compute_backoff(3, &backoff), 109);
+        // attempts=1: 1^2 * 1000 + 100 = 1100
+        assert_eq!(compute_backoff(1, &backoff), 1100);
+        // attempts=2: 2^2 * 1000 + 100 = 4100
+        assert_eq!(compute_backoff(2, &backoff), 4100);
+        // attempts=3: 3^2 * 1000 + 100 = 9100
+        assert_eq!(compute_backoff(3, &backoff), 9100);
     }
 
     #[test]
@@ -307,8 +312,8 @@ mod tests {
         // Run many times to exercise randomness.
         for attempts in 1..=10 {
             let delay = compute_backoff(attempts, &backoff);
-            let base = (attempts as f64).powf(2.0) + 100.0;
-            let max_jitter = 50.0 * (attempts as f64 + 1.0);
+            let base = (attempts as f64).powf(2.0) * 1000.0 + 100.0;
+            let max_jitter = 50.0 * attempts as f64;
             assert!(
                 delay >= base as u64,
                 "delay {delay} below base {base} for attempt {attempts}"
@@ -329,8 +334,62 @@ mod tests {
             jitter_ms: 0,
         };
 
-        // attempts=0: 0^2 + 100 = 100
+        // attempts=0: 0^2 * 1000 + 100 = 100
         assert_eq!(compute_backoff(0, &backoff), 100);
+    }
+
+    /// Pin the total retry window that the server defaults produce.
+    ///
+    /// With `exponent=4`, `base=15s`, `jitter=30s`, `retry_limit=25` a job
+    /// takes ~25 days to exhaust all retries before moving to `dead`.
+    /// Regressing this window (e.g. re-introducing the historic ms/seconds
+    /// unit bug that made retries exhaust in hours) would silently change
+    /// production behaviour.
+    #[test]
+    fn compute_backoff_total_retry_window_with_defaults() {
+        use crate::store::storage_config::{
+            DEFAULT_BACKOFF_BASE_MS, DEFAULT_BACKOFF_EXPONENT, DEFAULT_BACKOFF_JITTER_MS,
+            DEFAULT_RETRY_LIMIT,
+        };
+
+        const DAY_MS: u64 = 86_400_000;
+
+        // Minimum total: force jitter to zero and sum every scheduled delay
+        // from the first retry (attempts=1) to the last (attempts=N).
+        let no_jitter = BackoffConfig {
+            exponent: DEFAULT_BACKOFF_EXPONENT,
+            base_ms: DEFAULT_BACKOFF_BASE_MS,
+            jitter_ms: 0,
+        };
+        let min_total_ms: u64 = (1..=DEFAULT_RETRY_LIMIT)
+            .map(|a| compute_backoff(a, &no_jitter))
+            .sum();
+
+        // Maximum total: compute analytically since compute_backoff randomises
+        // jitter. Max per-attempt delay is a^E*1000 + base_ms + jitter_ms*a.
+        let max_total_ms: u64 = (1..=DEFAULT_RETRY_LIMIT)
+            .map(|a| {
+                let base = (a as f64).powf(DEFAULT_BACKOFF_EXPONENT as f64) * 1000.0
+                    + DEFAULT_BACKOFF_BASE_MS as f64;
+                let max_jitter = DEFAULT_BACKOFF_JITTER_MS as f64 * a as f64;
+                (base + max_jitter) as u64
+            })
+            .sum();
+
+        assert!(
+            min_total_ms >= 24 * DAY_MS,
+            "min total {} ms (~{} days) below expected floor of 24 days — \
+             backoff formula regressed?",
+            min_total_ms,
+            min_total_ms / DAY_MS
+        );
+        assert!(
+            max_total_ms <= 26 * DAY_MS,
+            "max total {} ms (~{} days) above expected ceiling of 26 days — \
+             backoff formula regressed?",
+            max_total_ms,
+            max_total_ms / DAY_MS
+        );
     }
 
     // --- record_failure tests ---


### PR DESCRIPTION
There was a unit error (seconds vs milliseconds) in the backoff curve formula, meaning retries were exhausted within hours, rather than weeks. Added new unit test coverage asserting the _cumulative_ outcome we expect.