### PR TITLE
Fix Copyright Date in File Header Comments.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,15 +4,15 @@ License text copyright (c) 2024 MariaDB plc, All Rights Reserved.
 Parameters
 
 Licensor:             Chris Corbyn <chris@zizq.io>
-Licensed Work:        Zizq 0.1.0
-                      The Licensed Work is (c) 2025 Chris Corbyn
+Licensed Work:        Zizq 0.6.1
+                      The Licensed Work is (c) 2026 Chris Corbyn
 Additional Use Grant: You may use the Licensed Work for non-commercial and
                       personal purposes. You may freely use short portions
                       of the source code in your own projects provided that
                       you give credit to the Licensor alongside such usages
                       within your project
 
-Change Date:          2030-02-12
+Change Date:          2030-08-05
 
 Change License:       Apache License, Version 2.0
 

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -49,12 +49,17 @@ cargo update -p zizq --quiet 2>/dev/null || cargo generate-lockfile --quiet 2>/d
 echo "  Updated Cargo.lock"
 
 # Update docs.
-for doc in docs/getting-started/src/quick-start.md docs/cli/src/installation.md README.md
+for doc in docs/getting-started/src/quick-start.md docs/cli/src/installation.md README.md LICENSE
 do
     sed -i "s/Zizq ${CURRENT}/Zizq ${NEW}/" $doc
     sed -i "s/\\/v${CURRENT}\\//\\/v${NEW}\\//" $doc
     sed -i "s/zizq-${CURRENT}/zizq-${NEW}/" $doc
 done
+
+# Update Change Date in LICENSE to 4 years from today.
+NEW_CHANGE_DATE=$(date -d "+4 years" +%Y-%m-%d)
+sed -i "s/^Change Date:.*/Change Date:          ${NEW_CHANGE_DATE}/" LICENSE
+echo "  Updated LICENSE Change Date to ${NEW_CHANGE_DATE}"
 
 # Add new CHANGELOG section if it doesn't already exist.
 if ! grep -q "^## ${NEW}" CHANGELOG.md 2>/dev/null; then

--- a/src/api/admin/backup.rs
+++ b/src/api/admin/backup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Admin backup endpoint.

--- a/src/api/admin/compact.rs
+++ b/src/api/admin/compact.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Admin compaction endpoint.

--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! WebSocket event stream (currently) for Terminal UI clients.

--- a/src/api/admin/handlers.rs
+++ b/src/api/admin/handlers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Admin API request handlers.

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Admin API for the Zizq dashboard.

--- a/src/api/admin/types.rs
+++ b/src/api/admin/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Types for the admin WebSocket API.

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Shared middleware for the API layer.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 pub mod admin;

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Primary API request handlers.

--- a/src/api/primary/mod.rs
+++ b/src/api/primary/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 mod handlers;

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Request, response, and API types for the HTTP layer.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! jq-style expression evaluation for batched jobs.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! `zizq backup` subcommand.

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! `zizq compact` subcommand.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! CLI subcommand implementations.

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! `zizq restore` subcommand.

--- a/src/commands/serve/cron_scheduler.rs
+++ b/src/commands/serve/cron_scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Background cron scheduler that enqueues jobs from cron entries.

--- a/src/commands/serve/mod.rs
+++ b/src/commands/serve/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Zizq CLI `serve` command entry point.

--- a/src/commands/serve/reaper.rs
+++ b/src/commands/serve/reaper.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Background reaper that purges expired completed and dead jobs.

--- a/src/commands/serve/scheduler.rs
+++ b/src/commands/serve/scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Background scheduler that promotes scheduled jobs to the Ready state.

--- a/src/commands/serve/tls.rs
+++ b/src/commands/serve/tls.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! TLS support for the primary HTTP listener.

--- a/src/commands/tls.rs
+++ b/src/commands/tls.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! CLI subcommands for generating TLS certificates.

--- a/src/commands/top/app.rs
+++ b/src/commands/top/app.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! TUI application state model.

--- a/src/commands/top/events.rs
+++ b/src/commands/top/events.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Event sources for the TUI.

--- a/src/commands/top/mod.rs
+++ b/src/commands/top/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Terminal UI dashboard for Zizq.

--- a/src/commands/top/ui/depth_bar.rs
+++ b/src/commands/top/ui/depth_bar.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Depth bar visualization — the `Depth[│││             3 jobs]` widget

--- a/src/commands/top/ui/detail_panel.rs
+++ b/src/commands/top/ui/detail_panel.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Detail panel — the lower split that shows the metadata + payload of

--- a/src/commands/top/ui/format.rs
+++ b/src/commands/top/ui/format.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Pure formatting helpers used across the UI components.

--- a/src/commands/top/ui/header.rs
+++ b/src/commands/top/ui/header.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Top-of-screen header — version, connection indicator, server info,

--- a/src/commands/top/ui/help_bar.rs
+++ b/src/commands/top/ui/help_bar.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Bottom help bar — keyboard shortcut hints, the delete confirmation

