### PR TITLE
Add Elixir to Integration Test Matrix.

### DIFF
--- a/.github/scripts/discover-client-versions.sh
+++ b/.github/scripts/discover-client-versions.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-language="${1:?language required (node|ruby|rust)}"
+language="${1:?language required (node|ruby|rust|elixir)}"
 server_version="${2:?server version required}"
 
 case "$language" in
@@ -62,6 +62,20 @@ case "$language" in
         | sed -E 's/.*"([^"]+)".*/\1/'
     }
     ;;
+  elixir)
+    repo="zizq-labs/zizq-elixir"
+    version_path="mix.exs"
+    asset_prefix="zizq-"
+    asset_suffix=".tar"
+    # `@version "x.y.z"` is the single source of truth in mix.exs —
+    # `release.sh` and `bump-version.sh` read the same line.
+    extract_main_version() {
+      gh api "repos/${repo}/contents/${version_path}?ref=main" --jq '.content' \
+        | base64 -d \
+        | sed -n 's/^[[:space:]]*@version "\(.*\)"/\1/p' \
+        | head -n1
+    }
+    ;;
   *)
     echo "unknown language: $language" >&2
     exit 1
@@ -76,6 +90,13 @@ server_minor="${rest%%.*}"
 #   - tag name matches v<major>.<minor>.<patch>
 #   - same major as the server
 #   - minor <= server minor
+#
+# The tag pattern is anchored at BOTH ends deliberately: that is what
+# keeps pre-releases (`v0.6.0-alpha.9`, `v1.0.0-rc.1`) out of the
+# matrix. Unstable client builds must not be able to fail this repo's
+# CI. Do not relax the anchors — nothing else excludes them, since the
+# clients publish pre-releases as ordinary GitHub releases rather than
+# marking them `--prerelease`, so `isPrerelease` would not help.
 #
 # Then split each version into numeric components (so v0.20.1 > v0.3.1),
 # sort by those, group by [major, minor], and take the last element of
