### PR TITLE
Allow Specifying a `timezone` on a Whole Cron Group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.7.0 (Unreleased)
+
+- Added a **group-level cron timezone**. `PUT /crons/{group}` and
+  `PATCH /crons/{group}` now accept a `timezone` field alongside
+  `paused`, and it is returned on every cron group response. Entries
+  that do not name a timezone of their own are evaluated in the
+  group's; entries that do are unaffected. Without either, entries
+  continue to run in the server's local timezone, so existing
+  schedules are unchanged. Previously a client wanting one timezone
+  for a whole schedule had to copy it onto every entry, which did not
+  survive a read-back as a group-level fact.
+
+  `PATCH /crons/{group}` follows JSON merge patch semantics for this:
+  an absent field is left alone, and `"timezone": null` clears the
+  group's timezone. `paused` is now optional there for the same
+  reason — a patch may change only the timezone. Because
+  `PUT /crons/{group}` replaces a group in full, omitting `timezone`
+  on a `PUT` clears it.
+
+  Changing a group's timezone reschedules every entry that inherits
+  it, rather than leaving the old firing times in place until each
+  entry next fires.
+
+- Fixed cron entries keeping a stale `next_enqueue_at` when only their
+  `timezone` changed. `PUT /crons/{group}` and
+  `PUT /crons/{group}/entries/{entry}` preserve scheduling state when
+  an entry is unchanged, but compared expressions alone — so moving an
+  entry between timezones left it firing at the old wall-clock time
+  until its next occurrence passed. The comparison now covers the
+  effective timezone as well.
+
 ## 0.6.1
 
 - Fixed a units error in the retry backoff formula where the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ License text copyright (c) 2024 MariaDB plc, All Rights Reserved.
 Parameters
 
 Licensor:             Chris Corbyn <chris@zizq.io>
-Licensed Work:        Zizq 0.6.1
+Licensed Work:        Zizq 0.7.0
                       The Licensed Work is (c) 2026 Chris Corbyn
 Additional Use Grant: You may use the Licensed Work for non-commercial and
                       personal purposes. You may freely use short portions
@@ -12,7 +12,7 @@ Additional Use Grant: You may use the Licensed Work for non-commercial and
                       you give credit to the Licensor alongside such usages
                       within your project
 
-Change Date:          2030-08-05
+Change Date:          2030-08-18
 
 Change License:       Apache License, Version 2.0
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.1/zizq-0.6.1-linux-x86_64.tar.gz
-tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.0/zizq-0.7.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -59,7 +59,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.6.1
+Zizq 0.7.0
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/api/src/cron-group-entry-response.md
+++ b/docs/api/src/cron-group-entry-response.md
@@ -36,8 +36,9 @@
             <td>
                 Optional IANA timezone identifier in which the cron expression
                 should be evaluated. When not specified, the expression is
-                evaluated in the system timezone where the Zizq server is
-                running.
+                evaluated in the group's <code>timezone</code>, or in the system
+                timezone where the Zizq server is running when the group does not
+                specify one either.
             </td>
         </tr>
         <tr>

--- a/docs/api/src/cron-group-response.md
+++ b/docs/api/src/cron-group-response.md
@@ -30,6 +30,19 @@
         </tr>
         <tr>
             <td>
+                <div><code>timezone</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                IANA timezone identifier applied to every entry in the group
+                that does not specify one of its own. Absent when the group
+                does not specify one, in which case those entries are
+                evaluated in the system timezone where the Zizq server is
+                running.
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <div><code>paused_at</code></div>
                 <div><pre>int64</pre></div>
             </td>
@@ -89,8 +102,9 @@
             <td>
                 Optional IANA timezone identifier in which the cron expression
                 should be evaluated. When not specified, the expression is
-                evaluated in the system timezone where the Zizq server is
-                running.
+                evaluated in the group's <code>timezone</code>, or in the system
+                timezone where the Zizq server is running when the group does not
+                specify one either.
             </td>
         </tr>
         <tr>

--- a/docs/api/src/cron.md
+++ b/docs/api/src/cron.md
@@ -149,6 +149,20 @@ schedule data unconditionally and Zizq is smart enough to handle it safely.
         </tr>
         <tr>
             <td>
+                <div><code>timezone</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Optional IANA timezone identifier applied to every entry in
+                the group that does not specify one of its own. When not
+                specified, those entries are evaluated in the system timezone
+                where the Zizq server is running. Because this endpoint
+                replaces the group in full, omitting this field clears any
+                timezone the group previously had.
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <div><code>entries</code> <em>required</em></div>
                 <div><pre>array</pre></div>
             </td>
@@ -186,8 +200,9 @@ schedule data unconditionally and Zizq is smart enough to handle it safely.
             <td>
                 Optional IANA timezone identifier in which the cron expression
                 should be evaluated. When not specified, the expression is
-                evaluated in the system timezone where the Zizq server is
-                running.
+                evaluated in the group's <code>timezone</code>, or in the system
+                timezone where the Zizq server is running when the group does not
+                specify one either.
             </td>
         </tr>
         <tr>
@@ -431,7 +446,11 @@ Returned when the server is not configured with a pro license.
 
 ## `PATCH /crons/{group}` { #patch-crons-group }
 
-Update an existing cron group. Currently only used to pause/resume the group.
+Update an existing cron group, to pause/resume it or to change the timezone
+its entries default to.
+
+Fields that are omitted are left unchanged. A field explicitly set to `null`
+is cleared.
 
 ### Parameters { #patch-crons-group-parameters }
 
@@ -466,6 +485,20 @@ Update an existing cron group. Currently only used to pause/resume the group.
                 the <code>resumed_at</code> timestamp on the group and
                 re-commences enqueueing jobs for all unpaused entries in the
                 group.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>timezone</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                IANA timezone identifier applied to every entry in the group
+                that does not specify one of its own. Set it to
+                <code>null</code> to clear it, which returns those entries to
+                the system timezone where the Zizq server is running. Changing
+                it reschedules every entry that inherits it; entries that
+                specify their own timezone are unaffected.
             </td>
         </tr>
     </tbody>
@@ -696,8 +729,9 @@ within it. This operation is atomic and idempotent when given the same entry.
             <td>
                 Optional IANA timezone identifier in which the cron expression
                 should be evaluated. When not specified, the expression is
