### PR TITLE
Implement Job Filtering by Budget Key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@
   and remain peristed indefinitely. Future releases will enable more
   dynamic sub-buckets within budgets.
 
+  Jobs can be filtered by budget with `?budgets.key=`, comma-delimited
+  like `queue` and `type`, on `GET /jobs`, `GET /jobs/count`,
+  `PATCH /jobs` and `DELETE /jobs`. It matches a job drawing on any of
+  the named budgets. This is what makes the refusal above actionable:
+  `DELETE /jobs?budgets.key=stripe` clears the jobs holding a budget
+  open so it can then be deleted. There is no index from budget to job,
+  so combined with a `status`, `queue`, `type` or `id` filter it narrows
+  within that scan, and on its own it is a full scan — the same cost
+  profile the existing payload filter carries.
+
   `POST /reset` now clears budgets along with jobs and cron groups.
 
   Token state is deliberately not persisted, so a server restart brings

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -1302,6 +1302,9 @@ async fn bulk_delete_jobs(
     if !params.job_type.is_empty() {
         opts.filter.types = params.job_type.0;
     }
+    if !params.budgets_key.is_empty() {
+        opts.filter.budget_keys = params.budgets_key.0;
+    }
     opts.filter.priority = params.priority.0;
     opts.filter.ready_at = params.ready_at.0;
     opts.filter.attempts = params.attempts.0;
@@ -1474,6 +1477,11 @@ async fn bulk_patch_jobs(
             } else {
                 params.job_type.0
             },
+            budget_keys: if params.budgets_key.is_empty() {
+                HashSet::new()
+            } else {
+                params.budgets_key.0
+            },
             priority: params.priority.0,
             ready_at: params.ready_at.0,
             attempts: params.attempts.0,
@@ -1555,6 +1563,9 @@ async fn list_jobs(
     }
     if !params.job_type.is_empty() {
         opts = opts.types(params.job_type.0.clone());
+    }
+    if !params.budgets_key.is_empty() {
+        opts = opts.budget_keys(params.budgets_key.0.clone());
     }
     if !params.id.is_empty() {
         for id in params.id.iter() {
@@ -1768,6 +1779,9 @@ async fn count_jobs(
     }
     if !params.job_type.is_empty() {
         opts = opts.types(params.job_type.0.clone());
+    }
+    if !params.budgets_key.is_empty() {
+        opts = opts.budget_keys(params.budgets_key.0.clone());
     }
     if !params.id.is_empty() {
         for id in params.id.iter() {
@@ -2453,6 +2467,10 @@ fn parse_budget_bindings(
     budgets
         .into_iter()
         .map(|entry| {
+            // Validated here as well as on the budget endpoints, because
+            // `create_with` makes this a creation path too.
+            validate_name("budget key", &entry.key)?;
+
             if entry.bucket.is_some() {
                 return Err(format!(
                     "budget '{}' sets bucket, which is reserved and not yet supported",
@@ -8567,6 +8585,163 @@ mod tests {
         let res = app.oneshot(req).await.unwrap();
         let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
         assert_eq!(body["jobs"][0]["budgets"][1]["key"], "mailgun");
+    }
+
+    /// `create_with` makes enqueue a budget *creation* path, so it needs
+    /// the same name validation the budget endpoints apply — otherwise a
+    /// key could be stored that `POST /budgets/{key}` would have
+    /// refused.
+    ///
+    /// A comma is the one that bites hardest: `?budgets.key=` is
+    /// comma-delimited, so a key containing one could never be filtered
+    /// for, and the job holding a budget open would be unfindable.
+    #[tokio::test]
+    async fn enqueue_rejects_a_budget_key_with_reserved_characters() {
+        for key in ["a,b", "a*b", "a?b", "a{b}"] {
+            let req = json_request(
+                "POST",
+                "/jobs",
+                &serde_json::json!({
+                    "type": "t",
+                    "queue": "q",
+                    "payload": {},
+                    "budgets": [{
+                        "key": key,
+                        "create_with": {
+                            "allocation": 10,
+                            "strategy": { "type": "while_in_flight" }
+                        }
+                    }],
+                }),
+            );
+            let res = pro_app().oneshot(req).await.unwrap();
+            assert_eq!(
+                res.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "expected {key:?} to be rejected"
+            );
+        }
+    }
+
+    /// Filtering jobs by budget is what makes the `409` from deleting a
+    /// busy budget actionable: without it an operator is told to remove
+    /// the jobs holding a budget open, with no way to find them.
+    ///
+    /// Covers all four endpoints that take a job filter, since a filter
+    /// that works on `GET /jobs` but silently does nothing on
+    /// `DELETE /jobs` is worse than one that does not exist.
+    #[tokio::test]
+    async fn jobs_can_be_filtered_by_budget() {
+        let app = pro_app();
+
+        for key in ["stripe", "mailgun"] {
+            let res = app
+                .clone()
+                .oneshot(budget_post(key, &while_in_flight(10)))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::CREATED);
+        }
+
+        // Two on `stripe`, one on `mailgun`, one unthrottled.
+        for budgets in [
+            serde_json::json!([{ "key": "stripe" }]),
+            serde_json::json!([{ "key": "stripe" }]),
+            serde_json::json!([{ "key": "mailgun" }]),
+            serde_json::json!([]),
+        ] {
+            let res = app
+                .clone()
+                .oneshot(json_request(
+                    "POST",
+                    "/jobs",
+                    &serde_json::json!({
+                        "type": "t",
+                        "queue": "q",
+                        "payload": {},
+                        "budgets": budgets,
+                    }),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::CREATED);
+        }
+
+        // GET /jobs
+        let req = empty_request("GET", "/jobs?budgets.key=stripe");
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["jobs"].as_array().unwrap().len(), 2);
+
+        // GET /jobs/count
+        let req = empty_request("GET", "/jobs/count?budgets.key=stripe");
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 2);
+
+        // Several keys at once, comma-delimited like every other filter.
+        let req = empty_request("GET", "/jobs/count?budgets.key=stripe,mailgun");
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 3);
+
+        // PATCH /jobs
+        let req = json_request(
+            "PATCH",
+            "/jobs?budgets.key=mailgun",
+            &serde_json::json!({ "priority": 5 }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["patched"], 1);
+
+        // DELETE /jobs — the remediation path the 409 points at.
+        let req = empty_request("DELETE", "/jobs?budgets.key=stripe");
+        let res = app.clone().oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["deleted"], 2);
+
+        // And with them gone, the budget deletes cleanly.
+        let req = json_request("DELETE", "/budgets/stripe", &serde_json::json!({}));
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    }
+
+    /// Combined with an index-backed filter it narrows within that scan
+    /// rather than replacing it, so the two intersect.
+    #[tokio::test]
+    async fn a_budget_filter_intersects_with_a_queue_filter() {
+        let app = pro_app();
+
+        let res = app
+            .clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        for queue in ["a", "b"] {
+            let res = app
+                .clone()
+                .oneshot(json_request(
+                    "POST",
+                    "/jobs",
+                    &serde_json::json!({
+                        "type": "t",
+                        "queue": queue,
+                        "payload": {},
+                        "budgets": [{ "key": "stripe" }],
+                    }),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::CREATED);
+        }
+
+        let req = empty_request("GET", "/jobs/count?budgets.key=stripe&queue=a");
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 1);
     }
 
     /// An unthrottled job pays nothing for the feature, on the wire as

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -831,6 +831,14 @@ pub struct ListJobsParams {
     #[serde(default)]
     pub attempts: RangeQuery<u32>,
 
+    /// Budget filter, comma-delimited (e.g. "stripe,mailgun").
+    ///
+    /// Matches a job drawing on any of the named budgets. Dotted to
+    /// mirror the `budgets` array on a job rather than inventing a
+    /// separate name for the same thing.
+    #[serde(default, rename = "budgets.key")]
+    pub budgets_key: CommaSet<String>,
+
     /// jq expression to filter jobs by payload (e.g. ".user_id == 42").
     pub filter: Option<String>,
 }
@@ -866,6 +874,14 @@ pub struct CountJobsParams {
     /// `attempts` range (inclusive). Same syntax as `priority`.
     #[serde(default)]
     pub attempts: RangeQuery<u32>,
+
+    /// Budget filter, comma-delimited (e.g. "stripe,mailgun").
+    ///
+    /// Matches a job drawing on any of the named budgets. Dotted to
+    /// mirror the `budgets` array on a job rather than inventing a
+    /// separate name for the same thing.
+    #[serde(default, rename = "budgets.key")]
+    pub budgets_key: CommaSet<String>,
 
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
@@ -903,6 +919,14 @@ pub struct DeleteJobsParams {
     #[serde(default)]
     pub attempts: RangeQuery<u32>,
 
+    /// Budget filter, comma-delimited (e.g. "stripe,mailgun").
+    ///
+    /// Matches a job drawing on any of the named budgets. Dotted to
+    /// mirror the `budgets` array on a job rather than inventing a
+    /// separate name for the same thing.
+    #[serde(default, rename = "budgets.key")]
+    pub budgets_key: CommaSet<String>,
+
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,
 }
@@ -938,6 +962,14 @@ pub struct PatchJobsParams {
     /// `attempts` range (inclusive). Same syntax as `priority`.
     #[serde(default)]
     pub attempts: RangeQuery<u32>,
+
+    /// Budget filter, comma-delimited (e.g. "stripe,mailgun").
+    ///
+    /// Matches a job drawing on any of the named budgets. Dotted to
+    /// mirror the `budgets` array on a job rather than inventing a
+    /// separate name for the same thing.
+    #[serde(default, rename = "budgets.key")]
+    pub budgets_key: CommaSet<String>,
 
     /// jq expression to filter jobs by payload.
     pub filter: Option<String>,

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -60,6 +60,19 @@ pub struct JobFilter {
     /// Applied as a post-hydration check on each candidate job.
     pub attempts: Option<RangeInclusive<u32>>,
 
+    /// Optional budget filter. When non-empty, only jobs drawing on one
+    /// of these budgets are returned.
+    ///
+    /// A job may draw on several budgets, so this matches if *any* of
+    /// its bindings names one of these keys — the same "belongs to"
+    /// reading the queue and type filters have.
+    ///
+    /// Applied as a post-hydration check, since there is no index from
+    /// budget key to job. Combined with an index-backed filter it
+    /// narrows within that scan; on its own it is a full scan, the same
+    /// cost profile the payload filter already carries.
+    pub budget_keys: HashSet<String>,
+
     /// Optional jq-style payload filter. When provided, only jobs whose
     /// payload matches the filter are returned. Payloads are hydrated and
     /// checked after the index scan narrows the candidate set.
@@ -96,6 +109,14 @@ impl JobFilter {
     /// Filter by job type and return `self`.
     pub fn types(mut self, types: HashSet<String>) -> Self {
         self.types = types;
+        self
+    }
+
+    /// Filter by budget membership and return `self`.
+    ///
+    /// Matches a job drawing on any of these budgets.
+    pub fn budget_keys(mut self, keys: HashSet<String>) -> Self {
+        self.budget_keys = keys;
         self
     }
 
@@ -210,6 +231,14 @@ impl ListJobsOptions {
     /// Filter by job type and return `self`.
     pub fn types(mut self, types: HashSet<String>) -> Self {
         self.filter.types = types;
+        self
+    }
+
+    /// Filter by budget membership and return `self`.
+    ///
+    /// Matches a job drawing on any of these budgets.
+    pub fn budget_keys(mut self, keys: HashSet<String>) -> Self {
+        self.filter.budget_keys = keys;
         self
     }
 

--- a/src/store/scan.rs
+++ b/src/store/scan.rs
@@ -717,6 +717,36 @@ impl<I: Iterator<Item = Result<Job, StoreError>>> Iterator for PayloadFilteredIt
     }
 }
 
+/// Wraps a job iterator and keeps only jobs drawing on one of the given
+/// budgets.
+///
+/// A job may name several budgets, so this matches on *any* of them —
+/// asking "does this job draw on `stripe`?" rather than "is `stripe` its
+/// only budget". Jobs with no bindings never match, which is what makes
+/// `?budgets.key=x` mean "throttled by x" rather than "not throttled by
+/// anything else".
+pub(super) struct BudgetFilteredIter<I> {
+    pub(super) inner: I,
+    pub(super) keys: HashSet<String>,
+}
+
+impl<I: Iterator<Item = Result<Job, StoreError>>> Iterator for BudgetFilteredIter<I> {
+    type Item = Result<Job, StoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let job = match self.inner.next()? {
+                Ok(j) => j,
+                Err(e) => return Some(Err(e)),
+            };
+
+            if job.budgets.iter().any(|b| self.keys.contains(&b.key)) {
+                return Some(Ok(job));
+            }
+        }
+    }
+}
+
 /// Build an `IdStream` from a `JobFilter`'s index-backed fields.
 ///
 /// Returns `None` when no index-backed filter is active (caller should use
@@ -808,6 +838,19 @@ pub(super) fn apply_filters<'a, R: Readable + 'a>(
             })
         } else {
             Box::new(inner)
+        };
+
+    // Before the payload filter, which is the expensive one: budget
+    // membership is a field comparison on an already-hydrated job,
+    // where a jq filter has to evaluate a program against a payload.
+    let stream: Box<dyn Iterator<Item = Result<Job, StoreError>> + 'a> =
+        if filter.budget_keys.is_empty() {
+            stream
+        } else {
+            Box::new(BudgetFilteredIter {
+                inner: stream,
+                keys: filter.budget_keys.clone(),
+            })
         };
 
     if let Some(payload_filter) = &filter.payload_filter {


### PR DESCRIPTION
It is now possible to pass `?budgets.key=a,b,c` when listing jobs, counting jobs, patching jobs and deleting them. Matches *any* of the named keys.