@@ -106,6 +127,13 @@ releases=$(gh release list --repo "$repo" --limit 200 --json tagName \
       ')
 
 # Include main if its version is still compatible.
+#
+# Unlike the tag pattern above, this regex is intentionally NOT
+# anchored at the end, so a pre-release version on main still matches
+# and `main` is still tested. That is the point: during an alpha cycle
+# the client's head carries a version like `0.6.0-alpha.9` for months,
+# and it is exactly then that we most want to know the server has not
+# broken it. Only the major/minor decide compatibility.
 main_version=$(extract_main_version 2>/dev/null || true)
 if [[ "$main_version" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
   main_major="${BASH_REMATCH[1]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,27 @@ jobs:
 
       - name: Run integration tests
         working-directory: client
+        env:
+          ZIZQ_LICENSE_KEY: ${{ secrets.ZIZQ_LICENSE_KEY }}
         run: |
-          ./integration/run.sh \
-            --binary ${{ github.workspace }}/server/zizq \
+          ARGS=(
+            --binary ${{ github.workspace }}/server/zizq
             --tarball ${{ github.workspace }}/artifact/zizq-*.tgz
+          )
+          # Harnesses predating 0.3.x reject unknown arguments rather
+          # than ignoring them, and predate this flag entirely. Probe
+          # the checkout for the parser arm rather than keeping a
+          # version table here — same idiom as the `zizq-derive`
+          # check in the Rust job.
+          if grep -q -- '--license-key)' integration/run.sh; then
+            if [[ -n "$ZIZQ_LICENSE_KEY" ]]; then
+              ARGS+=(--license-key "$ZIZQ_LICENSE_KEY")
+            fi
+          else
+            echo "note: this client's harness predates --license-key;" \
+                 "licensed tests will skip"
+          fi
+          ./integration/run.sh "${ARGS[@]}"
 
   discover-ruby:
     name: Discover Ruby Versions
@@ -259,10 +276,27 @@ jobs:
 
       - name: Run integration tests
         working-directory: client
+        env:
+          ZIZQ_LICENSE_KEY: ${{ secrets.ZIZQ_LICENSE_KEY }}
         run: |
-          ./integration/run.sh \
-            --binary ${{ github.workspace }}/server/zizq \
+          ARGS=(
+            --binary ${{ github.workspace }}/server/zizq
             --gem ${{ github.workspace }}/artifact/zizq-*.gem
+          )
+          # Harnesses predating 0.3.x reject unknown arguments rather
+          # than ignoring them, and predate this flag entirely. Probe
+          # the checkout for the parser arm rather than keeping a
+          # version table here — same idiom as the `zizq-derive`
+          # check in the Rust job.
+          if grep -q -- '--license-key)' integration/run.sh; then
+            if [[ -n "$ZIZQ_LICENSE_KEY" ]]; then
+              ARGS+=(--license-key "$ZIZQ_LICENSE_KEY")
+            fi
+          else
+            echo "note: this client's harness predates --license-key;" \
+                 "licensed tests will skip"
+          fi
+          ./integration/run.sh "${ARGS[@]}"
 
   discover-rust:
     name: Discover Rust Versions
@@ -358,6 +392,8 @@ jobs:
 
       - name: Run integration tests
         working-directory: client
+        env:
+          ZIZQ_LICENSE_KEY: ${{ secrets.ZIZQ_LICENSE_KEY }}
         run: |
           # Digit-anchored glob so the main-crate arg doesn't
           # accidentally expand to include the derive sibling.
@@ -374,6 +410,125 @@ jobs:
             DERIVE_CRATE=(${{ github.workspace }}/artifact/zizq-derive-*.crate)
             ARGS+=(--macro-crate "${DERIVE_CRATE[0]}")
           fi
+          # Harnesses predating 0.3.x reject unknown arguments rather
+          # than ignoring them, and predate this flag entirely. Probe
+          # the checkout for the parser arm rather than keeping a
+          # version table here — same idiom as the `zizq-derive`
+          # check in the Rust job.
+          if grep -q -- '--license-key)' integration/run.sh; then
+            if [[ -n "$ZIZQ_LICENSE_KEY" ]]; then
+              ARGS+=(--license-key "$ZIZQ_LICENSE_KEY")
+            fi
+          else
+            echo "note: this client's harness predates --license-key;" \
+                 "licensed tests will skip"
+          fi
+          ./integration/run.sh "${ARGS[@]}"
+
+  discover-elixir:
+    name: Discover Elixir Versions
+    needs: release-binary
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Discover compatible client versions
+        id: discover
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          matrix=$(./.github/scripts/discover-client-versions.sh \
+            elixir "${{ needs.release-binary.outputs.version }}")
+          echo "Discovered matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  integration-elixir:
+    name: Integration (Elixir, ${{ matrix.label }})
+    needs: [release-binary, discover-elixir]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover-elixir.outputs.matrix) }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: zizq-binary-v${{ needs.release-binary.outputs.version }}
+          path: server
+      - name: Unpack server binary
+        run: tar -xzf server/zizq-${{ needs.release-binary.outputs.version }}-linux-x86_64.tar.gz -C server
+
+      - name: Checkout Elixir client @ ${{ matrix.ref }}
+        uses: actions/checkout@v7
+        with:
+          repository: zizq-labs/zizq-elixir
+          ref: ${{ matrix.ref }}
+          path: client
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+
+      # Pinned to the client's declared floor (`elixir: "~> 1.18"` in
+      # its mix.exs), so every tag this matrix can select compiles by
+      # construction. Bump when the client raises its floor — a
+      # floating toolchain would let an unrelated Elixir or OTP
+      # release muddy the signal this job exists to give.
+      - name: Set up BEAM
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18"
+          otp-version: "27"
+
+      - name: Prepare artifact directory
+        run: mkdir -p artifact
+
+      - name: Download release tarball (tagged version)
+        if: matrix.tarball != ''
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          gh release download "${{ matrix.ref }}" \
+            --repo zizq-labs/zizq-elixir \
+            --pattern "${{ matrix.tarball }}" \
+            --dir artifact
+
+      - name: Build client from source (main)
+        if: matrix.tarball == ''
+        working-directory: client
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+          ./release.sh
+          cp _build/release/zizq-*.tar ../artifact/
+
+      # The harness is a separate Mix project built against the
+      # packaged tarball, so it tests what would be published rather
+      # than the checkout.
+      - name: Run integration tests
+        working-directory: client
+        env:
+          ZIZQ_LICENSE_KEY: ${{ secrets.ZIZQ_LICENSE_KEY }}
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          ARGS=(
+            --binary ${{ github.workspace }}/server/zizq
+            --tarball ${{ github.workspace }}/artifact/zizq-*.tar
+          )
+          # Harnesses predating 0.3.x reject unknown arguments rather
+          # than ignoring them, and predate this flag entirely. Probe
+          # the checkout for the parser arm rather than keeping a
+          # version table here — same idiom as the `zizq-derive`
+          # check in the Rust job.
+          if grep -q -- '--license-key)' integration/run.sh; then
+            if [[ -n "$ZIZQ_LICENSE_KEY" ]]; then
+              ARGS+=(--license-key "$ZIZQ_LICENSE_KEY")
+            fi
+          else
+            echo "note: this client's harness predates --license-key;" \
+                 "licensed tests will skip"
+          fi
           ./integration/run.sh "${ARGS[@]}"
 
   # --- Integration gate (stable check name for branch protection) ---
@@ -381,17 +536,19 @@ jobs:
   integration:
     name: Integration
     runs-on: ubuntu-latest
-    needs: [integration-node, integration-ruby, integration-rust]
+    needs: [integration-node, integration-ruby, integration-rust, integration-elixir]
     if: always()
     steps:
       - run: |
           if [ "${{ needs.integration-node.result }}" != "success" ] || \
              [ "${{ needs.integration-ruby.result }}" != "success" ] || \
-             [ "${{ needs.integration-rust.result }}" != "success" ]; then
+             [ "${{ needs.integration-rust.result }}" != "success" ] || \
+             [ "${{ needs.integration-elixir.result }}" != "success" ]; then
             echo "Integration tests failed or were skipped."
             echo "  Node: ${{ needs.integration-node.result }}"
             echo "  Ruby: ${{ needs.integration-ruby.result }}"
             echo "  Rust: ${{ needs.integration-rust.result }}"
+            echo "  Elixir: ${{ needs.integration-elixir.result }}"
             exit 1
           fi
           echo "All integration tests passed."

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ By default `zizq top` connects to `127.0.0.1:8901`. Specify `--url` to connect
 to a different host.
 
 Scroll up and down the list to visualise the backlog. The current position in
-the list is presented in the overall queue depth in real time. You can wiew the
+the list is presented in the overall queue depth in real time. You can view the
 jobs that are currently in-flight, ready and scheduled for a later time.
 
 <p align="center">

--- a/docs/getting-started/src/introduction.md
+++ b/docs/getting-started/src/introduction.md
@@ -259,8 +259,9 @@ architectures.
 
 ### Client libraries
 
-Zizq provides [client libraries](/docs/clients) (starting with
-[Ruby](/docs/clients/ruby/) and [Node.js](/docs/clients/node/)) to simplify
+Zizq provides [client libraries](/docs/clients) for
+[Ruby](/docs/clients/ruby/), [Node.js](/docs/clients/node/),
+[Elixir](/docs/clients/elixir/) and [Rust](/docs/clients/rust/) to simplify
 integration.
 
 More clients for other languages will be added over time and based on demand,


### PR DESCRIPTION
Since we've shipped a stable elixir client, we need to include it in the integration test matrix to make sure we don't break anything it assumes. Also updates mdBook docs.