### PR TITLE
Deep Merge Budgets in `PATCH /budgets/{key}`.

### DIFF
--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -38,9 +38,9 @@ use super::types::{
     DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse, FailureRequest, HealthResponse,
     Job, JobStatus, ListBudgetsResponse, ListCronGroupsResponse, ListErrorsPages, ListErrorsParams,
     ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse, ListQueuesResponse, Order,
-    PatchBudgetRequest, PatchCronEntryRequest, PatchCronGroupRequest, PatchJobBody,
-    PatchJobsParams, RangeQuery, ReplaceCronGroupRequest, TakeParams, UnsupportedFormatResponse,
-    VersionResponse, parse_unique_while,
+    PatchBudgetRequest, PatchBudgetStrategyRequest, PatchCronEntryRequest, PatchCronGroupRequest,
+    PatchJobBody, PatchJobsParams, RangeQuery, ReplaceCronGroupRequest, TakeParams,
+    UnsupportedFormatResponse, VersionResponse, parse_unique_while,
 };
 
 /// Default priority for jobs that don't specify one.
@@ -2535,6 +2535,33 @@ fn parse_budget_strategy(req: BudgetStrategyRequest) -> Result<store::BudgetStra
     }
 }
 
+/// Convert a wire strategy patch into its store form.
+///
+/// Only the tag is checked here. Everything else — whether a period is
+/// required, whether a burst is meaningful — depends on the strategy the
+/// budget already has, so it is resolved by the merge inside the
+/// transaction rather than guessed at from the request alone.
+fn parse_budget_strategy_patch(
+    req: PatchBudgetStrategyRequest,
+) -> Result<store::BudgetStrategyPatch, String> {
+    let kind = match req.kind.as_deref() {
+        None => None,
+        Some("time_based") => Some(store::BudgetStrategyKind::TimeBased),
+        Some("while_in_flight") => Some(store::BudgetStrategyKind::WhileInFlight),
+        Some(other) => {
+            return Err(format!(
+                "unknown strategy type {other:?} (expected \"time_based\" or \"while_in_flight\")"
+            ));
+        }
+    };
+
+    Ok(store::BudgetStrategyPatch {
+        kind,
+        duration_ms: req.duration_ms,
+        burst: req.burst,
+    })
+}
+
 /// Reject a budget request the store would not accept, returning the
 /// validated key and strategy.
 fn validate_budget_request(key: &str, req: BudgetRequest) -> Result<store::BudgetStrategy, String> {
@@ -2764,8 +2791,8 @@ async fn patch_budget(
         return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
     }
 
-    let strategy = match req.strategy.map(parse_budget_strategy).transpose() {
-        Ok(strategy) => strategy,
+    let strategy = match req.strategy.map(parse_budget_strategy_patch).transpose() {
+        Ok(strategy) => strategy.unwrap_or_default(),
         Err(msg) => {
             return respond(
                 fmt,
@@ -8585,6 +8612,176 @@ mod tests {
         let res = app.oneshot(req).await.unwrap();
         let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
         assert_eq!(body["jobs"][0]["budgets"][1]["key"], "mailgun");
+    }
+
+    /// The strategy is a nested object, so merge patch recurses into
+    /// it: naming one field leaves the others alone. Requiring the kind
+    /// and period to be restated just to adjust a burst is what merge
+    /// patch exists to avoid.
+    #[tokio::test]
+    async fn patching_a_budget_strategy_merges_rather_than_replaces() {
+        let app = pro_app();
+
+        let res = app
+            .clone()
+            .oneshot(budget_post(
+                "stripe",
+                &serde_json::json!({
+                    "allocation": 100,
+                    "strategy": { "type": "time_based", "duration_ms": 60000 }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        // Burst alone, with no `type` and no `duration_ms`.
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "burst": 5 } }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["allocation"], 100);
+        assert_eq!(body["strategy"]["type"], "time_based");
+        assert_eq!(body["strategy"]["duration_ms"], 60000);
+        assert_eq!(body["strategy"]["burst"], 5);
+
+        // And the period alone, leaving the burst in place.
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "duration_ms": 30000 } }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["strategy"]["duration_ms"], 30000);
+        assert_eq!(body["strategy"]["burst"], 5);
+    }
+
+    /// `null` clears, which is what merge patch means by it — distinct
+    /// from an absent field, which leaves the value alone.
+    #[tokio::test]
+    async fn patching_a_null_burst_clears_it() {
+        let app = pro_app();
+
+        let res = app
+            .clone()
+            .oneshot(budget_post(
+                "stripe",
+                &serde_json::json!({
+                    "allocation": 100,
+                    "strategy": { "type": "time_based", "duration_ms": 60000, "burst": 5 }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "burst": null } }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        // Absent means the ceiling is the allocation again.
+        assert!(
+            body["strategy"].get("burst").is_none(),
+            "unexpected: {body}"
+        );
+    }
+
+    /// Switching to a strategy with no drip drops the period and burst
+    /// rather than carrying them across — they describe a drip, and a
+    /// strategy without one cannot hold them.
+    #[tokio::test]
+    async fn patching_to_while_in_flight_drops_the_drip_fields() {
+        let app = pro_app();
+
+        let res = app
+            .clone()
+            .oneshot(budget_post(
+                "stripe",
+                &serde_json::json!({
+                    "allocation": 100,
+                    "strategy": { "type": "time_based", "duration_ms": 60000, "burst": 5 }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "type": "while_in_flight" } }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["strategy"]["type"], "while_in_flight");
+        assert!(body["strategy"].get("duration_ms").is_none());
+        assert!(body["strategy"].get("burst").is_none());
+    }
+
+    /// Going the other way has nothing to inherit, so the period has to
+    /// be supplied — a rate limit with no period is not a rate limit.
+    #[tokio::test]
+    async fn patching_to_time_based_requires_a_duration() {
+        let app = pro_app();
+
+        let res = app
+            .clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "type": "time_based" } }),
+        );
+        let res = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        // With one, it converts.
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "type": "time_based", "duration_ms": 1000 } }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    /// A burst is meaningless without a drip, so setting one on a
+    /// concurrency budget is refused rather than stored and ignored.
+    #[tokio::test]
+    async fn patching_a_burst_onto_a_concurrency_budget_is_refused() {
+        let app = pro_app();
+
+        let res = app
+            .clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let req = json_request(
+            "PATCH",
+            "/budgets/stripe",
+            &serde_json::json!({ "strategy": { "burst": 5 } }),
+        );
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     /// `create_with` makes enqueue a budget *creation* path, so it needs

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -1265,9 +1265,35 @@ pub struct PatchBudgetRequest {
     /// Tokens the bucket holds when full.
     pub allocation: Option<u32>,
 
-    /// How tokens replenish. Replaced whole when given — a strategy is
-    /// only meaningful with the fields its kind implies.
-    pub strategy: Option<BudgetStrategyRequest>,
+    /// Changes to how tokens replenish, merged onto the stored strategy.
+    pub strategy: Option<PatchBudgetStrategyRequest>,
+}
+
+/// A merge patch over a budget's strategy.
+///
+/// Every field is optional, because merge patch recurses into nested
+/// objects: `{"strategy": {"burst": 5}}` sets the burst and leaves the
+/// kind and period alone, rather than requiring all three be restated.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatchBudgetStrategyRequest {
+    /// `"time_based"` or `"while_in_flight"`. Absent keeps the current
+    /// strategy.
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
+
+    /// Absent keeps the current period. Required only when switching a
+    /// budget to `time_based`, which has none to inherit.
+    pub duration_ms: Option<u64>,
+
+    /// Absent keeps the current ceiling; `null` clears it back to the
+    /// allocation.
+    ///
+    /// The one nullable field here, because it is the one that has a
+    /// meaningful "unset" — a strategy with no kind or a `time_based`
+    /// one with no period is not a strategy at all.
+    #[serde(default, deserialize_with = "deserialize_nullable")]
+    pub burst: Option<Option<u32>>,
 }
 
 /// Response shape for a single budget.

--- a/src/store/budget/ops.rs
+++ b/src/store/budget/ops.rs
@@ -163,9 +163,15 @@ impl Store {
             // Re-validated through `Budget::new`, since a patch can
             // reach a combination neither the stored policy nor the
             // patch alone would have been rejected for.
+            // Merged rather than replaced: the strategy is a nested
+            // object, and merge patch recurses into those. Applied here
+            // rather than in the API layer because it needs the stored
+            // policy, and reading that outside this transaction would
+            // leave a window for a concurrent write between the read and
+            // the merge.
             let mut budget = Budget::new(
                 opts.allocation.unwrap_or(existing.allocation),
-                opts.strategy.unwrap_or(existing.strategy),
+                opts.strategy.apply(existing.strategy)?,
                 now,
             )?;
             budget.created_at = existing.created_at;
@@ -767,7 +773,9 @@ pub(in crate::store) fn make_budget_key(key: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::options::PatchBudgetOptions;
+    use super::super::super::options::{
+        BudgetStrategyKind, BudgetStrategyPatch, PatchBudgetOptions,
+    };
     use super::super::super::test_support::{test_store, test_store_with_max_budgets};
     use super::super::BudgetStrategy;
     use crate::store::Store;
@@ -775,7 +783,24 @@ mod tests {
 
     const NOW: u64 = 1_700_000_000_000;
 
+    /// A patch that replaces the strategy wholesale, for the tests that
+    /// predate merge semantics and care about the end state rather than
+    /// which fields were named.
     fn patch(allocation: Option<u32>, strategy: Option<BudgetStrategy>) -> PatchBudgetOptions {
+        let strategy = match strategy {
+            None => BudgetStrategyPatch::default(),
+            Some(BudgetStrategy::TimeBased { duration_ms, burst }) => BudgetStrategyPatch {
+                kind: Some(BudgetStrategyKind::TimeBased),
+                duration_ms: Some(duration_ms),
+                burst: Some(burst),
+            },
+            Some(BudgetStrategy::WhileInFlight) => BudgetStrategyPatch {
+                kind: Some(BudgetStrategyKind::WhileInFlight),
+                duration_ms: None,
+                burst: None,
+            },
+        };
+
         PatchBudgetOptions {
             allocation,
             strategy,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -32,9 +32,10 @@ mod types;
 mod test_support;
 
 pub use options::{
-    BulkDeleteOptions, BulkPatchOptions, CronEntryOptions, EnqueueOptions, FailureOptions,
-    JobFilter, ListErrorsOptions, ListJobsOptions, PatchBudgetOptions, PatchCronGroupOptions,
-    PatchJobOptions, ReplaceCronGroupOptions, RetentionConfigPatch,
+    BudgetStrategyKind, BudgetStrategyPatch, BulkDeleteOptions, BulkPatchOptions, CronEntryOptions,
+    EnqueueOptions, FailureOptions, JobFilter, ListErrorsOptions, ListJobsOptions,
+    PatchBudgetOptions, PatchCronGroupOptions, PatchJobOptions, ReplaceCronGroupOptions,
+    RetentionConfigPatch,
 };
 
 pub use find::{FindDirection, FindOutcome, WindowAnchor, WindowFallback, WindowOutcome};

--- a/src/store/options.rs
+++ b/src/store/options.rs
@@ -16,7 +16,7 @@ use crate::filter::PayloadFilter;
 
 use super::budget::{BudgetBinding, BudgetStrategy};
 use super::types::{
-    BackoffConfig, BatchConfig, JobStatus, RetentionConfig, ScanDirection, UniqueWhile,
+    BackoffConfig, BatchConfig, JobStatus, RetentionConfig, ScanDirection, StoreError, UniqueWhile,
 };
 
 /// Predicate that selects which jobs an operation acts on.
@@ -593,17 +593,121 @@ pub struct PatchCronGroupOptions {
     pub timezone: Option<Option<String>>,
 }
 
+/// Which way a budget's tokens come back, without the fields that go
+/// with it.
+///
+/// Exists so a patch can say "make this a rate limit" without also
+/// having to restate the period, which the merge takes from whatever is
+/// already stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetStrategyKind {
+    TimeBased,
+    WhileInFlight,
+}
+
+/// A JSON merge patch over a budget's [`BudgetStrategy`].
+///
+/// Every field absent means "leave the strategy alone". A strategy is a
+/// nested object on the wire, and merge patch recurses into those — so
+/// `{"strategy": {"burst": 5}}` sets the burst and keeps the kind and
+/// period, rather than demanding all three be restated.
+///
+/// Applied inside the transaction that reads the existing policy, since
+/// merging needs it. Doing that in the API layer would mean a read
+/// followed by a write with no lock between them.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BudgetStrategyPatch {
+    /// Change which strategy this is. Absent keeps the current one.
+    pub kind: Option<BudgetStrategyKind>,
+
+    /// Change the refill period. Absent keeps the current one.
+    pub duration_ms: Option<u64>,
+
+    /// Change the bucket ceiling. Absent keeps the current one;
+    /// `Some(None)` clears it back to the allocation, which is what
+    /// merge patch means by an explicit `null`.
+    pub burst: Option<Option<u32>>,
+}
+
+impl BudgetStrategyPatch {
+    /// Whether this patch asks for any change at all.
+    pub fn is_empty(&self) -> bool {
+        self.kind.is_none() && self.duration_ms.is_none() && self.burst.is_none()
+    }
+
+    /// Merge onto the stored strategy.
+    ///
+    /// The kind decides which other fields are meaningful, so it is
+    /// resolved first and the rest are read against *that* rather than
+    /// against whatever the budget used to be.
+    ///
+    /// Switching to `while_in_flight` drops the period and burst rather
+    /// than carrying them across. Merge patch keeps absent fields, but
+    /// those two describe a drip, and a strategy with no drip cannot
+    /// hold them — so keeping them would produce a value the type system
+    /// does not admit. Supplying either *while* switching is a
+    /// contradiction and is rejected.
+    pub fn apply(&self, existing: BudgetStrategy) -> Result<BudgetStrategy, StoreError> {
+        let kind = self.kind.unwrap_or(match existing {
+            BudgetStrategy::TimeBased { .. } => BudgetStrategyKind::TimeBased,
+            BudgetStrategy::WhileInFlight => BudgetStrategyKind::WhileInFlight,
+        });
+
+        match kind {
+            BudgetStrategyKind::TimeBased => {
+                let (existing_duration, existing_burst) = match existing {
+                    BudgetStrategy::TimeBased { duration_ms, burst } => (Some(duration_ms), burst),
+                    // Becoming a rate limit for the first time: there is
+                    // no period to inherit, so one has to be supplied.
+                    BudgetStrategy::WhileInFlight => (None, None),
+                };
+
+                let Some(duration_ms) = self.duration_ms.or(existing_duration) else {
+                    return Err(StoreError::InvalidOperation(
+                        "changing a budget to time_based requires strategy.duration_ms".to_string(),
+                    ));
+                };
+
+                Ok(BudgetStrategy::TimeBased {
+                    duration_ms,
+                    burst: self.burst.unwrap_or(existing_burst),
+                })
+            }
+            BudgetStrategyKind::WhileInFlight => {
+                if self.duration_ms.is_some() {
+                    return Err(StoreError::InvalidOperation(
+                        "while_in_flight budget must not set strategy.duration_ms — \
+                         its tokens return on acknowledgement, not on a clock"
+                            .to_string(),
+                    ));
+                }
+
+                if self.burst.is_some_and(|burst| burst.is_some()) {
+                    return Err(StoreError::InvalidOperation(
+                        "while_in_flight budget must not set strategy.burst — \
+                         it has no drip to burst ahead of"
+                            .to_string(),
+                    ));
+                }
+
+                Ok(BudgetStrategy::WhileInFlight)
+            }
+        }
+    }
+}
+
 /// Options for `Store::patch_budget`.
 ///
-/// Follows JSON Merge Patch semantics: `None` leaves a field alone.
-/// Neither field is nullable — a budget with no allocation or no
-/// strategy is not a budget, so there is nothing to clear them to.
+/// Follows JSON Merge Patch semantics: an absent field is left alone.
+/// `allocation` is not nullable — a budget without one is not a budget,
+/// so there is nothing to clear it to — and neither is the strategy as a
+/// whole, though fields *within* it may be.
 pub struct PatchBudgetOptions {
     /// Tokens the bucket holds when full.
     pub allocation: Option<u32>,
 
-    /// How tokens replenish.
-    pub strategy: Option<BudgetStrategy>,
+    /// Changes to how tokens replenish, merged onto the stored strategy.
+    pub strategy: BudgetStrategyPatch,
 }
 
 /// A single entry in a `replace_cron_group` request.


### PR DESCRIPTION
Previously `strategy` needed a full replacement, which made controlling just the duration or just the burst of a `time_based` budget challenging, as you needed to provide all the existing fields. This now does the deep merge patch.