--- a/src/commands/top/ui/job_table.rs
+++ b/src/commands/top/ui/job_table.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Job-table rendering for each tab (Ready / In-Flight / Scheduled),

--- a/src/commands/top/ui/mod.rs
+++ b/src/commands/top/ui/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Ratatui rendering for the TUI dashboard.

--- a/src/commands/top/ui/tabs.rs
+++ b/src/commands/top/ui/tabs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Tab bar — the row of `[In-Flight] [Ready] [Scheduled]` labels above

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! jq-style payload filtering for the List Jobs API.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Zizq job queue library crate.

--- a/src/license.rs
+++ b/src/license.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! License validation for paid feature gating.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Logging initialization for Zizq.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Zizq CLI entry point.

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Shared server state.

--- a/src/store/complete/apply.rs
+++ b/src/store/complete/apply.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Write-tx phase of completion: apply pre-built `PreparedComplete`

--- a/src/store/complete/batcher.rs
+++ b/src/store/complete/batcher.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Server-side opportunistic batching for concurrent completions

--- a/src/store/complete/mod.rs
+++ b/src/store/complete/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Job completion operations on `Store`.

--- a/src/store/complete/pre_read.rs
+++ b/src/store/complete/pre_read.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Pre-tx phase of completion: read each candidate job from the data

--- a/src/store/cron/mod.rs
+++ b/src/store/cron/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Cron scheduling types and in-memory schedule index.

--- a/src/store/cron/ops.rs
+++ b/src/store/cron/ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Cron group/entry CRUD, scheduler integration, and recovery rebuild.

--- a/src/store/delete.rs
+++ b/src/store/delete.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Job deletion operations: single-job purge/delete, bulk delete, and

--- a/src/store/enqueue/apply.rs
+++ b/src/store/enqueue/apply.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Write-tx phase of enqueue: apply pre-built `PreparedEnqueue` values to

--- a/src/store/enqueue/batcher.rs
+++ b/src/store/enqueue/batcher.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Server-side opportunistic batching for concurrent enqueues.

--- a/src/store/enqueue/finalize.rs
+++ b/src/store/enqueue/finalize.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Post-commit phase of enqueue: update the in-memory ready/scheduled

--- a/src/store/enqueue/mod.rs
+++ b/src/store/enqueue/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Enqueue operations: single and bulk job insertion.

--- a/src/store/enqueue/prepare.rs
+++ b/src/store/enqueue/prepare.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Pure-computation phase of enqueue: assemble a `PreparedEnqueue` from

--- a/src/store/fail.rs
+++ b/src/store/fail.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Job failure handling: retry vs kill, backoff, error record persistence.

--- a/src/store/find.rs
+++ b/src/store/find.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! `less`-style search over the in-memory Ready / InFlight / Scheduled

--- a/src/store/group_committer.rs
+++ b/src/store/group_committer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Group commit batching for journal persistence.

--- a/src/store/in_flight_index.rs
+++ b/src/store/in_flight_index.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 use crossbeam_skiplist::SkipSet;

--- a/src/store/keys.rs
+++ b/src/store/keys.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! On-disk key encoding for the data and index keyspaces.

--- a/src/store/maintenance.rs
+++ b/src/store/maintenance.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Maintenance ops that don't fit any single job-lifecycle pass:

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 mod complete;

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Input/builder types for store operations.

--- a/src/store/patch.rs
+++ b/src/store/patch.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Single-job and bulk-job patch operations.

--- a/src/store/read.rs
+++ b/src/store/read.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Read-only operations on the store: single-job lookup, paginated job

--- a/src/store/ready_index.rs
+++ b/src/store/ready_index.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 use std::collections::HashSet;

--- a/src/store/recover.rs
+++ b/src/store/recover.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Startup recovery: re-promote orphaned in-flight jobs to Ready, then

--- a/src/store/requeue.rs
+++ b/src/store/requeue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Requeue: return an in-flight job to the ready queue.

--- a/src/store/results.rs
+++ b/src/store/results.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Result types returned by store operations.

--- a/src/store/scan.rs
+++ b/src/store/scan.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Iterator scaffolding shared by `read`, `delete`, and `patch`.

--- a/src/store/scheduled.rs
+++ b/src/store/scheduled.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Scheduled-job operations: scanning the chronological scheduled index

--- a/src/store/scheduled_index.rs
+++ b/src/store/scheduled_index.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 use crossbeam_skiplist::SkipSet;

--- a/src/store/storage_config.rs
+++ b/src/store/storage_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! `StorageConfig` + default constants + env-var loader.

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Persistent storage layer to manage job queues.

--- a/src/store/take.rs
+++ b/src/store/take.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Job dequeue: claim ready jobs from the priority index and mark them

--- a/src/store/test_support.rs
+++ b/src/store/test_support.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Shared test fixtures for the `store` module.

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Core domain types for the store layer.

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Chris Corbyn <chris@zizq.io>
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 
 //! Shared time utilities used across the crate.


### PR DESCRIPTION
2025 spread through the source tree and was never corrected to 2026. Not a real issue in practice but best to keep it up to date. Also need to keep the licensed software version in sync with the Cargo.toml version.