### PR TITLE
Announce BudgetPolicyChanged when Patching/Replacing Budgets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@
   within that scan, and on its own it is a full scan — the same cost
   profile the existing payload filter carries.
 
+  Policy changes take effect immediately, including on jobs already
+  waiting. Speeding a rate limit up re-arms the dispatcher rather than
+  leaving parked jobs to wait out the old period, and progress already
+  accrued toward the next token is kept across a change of rate — half a
+  minute spent waiting on a one-a-minute budget still counts when it
+  becomes two a second. Changing the *period* discards that progress,
+  since it is measured against the period it was accrued under.
+
   `POST /reset` now clears budgets along with jobs and cron groups.
 
   Token state is deliberately not persisted, so a server restart brings

--- a/src/api/admin/events.rs
+++ b/src/api/admin/events.rs
@@ -451,6 +451,13 @@ async fn process_store_event(
             // TODO: emit cron-specific admin events for `zizq top`.
             Vec::new()
         }
+        StoreEvent::BudgetPolicyChanged => {
+            // Nothing to diff: a policy change moves no job between the
+            // ready, scheduled and in-flight windows this connection
+            // tracks. Per-budget stats are their own admin surface and
+            // do not exist yet.
+            Vec::new()
+        }
     }
 }
 

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -2336,6 +2336,10 @@ async fn take_jobs(
                             Ok(StoreEvent::JobScheduled { .. }) => {}
                             Ok(StoreEvent::JobPatched { .. }) => {}
                             Ok(StoreEvent::CronScheduleChanged) => {}
+                            // A worker's view is unchanged by a policy
+                            // change: whether it can take a job is
+                            // answered by the claim, not by the policy.
+                            Ok(StoreEvent::BudgetPolicyChanged) => {}
                             Ok(StoreEvent::IndexRebuilt) => {
                                 // Indexes just became available — mint
                                 // an unclaimed token so the drain phase

--- a/src/commands/serve/budget_waker.rs
+++ b/src/commands/serve/budget_waker.rs
@@ -148,6 +148,15 @@ pub async fn run(
                         // different world.
                         Ok(StoreEvent::IndexRebuilt) => break,
 
+                        // A policy change moves when a parked job next
+                        // becomes affordable, so the armed timer is
+                        // stale. Speeding a budget up is the case that
+                        // needs this: nothing becomes dispatchable at
+                        // the moment of the change, so there is no
+                        // announcement to ride on — only a sooner
+                        // future to re-arm for.
+                        Ok(StoreEvent::BudgetPolicyChanged) => break,
+
                         // Missing events cannot be recovered, but the
                         // remedy for having missed them is the same as
                         // for hearing them.
@@ -442,6 +451,101 @@ mod tests {
             listening.await.unwrap(),
             "the second job was never announced, so nothing but the \
              first job finishing would have released it"
+        );
+    }
+
+    /// Speeding a budget up has to take effect now, not at the end of
+    /// the old period. This is the case `wake_budgeted_jobs` alone
+    /// cannot cover: at the instant of the change nothing has become
+    /// affordable, so there is no job to announce — only a sooner
+    /// future, which is useless to a waker asleep on the old one.
+    #[tokio::test]
+    async fn speeding_a_budget_up_re_arms_the_waker() {
+        let store = test_store();
+        let now = now_millis();
+        let (_tx, shutdown) = watch::channel(());
+
+        // One a minute: slow enough that the old timer would outlast
+        // any plausible test.
+        store
+            .create_budget(
+                "slow",
+                1,
+                BudgetStrategy::TimeBased {
+                    duration_ms: 60_000,
+                    burst: None,
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        for payload in ["a", "b"] {
+            store
+                .enqueue(
+                    now,
+                    EnqueueOptions::new("t", "q", serde_json::json!(payload))
+                        .budget(BudgetBinding::new("slow")),
+                )
+                .await
+                .unwrap();
+        }
+
+        // Spend the only token, leaving the second job parked behind a
+        // full minute of waiting.
+        store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+
+        tokio::spawn(run(
+            store.clone(),
+            crate::time::now_millis,
+            DEFAULT_BATCH_SIZE,
+            shutdown,
+        ));
+        tokio::task::yield_now().await;
+
+        let listening = tokio::spawn({
+            let store = store.clone();
+            async move {
+                let mut rx = store.subscribe();
+                let wait = async {
+                    loop {
+                        match rx.recv().await {
+                            Ok(StoreEvent::JobDispatchable { .. }) => return true,
+                            Ok(_) => continue,
+                            Err(_) => return false,
+                        }
+                    }
+                };
+                tokio::time::timeout(Duration::from_secs(5), wait)
+                    .await
+                    .unwrap_or(false)
+            }
+        });
+        tokio::task::yield_now().await;
+
+        // Six hundred a minute — a token every 100ms. If the waker
+        // ignored the policy change it would still be asleep on the
+        // minute it armed for, and the listener would time out.
+        store
+            .patch_budget(
+                "slow",
+                crate::store::PatchBudgetOptions {
+                    allocation: Some(600),
+                    strategy: Default::default(),
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            listening.await.unwrap(),
+            "the waker slept through the policy change"
         );
     }
 

--- a/src/store/budget/limiter.rs
+++ b/src/store/budget/limiter.rs
@@ -153,6 +153,7 @@ impl Limiter {
         self.refill(now);
 
         let was_concurrency = self.drip.is_none();
+        let old_period = self.drip.map(|drip| drip.duration_ms);
         let old_capacity = self.capacity;
 
         self.capacity = budget.capacity();
@@ -181,10 +182,22 @@ impl Limiter {
 
         self.tokens = self.tokens.min(self.capacity);
 
-        // Banked progress was measured against the old period, so it
-        // means nothing under the new one. At most a fraction of a
-        // token is lost.
-        self.credit = 0;
+        // Banked progress is measured in token-milliseconds against the
+        // period, so it survives a change of *rate* but not a change of
+        // *period*. Keeping it across a re-rate is worth doing: someone
+        // who has waited most of a slow minute should not have that
+        // waiting thrown away for speeding the budget up.
+        //
+        // Discarding it across a period change is not merely tidiness.
+        // `credit` is a remainder modulo `duration_ms`, so it is always
+        // smaller than the period it was computed against — which is
+        // exactly what stops `next_available` underflowing when it
+        // subtracts the credit from a shortfall's worth of the new
+        // period. Carry a remainder from a minute into a one-second
+        // budget and that invariant is gone.
+        if old_period != self.drip.map(|drip| drip.duration_ms) {
+            self.credit = 0;
+        }
     }
 
     /// What the bucket would hold at `now`, without mutating it.
@@ -612,6 +625,59 @@ mod tests {
         limiter.adopt(&concurrency(5), NOW);
 
         assert_eq!(limiter.tokens(), 0);
+    }
+
+    /// Speeding a budget up should credit the waiting already done, not
+    /// restart it. Half a minute spent waiting on a one-a-minute budget
+    /// is half a token's worth of progress, and it means the same thing
+    /// under any rate sharing that period.
+    #[test]
+    fn adopting_a_faster_rate_keeps_banked_progress() {
+        let mut limiter = Limiter::new(&per_minute(1), NOW);
+
+        // Spend the token, then wait half the period.
+        assert!(limiter.try_acquire(1, NOW));
+        limiter.refill(NOW + 30_000);
+
+        limiter.adopt(&per_minute(120), NOW + 30_000);
+
+        // Thirty seconds of the minute are already banked, so the next
+        // token needs 30_000 more token-milliseconds at 120 a minute —
+        // a quarter of a second, not the half it would be from scratch.
+        assert_eq!(
+            limiter.next_available(1, NOW + 30_000),
+            Availability::At(NOW + 30_250)
+        );
+    }
+
+    /// A period change makes the remainder meaningless — and unsafe.
+    /// `credit` is a remainder modulo the period, which is what keeps
+    /// `next_available` from underflowing; carrying a minute's worth
+    /// into a one-second budget would break that.
+    #[test]
+    fn adopting_a_new_period_discards_banked_progress() {
+        let mut limiter = Limiter::new(&per_minute(1), NOW);
+
+        assert!(limiter.try_acquire(1, NOW));
+        limiter.refill(NOW + 30_000);
+
+        let per_second = Budget::new(
+            1,
+            BudgetStrategy::TimeBased {
+                duration_ms: 1_000,
+                burst: None,
+            },
+            NOW,
+        )
+        .unwrap();
+        limiter.adopt(&per_second, NOW + 30_000);
+
+        // A full second from scratch, not an instant token from a
+        // remainder measured against a minute.
+        assert_eq!(
+            limiter.next_available(1, NOW + 30_000),
+            Availability::At(NOW + 31_000)
+        );
     }
 
     /// Tightening a budget applies at once rather than after the

--- a/src/store/budget/ops.rs
+++ b/src/store/budget/ops.rs
@@ -131,6 +131,7 @@ impl Store {
         // rather than inside the closure, which holds the keyspace and
         // the registry but not the event channel.
         self.wake_budgeted_jobs(now, BUDGET_WAKE_LIMIT);
+        self.announce_budget_change();
 
         Ok(budget)
     }
@@ -189,8 +190,22 @@ impl Store {
 
         // See `put_budget`: a grown allocation has to be announced.
         self.wake_budgeted_jobs(now, BUDGET_WAKE_LIMIT);
+        self.announce_budget_change();
 
         Ok(budget)
+    }
+
+    /// Tell the waker its armed timer may be stale.
+    ///
+    /// Distinct from [`Store::wake_budgeted_jobs`], and both are needed.
+    /// That one announces work that is affordable *now*, which is what a
+    /// widened concurrency budget produces. This one says only that the
+    /// future has moved — which is all a faster rate limit produces,
+    /// since its parked jobs are still unaffordable at the instant the
+    /// policy changes. Without it, a budget patched from one a minute to
+    /// two a second keeps its jobs waiting out the old minute.
+    fn announce_budget_change(&self) {
+        let _ = self.event_tx.send(StoreEvent::BudgetPolicyChanged);
     }
 
     /// Load a budget's policy, or `None` if it does not exist.

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -123,6 +123,21 @@ pub enum StoreEvent {
     /// The cron scheduler listens for this to recalculate its sleep timer.
     CronScheduleChanged,
 
+    /// A budget's policy was created or changed.
+    ///
+    /// The budget waker listens for this to recalculate its sleep timer.
+    /// Changing an allocation or a period changes when a parked job
+    /// next becomes affordable, which invalidates whatever the waker is
+    /// currently sleeping until — and nothing else would tell it. Making
+    /// a budget faster is the case that matters: the jobs waiting on it
+    /// are not dispatchable yet, so there is nothing to announce, only a
+    /// sooner future to re-arm for.
+    ///
+    /// Carries no key, like `CronScheduleChanged`. The waker recomputes
+    /// across every occupied budget anyway, so naming one would be
+    /// detail the only listener discards.
+    BudgetPolicyChanged,
+
     /// Recovery and index rebuilding completed.
     ///
     /// Emitted once when `rebuild_indexes()` finishes. Wakes sleeping


### PR DESCRIPTION
If a queue of jobs rate limited at 1/minute, for example, is currently sat waiting for the next minute, then patching that budget to 100/second makes no difference as the `BudgetWaker` is simply sat idle and sleeping. No event arrives to wake it sooner.

This commit fixes that by emitting a `BudgetPolicyChanged` event which wakes the `BudgetWaker`, making the higher rate limit take effect instantly.

Another minor fix included here too. Changing only `allocation` or `burst` should not impact the credit accrued by the `Limiter`. Only changing the duration over which the rate limit applies should do that (effectively starting a new limit completely fresh). We now only reset the credit when changing the duration, but not for anything else.