-                evaluated in the system timezone where the Zizq server is
-                running.
+                evaluated in the group's <code>timezone</code>, or in the system
+                timezone where the Zizq server is running when the group does not
+                specify one either.
             </td>
         </tr>
         <tr>

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.1/zizq-0.6.1-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.0/zizq-0.7.0-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -17,7 +17,7 @@ does almost all of the work.
 > Download:
 >
 > ```bash
-> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.6.1/zizq-0.6.1-linux-x86_64.tar.gz
+> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.0/zizq-0.7.0-linux-x86_64.tar.gz
 > ```
 
 ### 2. Extract it.
@@ -25,7 +25,7 @@ does almost all of the work.
 > Extract:
 >
 > ```bash
-> tar -xvzf zizq-0.6.1-linux-x86_64.tar.gz
+> tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
 > ```
 
 ### 3. Run it to start the server.
@@ -35,7 +35,7 @@ does almost all of the work.
 > ```bash
 > ./zizq serve
 > 
-> Zizq 0.6.1
+> Zizq 0.7.0
 > 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 > 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 > 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -37,9 +37,9 @@ use super::types::{
     CronGroupResponse, DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse,
     FailureRequest, HealthResponse, Job, JobStatus, ListCronGroupsResponse, ListErrorsPages,
     ListErrorsParams, ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse,
-    ListQueuesResponse, Order, PatchCronGroupRequest, PatchJobBody, PatchJobsParams, RangeQuery,
-    ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse, VersionResponse,
-    parse_unique_while,
+    ListQueuesResponse, Order, PatchCronEntryRequest, PatchCronGroupRequest, PatchJobBody,
+    PatchJobsParams, RangeQuery, ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse,
+    VersionResponse, parse_unique_while,
 };
 
 /// Default priority for jobs that don't specify one.
@@ -2486,6 +2486,7 @@ async fn replace_cron_group(
 
     let opts = store::ReplaceCronGroupOptions {
         paused: req.paused,
+        timezone: req.timezone,
         entries: entry_opts,
     };
 
@@ -2600,7 +2601,7 @@ async fn patch_cron_entry(
     AcceptFormat(fmt): AcceptFormat,
     State(state): State<Arc<AppState>>,
     Path((name, entry)): Path<(String, String)>,
-    NegotiatedBody(req): NegotiatedBody<PatchCronGroupRequest>,
+    NegotiatedBody(req): NegotiatedBody<PatchCronEntryRequest>,
 ) -> Response {
     let now_ms = (state.clock)();
     if let Err(e) = state
@@ -2676,7 +2677,8 @@ async fn delete_cron_entry(
     }
 }
 
-/// Handle `PATCH /crons/{name}` — update group-level fields (pause/unpause).
+/// Handle `PATCH /crons/{name}` — update group-level fields (pause state
+/// and default timezone).
 async fn patch_cron_group(
     AcceptFormat(fmt): AcceptFormat,
     State(state): State<Arc<AppState>>,
@@ -2693,11 +2695,12 @@ async fn patch_cron_group(
         return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
     }
 
-    match state
-        .store
-        .patch_cron_group(&name, req.paused, now_ms)
-        .await
-    {
+    let opts = store::PatchCronGroupOptions {
+        paused: req.paused,
+        timezone: req.timezone,
+    };
+
+    match state.store.patch_cron_group(&name, opts, now_ms).await {
         Ok(Some(group)) => {
             // Re-fetch the full group with entries for the response.
             match state.store.get_cron_group(&name).await {
@@ -2732,6 +2735,9 @@ async fn patch_cron_group(
                 error: format!("cron group '{name}' not found"),
             },
         ),
+        Err(StoreError::InvalidOperation(msg)) => {
+            respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error: msg })
+        }
         Err(e) => {
             tracing::error!(%e, "patch_cron_group failed");
             respond(
@@ -8194,6 +8200,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cron_put_accepts_group_level_timezone() {
+        let app = pro_app();
+
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "timezone": "Australia/Melbourne",
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["timezone"], "Australia/Melbourne");
+        // The entry inherits it rather than carrying a copy.
+        assert!(body["entries"][0]["timezone"].is_null());
+
+        // It survives a read-back.
+        let req = json_request("GET", "/crons/default", &serde_json::json!({}));
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["timezone"], "Australia/Melbourne");
+    }
+
+    #[tokio::test]
+    async fn cron_put_omitting_group_timezone_clears_it() {
+        let app = pro_app();
+
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "timezone": "Australia/Melbourne",
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // A replace is a full replace.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(body["timezone"].is_null());
+    }
+
+    #[tokio::test]
+    async fn cron_put_rejects_invalid_group_timezone() {
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "timezone": "Not/Real",
+                "entries": []
+            }),
+        );
+        let res = pro_app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn cron_put_rejects_invalid_timezone() {
         let req = cron_put(
             "default",
@@ -8404,6 +8489,120 @@ mod tests {
         let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
         assert_eq!(body["paused"], false);
         assert!(body["resumed_at"].is_number());
+    }
+
+    #[tokio::test]
+    async fn cron_patch_sets_group_timezone() {
+        let app = pro_app();
+
+        // Both timezones are named explicitly so the test does not depend on
+        // the local timezone of the machine running it.
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "paused": true,
+                "timezone": "UTC",
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        let before = body["entries"][0]["next_enqueue_at"].as_u64().unwrap();
+
+        let req = cron_patch(
+            "default",
+            &serde_json::json!({ "timezone": "Australia/Melbourne" }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["timezone"], "Australia/Melbourne");
+        // An absent `paused` leaves the pause state alone.
+        assert_eq!(body["paused"], true);
+        // The entry inherits the group's timezone, so it was rescheduled.
+        let after = body["entries"][0]["next_enqueue_at"].as_u64().unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[tokio::test]
+    async fn cron_patch_clears_group_timezone_with_null() {
+        let app = pro_app();
+
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "timezone": "Australia/Melbourne",
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let req = cron_patch("default", &serde_json::json!({ "timezone": null }));
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert!(body["timezone"].is_null());
+    }
+
+    #[tokio::test]
+    async fn cron_patch_preserves_group_timezone_when_absent() {
+        let app = pro_app();
+
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "timezone": "Australia/Melbourne",
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let req = cron_patch("default", &serde_json::json!({ "paused": true }));
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["paused"], true);
+        assert_eq!(body["timezone"], "Australia/Melbourne");
+    }
+
+    #[tokio::test]
+    async fn cron_patch_rejects_invalid_group_timezone() {
+        let app = pro_app();
+
+        let req = cron_put(
+            "default",
+            &serde_json::json!({
+                "entries": [{
+                    "name": "e1",
+                    "expression": "0 9 * * *",
+                    "job": { "type": "t", "queue": "q", "payload": {} }
+                }]
+            }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let req = cron_patch("default", &serde_json::json!({ "timezone": "Not/Real" }));
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -1078,9 +1078,28 @@ pub struct ListCronGroupsResponse {
 }
 
 /// Request shape for `PATCH /crons/{name}`.
+///
+/// Absent fields are left unchanged. A `null` timezone clears the group's
+/// default, falling its un-scoped entries back to the server's local
+/// timezone.
 #[derive(Deserialize)]
 pub struct PatchCronGroupRequest {
     /// Whether the group should be paused.
+    #[serde(default)]
+    pub paused: Option<bool>,
+
+    /// Default IANA timezone name for entries that do not name one.
+    #[serde(default, deserialize_with = "deserialize_nullable")]
+    pub timezone: Option<Option<String>>,
+}
+
+/// Request shape for `PATCH /crons/{name}/entries/{entry}`.
+///
+/// Separate from `PatchCronGroupRequest` because only a group carries a
+/// timezone — an entry's is set by writing the entry itself.
+#[derive(Deserialize)]
+pub struct PatchCronEntryRequest {
+    /// Whether the entry should be paused.
     pub paused: bool,
 }
 
@@ -1090,6 +1109,11 @@ pub struct ReplaceCronGroupRequest {
     /// Whether the group should be paused. Omitted means preserve existing
     /// state (or default to `false` for new groups).
     pub paused: Option<bool>,
+
+    /// Default IANA timezone name (e.g. `Australia/Melbourne`) for entries
+    /// that do not name one of their own. Because this is a full replace,
+    /// omitting it clears any timezone the group already had.
+    pub timezone: Option<String>,
 
     pub entries: Vec<CronEntryRequest>,
 }
@@ -1103,8 +1127,9 @@ pub struct CronEntryRequest {
     /// Cron expression (e.g. `*/15 * * * *`).
     pub expression: String,
 
-    /// IANA timezone name (e.g. `Australia/Melbourne`). When omitted,
-    /// the server's local timezone is used.
+    /// IANA timezone name (e.g. `Australia/Melbourne`). When omitted, the
+    /// group's timezone is used, or the server's local timezone when the
+    /// group does not name one either.
     pub timezone: Option<String>,
 
     /// Whether this entry should be paused. Omitted means preserve
@@ -1125,6 +1150,10 @@ pub struct CronGroupResponse {
 
     /// Whether the group is paused.
     pub paused: bool,
+
+    /// Default IANA timezone name for entries that do not name one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
 
     /// When the group was last paused (ms since epoch).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1147,6 +1176,7 @@ impl CronGroupResponse {
         Self {
             name,
             paused: group.paused,
+            timezone: group.timezone,
             paused_at: group.paused_at,
             resumed_at: group.resumed_at,
             entries: entries
@@ -1166,7 +1196,8 @@ pub struct CronEntryResponse {
     /// Cron expression.
     pub expression: String,
 
-    /// IANA timezone name. `None` means system local timezone.
+    /// IANA timezone name. `None` means the group's timezone, or the
+    /// system local timezone when the group does not name one either.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
 

--- a/src/commands/serve/cron_scheduler.rs
+++ b/src/commands/serve/cron_scheduler.rs
@@ -254,6 +254,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry("e1", "* * * * *")],
                 },
                 t,
@@ -306,6 +307,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry("e1", "* * * * *")],
                 },
                 t,
@@ -349,6 +351,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry("e1", "* * * * *")],
                 },
                 t,
@@ -408,6 +411,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry("e1", "* * * * *")],
                 },
                 t,

--- a/src/store/cron/mod.rs
+++ b/src/store/cron/mod.rs
@@ -24,6 +24,14 @@ pub struct CronGroup {
     #[serde(default)]
     pub paused: bool,
 
+    /// Default IANA timezone name (e.g. `Australia/Melbourne`) for entries
+    /// in this group that do not name one of their own. When `None`, such
+    /// entries fall back to the system's local timezone.
+    #[serde(rename = "Z")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+
     /// When the group was last paused (ms since epoch).
     #[serde(rename = "p")]
     #[serde(default)]
@@ -51,7 +59,8 @@ pub struct CronEntry {
     pub expression: String,
 
     /// IANA timezone name (e.g. `Australia/Melbourne`). When `None`, the
-    /// system's local timezone is used.
+    /// group's timezone is used, falling back to the system's local
+    /// timezone when the group does not name one either.
     #[serde(rename = "Z")]
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/store/cron/ops.rs
+++ b/src/store/cron/ops.rs
@@ -17,7 +17,7 @@ use super::super::enqueue::{
     apply_enqueue, finalize_enqueue, prepare_enqueue, validate_batch_config,
 };
 use super::super::keys::RecordKind;
-use super::super::options::{CronEntryOptions, ReplaceCronGroupOptions};
+use super::super::options::{CronEntryOptions, PatchCronGroupOptions, ReplaceCronGroupOptions};
 use super::super::store::{Store, StoreEvent};
 use super::super::types::StoreError;
 use super::{CronEntry, CronGroup};
@@ -42,18 +42,26 @@ impl Store {
         let event_tx = self.event_tx.clone();
         let group = group.to_string();
         let group_paused = opts.paused;
+        let group_timezone = opts.timezone;
         let entries = opts.entries;
 
         task::spawn_blocking(move || -> Result<(CronGroup, Vec<CronEntry>), StoreError> {
             let group_key = make_cron_group_key(&group);
             let prefix = make_cron_group_prefix(&group);
 
+            // Validate the group timezone even when no entry inherits it —
+            // otherwise it would be stored unchecked and only fail later.
+            validate_timezone(group_timezone.as_deref())?;
+
             // Validate all cron expressions and batch configs before
-            // acquiring the write lock.
+            // acquiring the write lock. The group timezone comes from the
+            // request, so no read is needed to resolve each entry's
+            // effective timezone.
             let mut computed_next: Vec<Option<u64>> = Vec::with_capacity(entries.len());
             for input in &entries {
                 // Validates the expression; None means no future occurrences.
-                let next = cron_next_after(&input.expression, now, input.timezone.as_deref())?;
+                let tz = input.timezone.as_deref().or(group_timezone.as_deref());
+                let next = cron_next_after(&input.expression, now, tz)?;
                 computed_next.push(next);
 
                 if let Some(ref cfg) = input.job.batch {
@@ -65,10 +73,19 @@ impl Store {
             // are consistent — no other writer can modify data.
             let mut tx = ks.write_tx();
 
-            // Load or create group metadata, applying pause state if requested.
+            // Load or create group metadata, applying pause state if
+            // requested. The timezone is applied unconditionally — this is a
+            // full replace, so an absent timezone clears any existing one.
+            let mut old_group_timezone: Option<String> = None;
+
             let existing_group: CronGroup = match ks.data.get(&group_key)? {
                 Some(bytes) => {
                     let mut g: CronGroup = rmp_serde::from_slice(&bytes)?;
+                    old_group_timezone = g.timezone.clone();
+
+                    let mut dirty = g.timezone != group_timezone;
+                    g.timezone = group_timezone.clone();
+
                     if let Some(paused) = group_paused {
                         if paused != g.paused {
                             match (g.paused, paused) {
@@ -78,6 +95,10 @@ impl Store {
                             }
                             g.paused = paused;
                         }
+                        dirty = true;
+                    }
+
+                    if dirty {
                         tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&g)?);
                     }
                     g
@@ -90,6 +111,7 @@ impl Store {
                         } else {
                             None
                         },
+                        timezone: group_timezone.clone(),
                         ..CronGroup::default()
                     };
                     tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&g)?);
@@ -123,7 +145,14 @@ impl Store {
                 .zip(computed_next)
                 .map(|(input, computed)| {
                     let existing = existing_entries.get(&input.name);
-                    merge_cron_entry(input, existing, computed, now)
+                    merge_cron_entry(
+                        input,
+                        existing,
+                        computed,
+                        now,
+                        old_group_timezone.as_deref(),
+                        group_timezone.as_deref(),
+                    )
                 })
                 .collect();
 
@@ -279,9 +308,10 @@ impl Store {
         let group = group.to_string();
 
         task::spawn_blocking(move || -> Result<CronEntry, StoreError> {
-            // Validate the cron expression before acquiring the write lock.
-            let next_enqueue_at = cron_next_after(&opts.expression, now, opts.timezone.as_deref())?;
-
+            // Validate the batch config before acquiring the write lock. The
+            // expression cannot be checked yet — resolving the entry's
+            // effective timezone needs the group, which must be read under
+            // the lock so a concurrent group patch cannot slip in between.
             if let Some(ref cfg) = opts.job.batch {
                 validate_batch_config(cfg, &opts.job.payload)?;
             }
@@ -292,10 +322,18 @@ impl Store {
             let mut tx = ks.write_tx();
 
             // Load or create group metadata.
-            if ks.data.get(&group_key)?.is_none() {
-                let group_meta = CronGroup::default();
-                tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
-            }
+            let group_meta: CronGroup = match ks.data.get(&group_key)? {
+                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                None => {
+                    let group_meta = CronGroup::default();
+                    tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
+                    group_meta
+                }
+            };
+
+            // Validates the expression; None means no future occurrences.
+            let tz = opts.timezone.as_deref().or(group_meta.timezone.as_deref());
+            let next_enqueue_at = cron_next_after(&opts.expression, now, tz)?;
 
             // Check for conflict.
             if ks.data.get(&entry_key)?.is_some() {
@@ -351,8 +389,6 @@ impl Store {
         let group = group.to_string();
 
         task::spawn_blocking(move || -> Result<CronEntry, StoreError> {
-            let next_enqueue_at = cron_next_after(&opts.expression, now, opts.timezone.as_deref())?;
-
             if let Some(ref cfg) = opts.job.batch {
                 validate_batch_config(cfg, &opts.job.payload)?;
             }
@@ -362,11 +398,20 @@ impl Store {
 
             let mut tx = ks.write_tx();
 
-            // Load or create group metadata.
-            if ks.data.get(&group_key)?.is_none() {
-                let group_meta = CronGroup::default();
-                tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
-            }
+            // Load or create group metadata. The group's timezone is needed
+            // to resolve the entry's effective timezone, so it is read under
+            // the write lock rather than before it.
+            let group_meta: CronGroup = match ks.data.get(&group_key)? {
+                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                None => {
+                    let group_meta = CronGroup::default();
+                    tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
+                    group_meta
+                }
+            };
+
+            let tz = opts.timezone.as_deref().or(group_meta.timezone.as_deref());
+            let next_enqueue_at = cron_next_after(&opts.expression, now, tz)?;
 
             // Load existing entry for smart merge.
             let old_entry: Option<CronEntry> = match ks.data.get(&entry_key)? {
@@ -374,7 +419,16 @@ impl Store {
                 None => None,
             };
 
-            let entry = merge_cron_entry(opts, old_entry.as_ref(), next_enqueue_at, now);
+            // The group timezone is unchanged by this call, so the entry's
+            // old and new effective timezones resolve against the same group.
+            let entry = merge_cron_entry(
+                opts,
+                old_entry.as_ref(),
+                next_enqueue_at,
+                now,
+                group_meta.timezone.as_deref(),
+                group_meta.timezone.as_deref(),
+            );
 
             tx.insert(&ks.data, &entry_key, &rmp_serde::to_vec_named(&entry)?);
 
@@ -492,21 +546,32 @@ impl Store {
         .await?
     }
 
-    /// Update group-level metadata (currently just pause state).
+    /// Update group-level metadata (pause state and default timezone).
+    ///
+    /// Follows JSON Merge Patch semantics — absent fields are left alone.
+    /// Changing the timezone recomputes `next_enqueue_at` for every entry
+    /// in the group that does not name a timezone of its own; entries that
+    /// do are unaffected.
     ///
     /// Returns the updated group, or `None` if the group does not exist.
     pub async fn patch_cron_group(
         &self,
         group: &str,
-        paused: bool,
+        opts: PatchCronGroupOptions,
         now: u64,
     ) -> Result<Option<CronGroup>, StoreError> {
         let ks = self.ks.clone();
+        let cron_index = self.cron_index.clone();
         let event_tx = self.event_tx.clone();
         let group = group.to_string();
 
         task::spawn_blocking(move || -> Result<Option<CronGroup>, StoreError> {
             let group_key = make_cron_group_key(&group);
+            let prefix = make_cron_group_prefix(&group);
+
+            if let Some(ref tz) = opts.timezone {
+                validate_timezone(tz.as_deref())?;
+            }
 
             let mut tx = ks.write_tx();
 
@@ -515,17 +580,95 @@ impl Store {
                 None => return Ok(None),
             };
 
-            if paused != group_meta.paused {
-                match (group_meta.paused, paused) {
-                    (false, true) => group_meta.paused_at = Some(now),
-                    (true, false) => group_meta.resumed_at = Some(now),
-                    _ => {}
+            let mut dirty = false;
+
+            if let Some(paused) = opts.paused {
+                if paused != group_meta.paused {
+                    match (group_meta.paused, paused) {
+                        (false, true) => group_meta.paused_at = Some(now),
+                        (true, false) => group_meta.resumed_at = Some(now),
+                        _ => {}
+                    }
+                    group_meta.paused = paused;
+                    dirty = true;
                 }
-                group_meta.paused = paused;
-                tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
-                ks.commit(tx, ks.default_commit_mode)?;
-                let _ = event_tx.send(StoreEvent::CronScheduleChanged);
             }
+
+            let timezone_changed = match opts.timezone {
+                Some(tz) if tz != group_meta.timezone => {
+                    group_meta.timezone = tz;
+                    dirty = true;
+                    true
+                }
+                _ => false,
+            };
+
+            if !dirty {
+                return Ok(Some(group_meta));
+            }
+
+            tx.insert(&ks.data, &group_key, &rmp_serde::to_vec_named(&group_meta)?);
+
+            // Reschedule entries that inherit the group's timezone. Their
+            // expressions are unchanged, but the wall-clock times those
+            // expressions denote have moved.
+            let mut rescheduled: Vec<(Option<u64>, Option<u64>, String)> = Vec::new();
+
+            if timezone_changed {
+                let mut range_end = prefix.clone();
+                *range_end.last_mut().unwrap() = 1; // \0 -> \1
+
+                let data: &fjall::Keyspace = ks.data.as_ref();
+                let entries: Vec<CronEntry> = data
+                    .range::<Vec<u8>, _>((
+                        Bound::Included(prefix.clone()),
+                        Bound::Excluded(range_end),
+                    ))
+                    .skip(1) // skip the group metadata key
+                    .map(|guard| {
+                        let (_, value) = guard.into_inner()?;
+                        let entry: CronEntry = rmp_serde::from_slice(&value)?;
+                        Ok(entry)
+                    })
+                    .collect::<Result<_, StoreError>>()?;
+
+                for mut entry in entries {
+                    // An entry naming its own timezone ignores the group's.
+                    if entry.timezone.is_some() {
+                        continue;
+                    }
+
+                    let next =
+                        cron_next_after(&entry.expression, now, group_meta.timezone.as_deref())?;
+                    if next == entry.next_enqueue_at {
+                        continue;
+                    }
+
+                    let old_next = entry.next_enqueue_at;
+                    entry.next_enqueue_at = next;
+
+                    tx.insert(
+                        &ks.data,
+                        &make_cron_entry_key(&group, &entry.name),
+                        &rmp_serde::to_vec_named(&entry)?,
+                    );
+                    rescheduled.push((old_next, next, entry.name));
+                }
+            }
+
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            // ---- outside tx: update in-memory cron index ----
+            for (old_next, next, name) in rescheduled {
+                if let Some(old) = old_next {
+                    cron_index.remove(old, &group, &name);
+                }
+                if let Some(next) = next {
+                    cron_index.insert(next, group.clone(), name);
+                }
+            }
+
+            let _ = event_tx.send(StoreEvent::CronScheduleChanged);
 
             Ok(Some(group_meta))
         })
@@ -723,18 +866,20 @@ impl Store {
                     _ => {}
                 }
 
-                // Check if group or entry is paused.
-                let group_paused = match ks.data.get(&group_key)? {
+                // Check if group or entry is paused, and pick up the group's
+                // timezone for entries that do not name one.
+                let (group_paused, group_timezone) = match ks.data.get(&group_key)? {
                     Some(bytes) => {
                         let g: CronGroup = rmp_serde::from_slice(&bytes)?;
-                        g.paused
+                        (g.paused, g.timezone)
                     }
-                    None => false,
+                    None => (false, None),
                 };
                 let is_paused = group_paused || entry.paused;
 
                 // Compute next occurrence (None if no future occurrences).
-                let next = cron_next_after(&entry.expression, now, entry.timezone.as_deref())?;
+                let tz = entry.timezone.as_deref().or(group_timezone.as_deref());
+                let next = cron_next_after(&entry.expression, now, tz)?;
 
                 // Prepare the job enqueue (unless paused).
                 let prepared = if !is_paused {
@@ -870,22 +1015,31 @@ fn make_cron_group_prefix(group: &str) -> Vec<u8> {
 
 /// Merge a `CronEntryOptions` with an optional existing `CronEntry`.
 ///
-/// When an existing entry is present and the expression hasn't changed,
-/// preserves `next_enqueue_at` and `last_enqueue_at`. When `paused` is
-/// omitted in the options, preserves the existing pause state. Tracks
-/// `paused_at` / `resumed_at` transitions.
+/// When an existing entry is present and neither the expression nor the
+/// effective timezone has changed, preserves `next_enqueue_at` and
+/// `last_enqueue_at`. When `paused` is omitted in the options, preserves
+/// the existing pause state. Tracks `paused_at` / `resumed_at` transitions.
 ///
 /// `computed_next` is the pre-computed next enqueue time from the new
-/// expression — used only when the expression has changed or the entry
-/// is new.
+/// expression and effective timezone — used only when either has changed,
+/// or the entry is new.
+///
+/// The effective timezone is the entry's own, falling back to the group's.
+/// The group's timezone is taken before and after the write because a
+/// replace can change it in the same operation.
 fn merge_cron_entry(
     opts: CronEntryOptions,
     existing: Option<&CronEntry>,
     computed_next: Option<u64>,
     now: u64,
+    old_group_timezone: Option<&str>,
+    new_group_timezone: Option<&str>,
 ) -> CronEntry {
     if let Some(old) = existing {
-        let (next, last) = if old.expression == opts.expression {
+        let old_timezone = old.timezone.as_deref().or(old_group_timezone);
+        let new_timezone = opts.timezone.as_deref().or(new_group_timezone);
+
+        let (next, last) = if old.expression == opts.expression && old_timezone == new_timezone {
             (old.next_enqueue_at, old.last_enqueue_at)
         } else {
             (computed_next, old.last_enqueue_at)
@@ -924,11 +1078,39 @@ fn merge_cron_entry(
     }
 }
 
+/// Parse an IANA timezone name, if one is given.
+///
+/// `None` in means `None` out — the caller treats that as the system's
+/// local timezone.
+fn parse_timezone(timezone: Option<&str>) -> Result<Option<chrono_tz::Tz>, StoreError> {
+    match timezone {
+        Some(name) => {
+            let tz: chrono_tz::Tz = name
+                .parse()
+                .map_err(|_| StoreError::InvalidOperation(format!("invalid timezone: {name:?}")))?;
+            Ok(Some(tz))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Reject an unparseable timezone name.
+///
+/// Used where a timezone is stored without any expression being evaluated
+/// against it — a group's timezone with no entries inheriting it would
+/// otherwise be accepted and only fail later.
+fn validate_timezone(timezone: Option<&str>) -> Result<(), StoreError> {
+    parse_timezone(timezone).map(|_| ())
+}
+
 /// Compute the next occurrence of a cron expression after `now_ms`.
 ///
 /// When `timezone` is `Some`, the expression is evaluated in that IANA
 /// timezone (e.g. "Australia/Melbourne"). When `None`, the system's
 /// local timezone is used.
+///
+/// Callers pass the entry's *effective* timezone — its own, or the
+/// group's when it does not name one.
 ///
 /// Returns `None` if the expression has no future occurrences.
 fn cron_next_after(
@@ -946,10 +1128,7 @@ fn cron_next_after(
     let dt = chrono::DateTime::from_timestamp(now_secs, 0)
         .ok_or_else(|| StoreError::InvalidOperation("invalid timestamp".to_string()))?;
 
-    if let Some(tz_name) = timezone {
-        let tz: chrono_tz::Tz = tz_name
-            .parse()
-            .map_err(|_| StoreError::InvalidOperation(format!("invalid timezone: {tz_name:?}")))?;
+    if let Some(tz) = parse_timezone(timezone)? {
         let dt_tz = dt.with_timezone(&tz);
         match cron.find_next_occurrence(&dt_tz, false) {
             Ok(next) => Ok(Some(next.timestamp() as u64 * 1000)),
@@ -967,7 +1146,8 @@ fn cron_next_after(
 #[cfg(test)]
 mod tests {
     use super::super::super::options::{
-        CronEntryOptions, EnqueueOptions, ListJobsOptions, ReplaceCronGroupOptions,
+        CronEntryOptions, EnqueueOptions, ListJobsOptions, PatchCronGroupOptions,
+        ReplaceCronGroupOptions,
     };
     use super::super::super::test_support::test_store;
     use crate::store::StoreError;
@@ -992,6 +1172,22 @@ mod tests {
         }
     }
 
+    /// A patch that only changes the group's pause state.
+    fn pause_group(paused: bool) -> PatchCronGroupOptions {
+        PatchCronGroupOptions {
+            paused: Some(paused),
+            timezone: None,
+        }
+    }
+
+    /// A patch that only changes the group's timezone.
+    fn set_group_timezone(timezone: Option<&str>) -> PatchCronGroupOptions {
+        PatchCronGroupOptions {
+            paused: None,
+            timezone: Some(timezone.map(str::to_string)),
+        }
+    }
+
     #[tokio::test]
     async fn replace_cron_group_creates_new_group() {
         let store = test_store();
@@ -1002,6 +1198,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("every-minute", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1029,6 +1226,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "*/5 * * * *", "q", "test")],
                 },
                 now,
@@ -1044,6 +1242,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "*/5 * * * *", "q", "test")],
                 },
                 now + 1000,
@@ -1064,6 +1263,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1079,6 +1279,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "0 0 * * *", "q", "test")],
                 },
                 now + 1000,
@@ -1099,6 +1300,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![
                         cron_entry_opts("e1", "* * * * *", "q", "test"),
                         cron_entry_opts("e2", "* * * * *", "q", "test"),
@@ -1115,6 +1317,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1140,6 +1343,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1153,6 +1357,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![],
                 },
                 now,
@@ -1181,6 +1386,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("bad", "not a cron expr", "q", "test")],
                 },
                 now,
@@ -1201,6 +1407,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![CronEntryOptions {
                         paused: Some(true),
                         ..cron_entry_opts("e1", "* * * * *", "q", "test")
@@ -1217,6 +1424,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now + 1000,
@@ -1237,6 +1445,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1250,6 +1459,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![CronEntryOptions {
                         paused: Some(true),
                         ..cron_entry_opts("e1", "* * * * *", "q", "test")
@@ -1274,6 +1484,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1304,6 +1515,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1348,6 +1560,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1381,6 +1594,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![CronEntryOptions {
                         paused: Some(true),
                         ..cron_entry_opts("e1", "* * * * *", "q", "test")
@@ -1437,6 +1651,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![
                         cron_entry_opts("e1", "* * * * *", "q", "test"),
                         cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
@@ -1470,6 +1685,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1492,6 +1708,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1541,6 +1758,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![utc_entry, melb_entry],
                 },
                 now,
@@ -1583,12 +1801,419 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![entry],
                 },
                 now,
             )
             .await;
         assert!(result.is_err());
+    }
+
+    /// "0 9 * * *" evaluated in UTC, from `CRON_NOW` — 2023-11-15 09:00 UTC.
+    const NEXT_9AM_UTC: u64 = 1_700_038_800_000;
+
+    /// The same expression in Australia/Melbourne (UTC+11 in November).
+    /// 9 AM local on the 15th is 22:00 UTC on the 14th, which `CRON_NOW`
+    /// has already passed, so the next occurrence is a day later.
+    const NEXT_9AM_MELBOURNE: u64 = 1_700_085_600_000;
+
+    #[tokio::test]
+    async fn replace_cron_group_applies_group_timezone_to_unscoped_entries() {
+        let store = test_store();
+
+        let (group, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Australia/Melbourne".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(group.timezone.as_deref(), Some("Australia/Melbourne"));
+        // The entry keeps no timezone of its own — it inherits.
+        assert_eq!(entries[0].timezone, None);
+        assert_eq!(entries[0].next_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_entry_timezone_wins_over_group() {
+        let store = test_store();
+
+        let entry = CronEntryOptions {
+            timezone: Some("UTC".to_string()),
+            ..cron_entry_opts("9am", "0 9 * * *", "q", "test")
+        };
+
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Australia/Melbourne".to_string()),
+                    entries: vec![entry],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(entries[0].next_enqueue_at, Some(NEXT_9AM_UTC));
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_reschedules_when_group_timezone_changes() {
+        let store = test_store();
+
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("UTC".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert_eq!(entries[0].next_enqueue_at, Some(NEXT_9AM_UTC));
+
+        // Same expression, different group timezone. The expression is
+        // unchanged but the wall-clock time it denotes has moved.
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Australia/Melbourne".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert_eq!(entries[0].next_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_reschedules_when_entry_timezone_changes() {
+        let store = test_store();
+
+        let utc = CronEntryOptions {
+            timezone: Some("UTC".to_string()),
+            ..cron_entry_opts("9am", "0 9 * * *", "q", "test")
+        };
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![utc],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert_eq!(entries[0].next_enqueue_at, Some(NEXT_9AM_UTC));
+
+        let melbourne = CronEntryOptions {
+            timezone: Some("Australia/Melbourne".to_string()),
+            ..cron_entry_opts("9am", "0 9 * * *", "q", "test")
+        };
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![melbourne],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert_eq!(entries[0].next_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_omitting_timezone_clears_it() {
+        let store = test_store();
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Australia/Melbourne".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        // A replace is a full replace — an absent timezone clears it rather
+        // than preserving what was there.
+        let (group, _) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(group.timezone, None);
+        let (group, _) = store.get_cron_group("default").await.unwrap().unwrap();
+        assert_eq!(group.timezone, None);
+    }
+
+    #[tokio::test]
+    async fn replace_cron_group_rejects_invalid_group_timezone() {
+        let store = test_store();
+
+        // No entries at all — nothing else would evaluate the timezone.
+        let result = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Not/A/Timezone".to_string()),
+                    entries: vec![],
+                },
+                CRON_NOW,
+            )
+            .await;
+
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+        assert!(store.get_cron_group("default").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn patch_cron_group_sets_timezone_and_reschedules() {
+        let store = test_store();
+
+        let scoped = CronEntryOptions {
+            timezone: Some("UTC".to_string()),
+            ..cron_entry_opts("scoped", "0 9 * * *", "q", "test")
+        };
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![
+                        cron_entry_opts("inherits", "0 9 * * *", "q", "test"),
+                        scoped,
+                    ],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        let group = store
+            .patch_cron_group(
+                "default",
+                set_group_timezone(Some("Australia/Melbourne")),
+                CRON_NOW,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(group.timezone.as_deref(), Some("Australia/Melbourne"));
+
+        let (_, entries) = store.get_cron_group("default").await.unwrap().unwrap();
+        let inherits = entries.iter().find(|e| e.name == "inherits").unwrap();
+        let scoped = entries.iter().find(|e| e.name == "scoped").unwrap();
+
+        assert_eq!(inherits.next_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+        // An entry naming its own timezone is untouched.
+        assert_eq!(scoped.next_enqueue_at, Some(NEXT_9AM_UTC));
+
+        // The in-memory schedule index moved with the rescheduled entry.
+        assert_eq!(store.cron_next_due_at(), Some(NEXT_9AM_UTC));
+        let due = store.next_due_cron_entries(NEXT_9AM_MELBOURNE);
+        assert!(
+            due.iter()
+                .any(|(ts, _, name)| *ts == NEXT_9AM_MELBOURNE && name == "inherits"),
+            "rescheduled entry should be indexed at its new time: {due:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_cron_group_clears_timezone_with_null() {
+        let store = test_store();
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("UTC".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        let group = store
+            .patch_cron_group("default", set_group_timezone(None), CRON_NOW)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(group.timezone, None);
+    }
+
+    #[tokio::test]
+    async fn patch_cron_group_leaves_absent_fields_alone() {
+        let store = test_store();
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: Some(true),
+                    timezone: Some("UTC".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        // Patching only the timezone leaves the pause state alone...
+        let group = store
+            .patch_cron_group(
+                "default",
+                set_group_timezone(Some("Australia/Melbourne")),
+                CRON_NOW,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(group.paused);
+
+        // ...and patching only the pause state leaves the timezone alone.
+        let group = store
+            .patch_cron_group("default", pause_group(false), CRON_NOW)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(group.timezone.as_deref(), Some("Australia/Melbourne"));
+    }
+
+    #[tokio::test]
+    async fn patch_cron_group_rejects_invalid_timezone() {
+        let store = test_store();
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        let result = store
+            .patch_cron_group(
+                "default",
+                set_group_timezone(Some("Not/A/Timezone")),
+                CRON_NOW,
+            )
+            .await;
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+
+        let (group, _) = store.get_cron_group("default").await.unwrap().unwrap();
+        assert_eq!(group.timezone, None);
+    }
+
+    #[tokio::test]
+    async fn add_and_put_cron_entry_inherit_group_timezone() {
+        let store = test_store();
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Australia/Melbourne".to_string()),
+                    entries: vec![],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        let added = store
+            .add_cron_entry(
+                "default",
+                cron_entry_opts("added", "0 9 * * *", "q", "test"),
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert_eq!(added.next_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+
+        let put = store
+            .put_cron_entry(
+                "default",
+                cron_entry_opts("put", "0 9 * * *", "q", "test"),
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+        assert_eq!(put.next_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+    }
+
+    #[tokio::test]
+    async fn promote_cron_entry_advances_in_group_timezone() {
+        let store = test_store();
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: Some("Australia/Melbourne".to_string()),
+                    entries: vec![cron_entry_opts("9am", "0 9 * * *", "q", "test")],
+                },
+                CRON_NOW,
+            )
+            .await
+            .unwrap();
+
+        // Promote at the moment it fires; the next occurrence is a day on,
+        // in Melbourne rather than the server's local time.
+        let entry = store
+            .promote_cron_entry("default", "9am", NEXT_9AM_MELBOURNE)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(entry.last_enqueue_at, Some(NEXT_9AM_MELBOURNE));
+        assert_eq!(
+            entry.next_enqueue_at,
+            Some(NEXT_9AM_MELBOURNE + 24 * 60 * 60 * 1000)
+        );
     }
 
     #[tokio::test]
@@ -1602,6 +2227,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("every-30s", "*/30 * * * * *", "q", "test")],
                 },
                 now,
@@ -1629,6 +2255,7 @@ mod tests {
                     name,
                     ReplaceCronGroupOptions {
                         paused: None,
+                        timezone: None,
                         entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                     },
                     now,
@@ -1654,6 +2281,7 @@ mod tests {
                     name,
                     ReplaceCronGroupOptions {
                         paused: None,
+                        timezone: None,
                         entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                     },
                     now,
@@ -1680,6 +2308,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![
                         cron_entry_opts("e1", "* * * * *", "q", "test"),
                         cron_entry_opts("e2", "* * * * *", "q", "test"),
@@ -1742,6 +2371,7 @@ mod tests {
                     name,
                     ReplaceCronGroupOptions {
                         paused: None,
+                        timezone: None,
                         entries: vec![
                             cron_entry_opts("e1", "* * * * *", "q", "test"),
                             cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
@@ -1773,6 +2403,7 @@ mod tests {
                     name,
                     ReplaceCronGroupOptions {
                         paused: None,
+                        timezone: None,
                         entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                     },
                     now,
@@ -1800,6 +2431,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![
                         cron_entry_opts("e1", "* * * * *", "q", "test"),
                         cron_entry_opts("e2", "*/5 * * * *", "q", "test"),
@@ -1833,6 +2465,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1842,7 +2475,7 @@ mod tests {
 
         // Pause.
         let group = store
-            .patch_cron_group("default", true, now + 1000)
+            .patch_cron_group("default", pause_group(true), now + 1000)
             .await
             .unwrap()
             .unwrap();
@@ -1852,7 +2485,7 @@ mod tests {
 
         // Unpause.
         let group = store
-            .patch_cron_group("default", false, now + 2000)
+            .patch_cron_group("default", pause_group(false), now + 2000)
             .await
             .unwrap()
             .unwrap();
@@ -1866,7 +2499,7 @@ mod tests {
         let store = test_store();
         assert!(
             store
-                .patch_cron_group("missing", true, CRON_NOW)
+                .patch_cron_group("missing", pause_group(true), CRON_NOW)
                 .await
                 .unwrap()
                 .is_none()
@@ -1883,6 +2516,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![
                         cron_entry_opts("e1", "* * * * *", "q", "test"),
                         cron_entry_opts("e2", "* * * * *", "q", "test"),
@@ -1931,6 +2565,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -1951,6 +2586,7 @@ mod tests {
                 "default",
                 ReplaceCronGroupOptions {
                     paused: None,
+                    timezone: None,
                     entries: vec![cron_entry_opts("e1", "* * * * *", "q", "test")],
                 },
                 now,
@@ -2060,6 +2696,7 @@ mod tests {
 
         let opts = ReplaceCronGroupOptions {
             paused: None,
+            timezone: None,
             entries: vec![cron_entry_with_batch("e1", serde_json::json!([1]), bad)],
         };
         let err = store

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -31,8 +31,8 @@ mod test_support;
 
 pub use options::{
     BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
-    JobFilter, ListErrorsOptions, ListJobsOptions, PatchJobOptions, ReplaceCronGroupOptions,
-    RetentionConfigPatch,
+    JobFilter, ListErrorsOptions, ListJobsOptions, PatchCronGroupOptions, PatchJobOptions,
+    ReplaceCronGroupOptions, RetentionConfigPatch,
 };
 
 pub use find::{FindDirection, FindOutcome, WindowAnchor, WindowFallback, WindowOutcome};

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -525,8 +525,25 @@ pub struct ReplaceCronGroupOptions {
     /// state (or default to `false` for new groups).
     pub paused: Option<bool>,
 
+    /// Default IANA timezone name for entries that do not name one of
+    /// their own. Because this is a full replace, `None` clears any
+    /// timezone the group already had.
+    pub timezone: Option<String>,
+
     /// The entries that should exist in the group after the replace.
     pub entries: Vec<CronEntryOptions>,
+}
+
+/// Options for `Store::patch_cron_group`.
+///
+/// Follows JSON Merge Patch semantics: `None` leaves a field alone.
+pub struct PatchCronGroupOptions {
+    /// Whether the group should be paused.
+    pub paused: Option<bool>,
+
+    /// The group's default timezone. `Some(None)` clears it, which falls
+    /// the group's un-scoped entries back to the server's local timezone.
+    pub timezone: Option<Option<String>>,
 }
 
 /// A single entry in a `replace_cron_group` request.
@@ -541,7 +558,8 @@ pub struct CronEntryOptions {
     pub expression: String,
 
     /// IANA timezone name (e.g. `Australia/Melbourne`). `None` means use
-    /// the system's local timezone.
+    /// the group's timezone, or the system's local timezone when the
+    /// group does not name one either.
     pub timezone: Option<String>,
 
     /// Whether this entry should be paused. `None` means preserve existing


### PR DESCRIPTION
Previously `timezone` was an attribute of each entry within a cron schedule (group). In the Ruby client we accept `timezone` on the cron builder and apply it to all entries. The natural shape here is for the server to handle defaulting the timezone on all entries, by holding its own definition on the group itself.