### PR TITLE
Add API Endpoints to Manage the Bindings on Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,31 @@
   under, so moving them would either invent a slot on the new budget or
   strand one on the old, and the request is refused with 422.
 
+  The same operations work across a filtered set, taking the same
+  filters as the other bulk job routes: `POST` / `PUT` / `PATCH` /
+  `DELETE /jobs/budgets/{key}` and `DELETE /jobs/budgets`. These skip
+  rather than fail on anything true of one job but not the request,
+  since a per-job 409 has nowhere to go in an operation over a matched
+  set. A malformed request still refuses outright, being wrong for every
+  job it could match.
+
+  The response is `{"changed": N, "blocked": [ids]}`. `blocked` names
+  the jobs the mutation *would* have changed but could not, because they
+  were in flight — the one outcome a caller can act on, by retrying
+  those ids once the jobs finish. Jobs the mutation simply did not apply
+  to are absent: an `Add` against a job already bound, or a `Remove`
+  against one that never had the binding, is the documented behaviour of
+  the verb rather than a shortfall. Terminal jobs are absent too, their
+  bindings being inert.
+
+  There is deliberately no `PUT /jobs/budgets` to replace whole sets
+  across a filter. A filter naming one budget still matches jobs drawing
+  on others, so replacing would silently discard bindings the caller
+  never mentioned. Splitting a shared budget is two scoped calls
+  instead — `POST /jobs/budgets/new?budgets.key=old` then
+  `DELETE /jobs/budgets/old?budgets.key=old` — each of which leaves
+  bindings it was not asked about alone.
+
   Jobs can be filtered by budget with `?budgets.key=`, comma-delimited
   like `queue` and `type`, on `GET /jobs`, `GET /jobs/count`,
   `PATCH /jobs` and `DELETE /jobs`. It matches a job drawing on any of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@
   and remain peristed indefinitely. Future releases will enable more
   dynamic sub-buckets within budgets.
 
+  A job's budgets can be changed after it is enqueued, through routes on
+  `/jobs/{id}/budgets`: `POST` a key to bind one (409 if already bound,
+  and `create_with` works here as it does on an enqueue), `PUT` to bind
+  or replace, `PATCH` to change what it draws, `DELETE` to unbind.
+  `PUT /jobs/{id}/budgets` replaces the whole set and
+  `DELETE /jobs/{id}/budgets` clears it. Only queued jobs may change —
+  an in-flight job holds tokens against the bindings it was dispatched
+  under, so moving them would either invent a slot on the new budget or
+  strand one on the old, and the request is refused with 422.
+
   Jobs can be filtered by budget with `?budgets.key=`, comma-delimited
   like `queue` and `type`, on `GET /jobs`, `GET /jobs/count`,
   `PATCH /jobs` and `DELETE /jobs`. It matches a job drawing on any of

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -21,7 +21,7 @@ use axum::http::{self, StatusCode};
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::response::sse::{Event, Sse};
-use axum::routing::{get, post};
+use axum::routing::{get, post, put};
 use serde::Serialize;
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::StreamExt;
@@ -36,7 +36,8 @@ use super::types::{
     BulkEnqueueResponse, BulkSuccessNotFoundResponse, BulkSuccessRequest, CommaSet,
     CountJobsParams, CountJobsResponse, CronEntryRequest, CronEntryResponse, CronGroupResponse,
     DeleteJobsParams, EnqueueRequest, ErrorRecord, ErrorResponse, FailureRequest, HealthResponse,
-    Job, JobStatus, ListBudgetsResponse, ListCronGroupsResponse, ListErrorsPages, ListErrorsParams,
+    Job, JobBudgetBindingRequest, JobBudgetCostRequest, JobBudgetsRequest, JobStatus,
+    ListBudgetsResponse, ListCronGroupsResponse, ListErrorsPages, ListErrorsParams,
     ListErrorsResponse, ListJobsPages, ListJobsParams, ListJobsResponse, ListQueuesResponse, Order,
     PatchBudgetRequest, PatchBudgetStrategyRequest, PatchCronEntryRequest, PatchCronGroupRequest,
     PatchJobBody, PatchJobsParams, RangeQuery, ReplaceCronGroupRequest, TakeParams,
@@ -403,6 +404,17 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/jobs/{id}/failure", post(report_failure))
         .route("/jobs/{id}/errors", get(list_errors))
         .route("/jobs/{id}/errors/{attempt}", get(get_error))
+        .route(
+            "/jobs/{id}/budgets",
+            put(replace_job_budgets).delete(clear_job_budgets),
+        )
+        .route(
+            "/jobs/{id}/budgets/{key}",
+            post(add_job_budget)
+                .put(set_job_budget)
+                .patch(patch_job_budget)
+                .delete(remove_job_budget),
+        )
         .route(
             "/crons",
             get(list_cron_groups).delete(bulk_delete_cron_groups),
@@ -2536,6 +2548,302 @@ fn parse_budget_strategy(req: BudgetStrategyRequest) -> Result<store::BudgetStra
         other => Err(format!(
             "unknown budget strategy: {other:?} (expected \"time_based\" or \"while_in_flight\")"
         )),
+    }
+}
+
+// --- Job budget bindings ---
+
+/// Turn a [`JobBudgetChange`] into a response.
+///
+/// Shared by every route here, so the mapping from outcome to status is
+/// stated once. `Unchanged` answers `200` alongside `Changed`: the
+/// caller asked for a state and the job is in it, which is a success
+/// however few bytes were written.
+fn job_budget_response(fmt: Format, id: &str, change: store::JobBudgetChange) -> Response {
+    match change {
+        store::JobBudgetChange::Changed(job) | store::JobBudgetChange::Unchanged(job) => {
+            match Job::try_from(job) {
+                Ok(job) => respond(fmt, StatusCode::OK, &job),
+                Err(e) => {
+                    tracing::error!(%e, "job budget change produced an unreadable job");
+                    respond(
+                        fmt,
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &ErrorResponse {
+                            error: "internal error".into(),
+                        },
+                    )
+                }
+            }
+        }
+        store::JobBudgetChange::JobNotFound => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("job '{id}' not found"),
+            },
+        ),
+        store::JobBudgetChange::NotBound(key) => respond(
+            fmt,
+            StatusCode::NOT_FOUND,
+            &ErrorResponse {
+                error: format!("job '{id}' does not draw on budget '{key}'"),
+            },
+        ),
+        store::JobBudgetChange::AlreadyBound(key) => respond(
+            fmt,
+            StatusCode::CONFLICT,
+            &ErrorResponse {
+                error: format!(
+                    "job '{id}' already draws on budget '{key}'. \
+                     Use PUT to replace the binding, or PATCH to change its cost."
+                ),
+            },
+        ),
+        // 422 rather than 409: the request is well formed and the job
+        // exists, but its bindings cannot move from where it is. An
+        // in-flight job holds tokens against them, and a finished one
+        // will never run again.
+        store::JobBudgetChange::NotQueued(status) => respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse {
+                error: format!(
+                    "job '{id}' is {status:?} — only queued jobs may have their budgets changed"
+                ),
+            },
+        ),
+    }
+}
+
+/// Build a binding from a path key and a body, validating both.
+///
+/// Routed through `parse_budget_bindings` rather than constructed
+/// directly, so a key arriving this way gets the same name validation as
+/// one on an enqueue, and `bucket` is refused in the same place.
+fn binding_from_path(
+    key: String,
+    cost: Option<u32>,
+    create_with: Option<BudgetRequest>,
+    bucket: Option<String>,
+) -> Result<store::BudgetBinding, String> {
+    let mut bindings = parse_budget_bindings(vec![BudgetBindingRequest {
+        key,
+        cost,
+        create_with,
+        bucket,
+    }])?;
+
+    bindings
+        .pop()
+        .ok_or_else(|| "budget binding could not be read".to_string())
+}
+
+/// Handle `POST /jobs/{id}/budgets/{key}` — bind a budget the job does
+/// not already draw on.
+async fn add_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((id, key)): Path<(String, String)>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetBindingRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    let binding = match binding_from_path(key, req.cost, req.create_with, req.bucket) {
+        Ok(binding) => binding,
+        Err(error) => {
+            return respond(
+                fmt,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                &ErrorResponse { error },
+            );
+        }
+    };
+
+    run_job_budget_mutation(state, fmt, id, store::BudgetMutation::Add(binding), now_ms).await
+}
+
+/// Handle `PUT /jobs/{id}/budgets/{key}` — bind a budget, replacing any
+/// existing binding to it.
+async fn set_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((id, key)): Path<(String, String)>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetBindingRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    let binding = match binding_from_path(key, req.cost, req.create_with, req.bucket) {
+        Ok(binding) => binding,
+        Err(error) => {
+            return respond(
+                fmt,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                &ErrorResponse { error },
+            );
+        }
+    };
+
+    run_job_budget_mutation(state, fmt, id, store::BudgetMutation::Set(binding), now_ms).await
+}
+
+/// Handle `PATCH /jobs/{id}/budgets/{key}` — change what the job draws.
+async fn patch_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((id, key)): Path<(String, String)>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetCostRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    if let Err(error) = validate_name("budget key", &key) {
+        return respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error },
+        );
+    }
+
+    let mutation = store::BudgetMutation::SetCost {
+        key,
+        cost: req.cost,
+    };
+    run_job_budget_mutation(state, fmt, id, mutation, now_ms).await
+}
+
+/// Handle `DELETE /jobs/{id}/budgets/{key}` — unbind one budget.
+async fn remove_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path((id, key)): Path<(String, String)>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    run_job_budget_mutation(
+        state,
+        fmt,
+        id,
+        store::BudgetMutation::Remove { key },
+        now_ms,
+    )
+    .await
+}
+
+/// Handle `PUT /jobs/{id}/budgets` — replace the whole set.
+///
+/// The one whole-set operation, and single-job only: replacing a set is
+/// sound when the caller knows what is being replaced, which over a
+/// filtered selection they do not.
+async fn replace_job_budgets(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetsRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    let bindings = match parse_budget_bindings(req.budgets) {
+        Ok(bindings) => bindings,
+        Err(error) => {
+            return respond(
+                fmt,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                &ErrorResponse { error },
+            );
+        }
+    };
+
+    let mutation = store::BudgetMutation::ReplaceAll(bindings);
+    run_job_budget_mutation(state, fmt, id, mutation, now_ms).await
+}
+
+/// Handle `DELETE /jobs/{id}/budgets` — unbind everything.
+async fn clear_job_budgets(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    run_job_budget_mutation(state, fmt, id, store::BudgetMutation::RemoveAll, now_ms).await
+}
+
+/// Apply a mutation and answer with the outcome.
+async fn run_job_budget_mutation(
+    state: Arc<AppState>,
+    fmt: Format,
+    id: String,
+    mutation: store::BudgetMutation,
+    now_ms: u64,
+) -> Response {
+    match state.store.patch_job_budgets(&id, mutation, now_ms).await {
+        Ok(change) => job_budget_response(fmt, &id, change),
+        // Malformed for any job rather than inapplicable to this one:
+        // an unknown budget, a cost the bucket could never hold, a
+        // repeated key, a cost of zero.
+        Err(store::StoreError::InvalidOperation(error)) => respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "patch_job_budgets failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
     }
 }
 
@@ -8797,6 +9105,343 @@ mod tests {
         );
         let res = app.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // --- job budget bindings ---
+
+    /// Enqueue a job bound to nothing, returning its id.
+    async fn plain_job(app: &Router) -> String {
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/jobs",
+                &serde_json::json!({ "type": "t", "queue": "q", "payload": {} }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        body["id"].as_str().unwrap().to_string()
+    }
+
+    async fn budgets_of(app: &Router, id: &str) -> serde_json::Value {
+        let res = app
+            .clone()
+            .oneshot(empty_request("GET", &format!("/jobs/{id}")))
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        body["budgets"].clone()
+    }
+
+    #[tokio::test]
+    async fn a_budget_can_be_bound_to_and_unbound_from_a_job() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        let id = plain_job(&app).await;
+
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                &format!("/jobs/{id}/budgets/stripe"),
+                &serde_json::json!({ "cost": 4 }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["budgets"][0]["key"], "stripe");
+        assert_eq!(body["budgets"][0]["cost"], 4);
+
+        let res = app
+            .clone()
+            .oneshot(empty_request(
+                "DELETE",
+                &format!("/jobs/{id}/budgets/stripe"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        assert!(budgets_of(&app, &id).await.is_null());
+    }
+
+    /// `POST` refuses to overwrite, so a caller adding a binding cannot
+    /// silently change a cost someone else set. `PUT` is the one that
+    /// replaces, and `PATCH` the one that adjusts.
+    #[tokio::test]
+    async fn post_conflicts_where_put_and_patch_succeed() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        let id = plain_job(&app).await;
+
+        let bind = |method: &str, body: serde_json::Value| {
+            json_request(method, &format!("/jobs/{id}/budgets/stripe"), &body)
+        };
+
+        let res = app
+            .clone()
+            .oneshot(bind("POST", serde_json::json!({ "cost": 1 })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let res = app
+            .clone()
+            .oneshot(bind("POST", serde_json::json!({ "cost": 9 })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+
+        let res = app
+            .clone()
+            .oneshot(bind("PUT", serde_json::json!({ "cost": 5 })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let res = app
+            .clone()
+            .oneshot(bind("PATCH", serde_json::json!({ "cost": 7 })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["budgets"][0]["cost"], 7);
+    }
+
+    /// Adjusting a cost will not create a binding: a caller doing so
+    /// believes the job is already throttled.
+    #[tokio::test]
+    async fn patching_a_budget_the_job_lacks_is_404() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        let id = plain_job(&app).await;
+
+        let res = app
+            .oneshot(json_request(
+                "PATCH",
+                &format!("/jobs/{id}/budgets/stripe"),
+                &serde_json::json!({ "cost": 3 }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn replacing_the_whole_set_takes_the_body_whole() {
+        let app = pro_app();
+        for key in ["a", "b", "c"] {
+            app.clone()
+                .oneshot(budget_post(key, &while_in_flight(10)))
+                .await
+                .unwrap();
+        }
+        let id = plain_job(&app).await;
+
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "PUT",
+                &format!("/jobs/{id}/budgets"),
+                &serde_json::json!({ "budgets": [{ "key": "a" }, { "key": "b", "cost": 2 }] }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "PUT",
+                &format!("/jobs/{id}/budgets"),
+                &serde_json::json!({ "budgets": [{ "key": "c", "cost": 3 }] }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let budgets = budgets_of(&app, &id).await;
+        assert_eq!(budgets.as_array().unwrap().len(), 1);
+        assert_eq!(budgets[0]["key"], "c");
+        assert_eq!(budgets[0]["cost"], 3);
+
+        let res = app
+            .clone()
+            .oneshot(empty_request("DELETE", &format!("/jobs/{id}/budgets")))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(budgets_of(&app, &id).await.is_null());
+    }
+
+    /// Binding to a budget nobody has configured is one call, as it is
+    /// on an enqueue.
+    #[tokio::test]
+    async fn create_with_creates_the_budget_while_binding() {
+        let app = pro_app();
+        let id = plain_job(&app).await;
+
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                &format!("/jobs/{id}/budgets/fresh"),
+                &serde_json::json!({
+                    "cost": 2,
+                    "create_with": {
+                        "allocation": 20,
+                        "strategy": { "type": "while_in_flight" }
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let res = app
+            .oneshot(empty_request("GET", "/budgets/fresh"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    /// Raising a cost past what the bucket can hold leaves a job that
+    /// never dispatches again, so it is refused rather than accepted
+    /// into a permanent stall.
+    #[tokio::test]
+    async fn raising_a_cost_above_the_burst_is_422() {
+        let app = pro_app();
+        let res = app
+            .clone()
+            .oneshot(budget_post(
+                "per-minute",
+                &serde_json::json!({
+                    "allocation": 10,
+                    "strategy": { "type": "time_based", "duration_ms": 60000, "burst": 1 }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let id = plain_job(&app).await;
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                &format!("/jobs/{id}/budgets/per-minute"),
+                &serde_json::json!({ "cost": 1 }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "PATCH",
+                &format!("/jobs/{id}/budgets/per-minute"),
+                &serde_json::json!({ "cost": 2 }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        // Unchanged, so it still dispatches.
+        assert_eq!(budgets_of(&app, &id).await[0]["cost"], 1);
+    }
+
+    /// An in-flight job holds tokens against the bindings it was
+    /// dispatched under, so they may not move.
+    #[tokio::test]
+    async fn an_in_flight_job_is_422() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        let id = plain_job(&app).await;
+
+        let res = app
+            .clone()
+            .oneshot(empty_request("GET", "/jobs/take?prefetch=1"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        // Drain one frame so the job is genuinely in flight.
+        let mut body = res.into_body();
+        let _ = next_body_bytes(&mut body).await;
+
+        let res = app
+            .oneshot(json_request(
+                "POST",
+                &format!("/jobs/{id}/budgets/stripe"),
+                &serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_job_is_404() {
+        let app = pro_app();
+        let res = app
+            .oneshot(empty_request(
+                "DELETE",
+                "/jobs/0000000000000000000000000/budgets",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// A cost of zero would let a job dispatch without decreasing the
+    /// bucket, which is what the waker's termination argument rules out.
+    #[tokio::test]
+    async fn a_zero_cost_is_422() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        let id = plain_job(&app).await;
+
+        let res = app
+            .oneshot(json_request(
+                "POST",
+                &format!("/jobs/{id}/budgets/stripe"),
+                &serde_json::json!({ "cost": 0 }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn job_budget_routes_are_403_on_free_tier() {
+        let res = test_app()
+            .oneshot(empty_request(
+                "DELETE",
+                "/jobs/0000000000000000000000000/budgets",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 
     /// `create_with` makes enqueue a budget *creation* path, so it needs

--- a/src/api/primary/handlers.rs
+++ b/src/api/primary/handlers.rs
@@ -21,7 +21,7 @@ use axum::http::{self, StatusCode};
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::response::sse::{Event, Sse};
-use axum::routing::{get, post, put};
+use axum::routing::{delete, get, post, put};
 use serde::Serialize;
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::StreamExt;
@@ -404,6 +404,14 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/jobs/{id}/failure", post(report_failure))
         .route("/jobs/{id}/errors", get(list_errors))
         .route("/jobs/{id}/errors/{attempt}", get(get_error))
+        .route("/jobs/budgets", delete(bulk_clear_job_budgets))
+        .route(
+            "/jobs/budgets/{key}",
+            post(bulk_add_job_budget)
+                .put(bulk_set_job_budget)
+                .patch(bulk_patch_job_budget)
+                .delete(bulk_remove_job_budget),
+        )
         .route(
             "/jobs/{id}/budgets",
             put(replace_job_budgets).delete(clear_job_budgets),
@@ -2845,6 +2853,301 @@ async fn run_job_budget_mutation(
             )
         }
     }
+}
+
+/// Build a job filter from bulk query parameters.
+///
+/// Shared by the bulk budget routes so they select exactly the same set
+/// as `DELETE /jobs` does for the same query string — a filter that
+/// meant something different depending on which verb you sent it to
+/// would be a trap.
+fn job_filter_from(params: DeleteJobsParams) -> Result<store::JobFilter, String> {
+    for id in params.id.iter() {
+        if !is_valid_job_id(id) {
+            return Err(format!("invalid job ID: {id:?}"));
+        }
+    }
+
+    let payload_filter = match params.filter {
+        Some(ref expr) => Some(std::sync::Arc::new(
+            PayloadFilter::compile(expr).map_err(|e| format!("invalid filter: {e}"))?,
+        )),
+        None => None,
+    };
+
+    let mut filter = store::JobFilter::new();
+    if !params.id.is_empty() {
+        filter.ids = params.id.0;
+    }
+    if !params.status.is_empty() {
+        filter.statuses = params
+            .status
+            .iter()
+            .map(|s| store::JobStatus::from(*s))
+            .collect();
+    }
+    if !params.queue.is_empty() {
+        filter.queues = params.queue.0;
+    }
+    if !params.job_type.is_empty() {
+        filter.types = params.job_type.0;
+    }
+    if !params.budgets_key.is_empty() {
+        filter.budget_keys = params.budgets_key.0;
+    }
+    filter.priority = params.priority.0;
+    filter.ready_at = params.ready_at.0;
+    filter.attempts = params.attempts.0;
+    filter.payload_filter = payload_filter;
+
+    Ok(filter)
+}
+
+/// Apply a mutation across a filtered set and answer with the counts.
+async fn run_bulk_job_budget_mutation(
+    state: Arc<AppState>,
+    fmt: Format,
+    filter: store::JobFilter,
+    mutation: store::BudgetMutation,
+    now_ms: u64,
+) -> Response {
+    match state
+        .store
+        .patch_jobs_budgets(filter, mutation, now_ms)
+        .await
+    {
+        Ok(result) => respond(
+            fmt,
+            StatusCode::OK,
+            &serde_json::json!({ "changed": result.changed, "blocked": result.blocked }),
+        ),
+        Err(store::StoreError::InvalidOperation(error)) => respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error },
+        ),
+        Err(e) => {
+            tracing::error!(%e, "patch_jobs_budgets failed");
+            respond(
+                fmt,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ErrorResponse {
+                    error: "internal error".into(),
+                },
+            )
+        }
+    }
+}
+
+/// Handle `POST /jobs/budgets/{key}` — bind a budget across a matched
+/// set, passing over jobs that already draw on it.
+async fn bulk_add_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+    Query(params): Query<DeleteJobsParams>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetBindingRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    let binding = match binding_from_path(key, req.cost, req.create_with, req.bucket) {
+        Ok(binding) => binding,
+        Err(error) => {
+            return respond(
+                fmt,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                &ErrorResponse { error },
+            );
+        }
+    };
+
+    let filter = match job_filter_from(params) {
+        Ok(filter) => filter,
+        Err(error) => {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error });
+        }
+    };
+
+    run_bulk_job_budget_mutation(
+        state,
+        fmt,
+        filter,
+        store::BudgetMutation::Add(binding),
+        now_ms,
+    )
+    .await
+}
+
+/// Handle `PUT /jobs/budgets/{key}` — bind or replace across a matched
+/// set.
+async fn bulk_set_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+    Query(params): Query<DeleteJobsParams>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetBindingRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    let binding = match binding_from_path(key, req.cost, req.create_with, req.bucket) {
+        Ok(binding) => binding,
+        Err(error) => {
+            return respond(
+                fmt,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                &ErrorResponse { error },
+            );
+        }
+    };
+
+    let filter = match job_filter_from(params) {
+        Ok(filter) => filter,
+        Err(error) => {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error });
+        }
+    };
+
+    run_bulk_job_budget_mutation(
+        state,
+        fmt,
+        filter,
+        store::BudgetMutation::Set(binding),
+        now_ms,
+    )
+    .await
+}
+
+/// Handle `PATCH /jobs/budgets/{key}` — change what a matched set draws,
+/// passing over jobs not bound to it.
+async fn bulk_patch_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+    Query(params): Query<DeleteJobsParams>,
+    NegotiatedBody(req): NegotiatedBody<JobBudgetCostRequest>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    if let Err(error) = validate_name("budget key", &key) {
+        return respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error },
+        );
+    }
+
+    let filter = match job_filter_from(params) {
+        Ok(filter) => filter,
+        Err(error) => {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error });
+        }
+    };
+
+    let mutation = store::BudgetMutation::SetCost {
+        key,
+        cost: req.cost,
+    };
+    run_bulk_job_budget_mutation(state, fmt, filter, mutation, now_ms).await
+}
+
+/// Handle `DELETE /jobs/budgets/{key}` — unbind one budget across a
+/// matched set.
+async fn bulk_remove_job_budget(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+    Query(params): Query<DeleteJobsParams>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    if let Err(error) = validate_name("budget key", &key) {
+        return respond(
+            fmt,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ErrorResponse { error },
+        );
+    }
+
+    let filter = match job_filter_from(params) {
+        Ok(filter) => filter,
+        Err(error) => {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error });
+        }
+    };
+
+    run_bulk_job_budget_mutation(
+        state,
+        fmt,
+        filter,
+        store::BudgetMutation::Remove { key },
+        now_ms,
+    )
+    .await
+}
+
+/// Handle `DELETE /jobs/budgets` — unbind everything across a matched
+/// set.
+///
+/// There is deliberately no `PUT` counterpart. Replacing a whole set is
+/// only sound when the caller knows what is being replaced, which over a
+/// filtered selection they do not — a filter naming one budget still
+/// matches jobs drawing on others, and replacing would silently discard
+/// those. Clearing is different: it says exactly what it does.
+async fn bulk_clear_job_budgets(
+    AcceptFormat(fmt): AcceptFormat,
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<DeleteJobsParams>,
+) -> Response {
+    let now_ms = (state.clock)();
+    if let Err(e) = state
+        .license
+        .read()
+        .unwrap()
+        .require(now_ms, crate::license::Feature::Budgets)
+    {
+        return respond(fmt, StatusCode::FORBIDDEN, &ErrorResponse { error: e });
+    }
+
+    let filter = match job_filter_from(params) {
+        Ok(filter) => filter,
+        Err(error) => {
+            return respond(fmt, StatusCode::BAD_REQUEST, &ErrorResponse { error });
+        }
+    };
+
+    run_bulk_job_budget_mutation(state, fmt, filter, store::BudgetMutation::RemoveAll, now_ms).await
 }
 
 /// Convert a wire strategy patch into its store form.
@@ -9439,6 +9742,234 @@ mod tests {
                 "DELETE",
                 "/jobs/0000000000000000000000000/budgets",
             ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    // --- bulk job budget bindings ---
+
+    /// `/jobs/budgets/{key}` and `/jobs/{id}/budgets` are both three
+    /// segments, so they could in principle shadow each other. Verified
+    /// rather than assumed: a job id is never the literal `budgets`, but
+    /// the router has to prefer the static segment for that to matter.
+    #[tokio::test]
+    async fn bulk_and_single_budget_routes_do_not_shadow_each_other() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+        let id = plain_job(&app).await;
+
+        // Three segments, middle one dynamic: the single-job route.
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "PUT",
+                &format!("/jobs/{id}/budgets"),
+                &serde_json::json!({ "budgets": [{ "key": "stripe" }] }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Three segments, middle one literal: the bulk route.
+        let res = app
+            .clone()
+            .oneshot(empty_request("DELETE", "/jobs/budgets/stripe"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["changed"], 1);
+
+        assert!(budgets_of(&app, &id).await.is_null());
+    }
+
+    /// The case the whole endpoint set exists for: move every job off
+    /// one budget onto another, leaving bindings it was not asked about
+    /// alone. Two calls, each scoped to one key.
+    #[tokio::test]
+    async fn a_shared_budget_can_be_split_over_http() {
+        let app = pro_app();
+        for key in ["old", "new", "other"] {
+            app.clone()
+                .oneshot(budget_post(key, &while_in_flight(10)))
+                .await
+                .unwrap();
+        }
+
+        let bind = |budgets: serde_json::Value| {
+            json_request(
+                "POST",
+                "/jobs",
+                &serde_json::json!({
+                    "type": "t", "queue": "q", "payload": {}, "budgets": budgets
+                }),
+            )
+        };
+        app.clone()
+            .oneshot(bind(serde_json::json!([{ "key": "old" }])))
+            .await
+            .unwrap();
+        app.clone()
+            .oneshot(bind(
+                serde_json::json!([{ "key": "old" }, { "key": "other", "cost": 2 }]),
+            ))
+            .await
+            .unwrap();
+
+        let res = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/jobs/budgets/new?budgets.key=old",
+                &serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["changed"], 2);
+
+        let res = app
+            .clone()
+            .oneshot(empty_request("DELETE", "/jobs/budgets/old?budgets.key=old"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Nothing draws on `old` any more, so it deletes cleanly — and
+        // `other` survived on the job that had it.
+        let res = app
+            .clone()
+            .oneshot(empty_request("DELETE", "/budgets/old"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        let res = app
+            .oneshot(empty_request("GET", "/jobs/count?budgets.key=other"))
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["count"], 1);
+    }
+
+    /// Jobs already bound are passed over rather than failing the
+    /// operation — a per-job 409 has nowhere to go here — and are not
+    /// reported, since that is what the verb promises to do.
+    #[tokio::test]
+    async fn bulk_binding_reports_what_it_skipped() {
+        let app = pro_app();
+        app.clone()
+            .oneshot(budget_post("stripe", &while_in_flight(10)))
+            .await
+            .unwrap();
+
+        app.clone()
+            .oneshot(json_request(
+                "POST",
+                "/jobs",
+                &serde_json::json!({
+                    "type": "t", "queue": "q", "payload": {},
+                    "budgets": [{ "key": "stripe" }]
+                }),
+            ))
+            .await
+            .unwrap();
+        plain_job(&app).await;
+
+        let res = app
+            .oneshot(json_request(
+                "POST",
+                "/jobs/budgets/stripe",
+                &serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["changed"], 1);
+        assert_eq!(body["blocked"], serde_json::json!([]));
+    }
+
+    /// The one outcome a caller can act on comes back by id, so it can
+    /// retry those jobs once they leave the in-flight state.
+    #[tokio::test]
+    async fn bulk_binding_names_the_jobs_it_could_not_touch() {
+        let app = pro_app();
+        for key in ["stripe", "mailgun"] {
+            app.clone()
+                .oneshot(budget_post(key, &while_in_flight(10)))
+                .await
+                .unwrap();
+        }
+
+        let bound = |n: u32| {
+            json_request(
+                "POST",
+                "/jobs",
+                &serde_json::json!({
+                    "type": "t", "queue": "q", "payload": { "n": n },
+                    "budgets": [{ "key": "stripe" }]
+                }),
+            )
+        };
+        app.clone().oneshot(bound(1)).await.unwrap();
+        app.clone().oneshot(bound(2)).await.unwrap();
+
+        // Put one in flight.
+        let res = app
+            .clone()
+            .oneshot(empty_request("GET", "/jobs/take?prefetch=1"))
+            .await
+            .unwrap();
+        let mut body = res.into_body();
+        let bytes = next_body_bytes(&mut body).await;
+        let taken: serde_json::Value =
+            serde_json::from_str(std::str::from_utf8(&bytes).unwrap().trim()).unwrap();
+        let taken_id = taken["id"].as_str().unwrap().to_string();
+
+        let res = app
+            .oneshot(json_request(
+                "POST",
+                "/jobs/budgets/mailgun",
+                &serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body: serde_json::Value = serde_json::from_str(&response_body(res).await).unwrap();
+        assert_eq!(body["changed"], 1);
+        assert_eq!(body["blocked"], serde_json::json!([taken_id]));
+    }
+
+    /// Wrong for every job the filter could match, so it refuses outright
+    /// rather than changing some of them.
+    #[tokio::test]
+    async fn a_bulk_request_naming_an_unknown_budget_is_422() {
+        let app = pro_app();
+        plain_job(&app).await;
+
+        let res = app
+            .oneshot(json_request(
+                "POST",
+                "/jobs/budgets/ghost",
+                &serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn bulk_job_budget_routes_are_403_on_free_tier() {
+        let res = test_app()
+            .oneshot(empty_request("DELETE", "/jobs/budgets"))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);

--- a/src/api/primary/types.rs
+++ b/src/api/primary/types.rs
@@ -1269,6 +1269,48 @@ pub struct PatchBudgetRequest {
     pub strategy: Option<PatchBudgetStrategyRequest>,
 }
 
+/// Request body for `POST` and `PUT /jobs/{id}/budgets/{key}`.
+///
+/// The key comes from the path, so it is deliberately absent here.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobBudgetBindingRequest {
+    /// Tokens this job consumes from the budget. Defaults to 1.
+    pub cost: Option<u32>,
+
+    /// Policy to create the budget with if it does not exist yet.
+    ///
+    /// This allows creating a budget that does not exist atomically and
+    /// without making two calls.
+    pub create_with: Option<BudgetRequest>,
+
+    /// Reserved for sub-buckets. Rejected rather than ignored.
+    pub bucket: Option<String>,
+}
+
+/// Request body for `PATCH /jobs/{id}/budgets/{key}`.
+///
+/// `cost` is required rather than optional: a patch naming no field at
+/// all would be a nonsensical request to change nothing.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobBudgetCostRequest {
+    /// The job's new cost against this budget.
+    pub cost: u32,
+}
+
+/// Request body for `PUT /jobs/{id}/budgets`.
+///
+/// Wrapped in an object rather than taking a bare array which leaves
+/// room for the request to accomodate new fields without changing
+/// shape.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobBudgetsRequest {
+    /// The complete set of budgets the job should draw on.
+    pub budgets: Vec<BudgetBindingRequest>,
+}
+
 /// A merge patch over a budget's strategy.
 ///
 /// Every field is optional, because merge patch recurses into nested

--- a/src/store/budget/job_ops.rs
+++ b/src/store/budget/job_ops.rs
@@ -53,12 +53,8 @@ use super::ops::{plan_budgets, stage_budgets, unstage_budgets, write_created_bud
 /// job turns them into status codes; a bulk route over a filtered set
 /// treats the last three as "skip this one" — a job already bound is not
 /// a failure of "add this budget to everything matching".
-#[allow(
-    dead_code,
-    reason = "consumed by the job-budget routes in the next commit"
-)]
 #[derive(Debug)]
-pub(in crate::store) enum JobBudgetChange {
+pub enum JobBudgetChange {
     /// The bindings changed. Carries the job as it now stands.
     Changed(Job),
 
@@ -88,11 +84,7 @@ impl Store {
     /// Budgets named by a `create_with` are created as part of the same
     /// transaction, exactly as an enqueue would, so binding a job to a
     /// budget that does not exist yet is one call rather than two.
-    #[allow(
-        dead_code,
-        reason = "consumed by the job-budget routes in the next commit"
-    )]
-    pub(in crate::store) async fn patch_job_budgets(
+    pub async fn patch_job_budgets(
         &self,
         id: &str,
         mutation: BudgetMutation,
@@ -137,12 +129,19 @@ impl Store {
                     Err(BudgetMutationError::NotBound(key)) => {
                         return Ok(JobBudgetChange::NotBound(key));
                     }
-                    // Malformed rather than inapplicable: the request
-                    // names one budget twice whatever job it is aimed
-                    // at, so it is wrong for all of them.
+                    // Malformed rather than inapplicable: these are
+                    // wrong for every job the request could be aimed at,
+                    // not just this one, so they fail the call rather
+                    // than reporting a per-job outcome a bulk route
+                    // would skip over.
                     Err(BudgetMutationError::DuplicateKey(key)) => {
                         return Err(StoreError::InvalidOperation(format!(
                             "budget '{key}' named more than once"
+                        )));
+                    }
+                    Err(BudgetMutationError::ZeroCost(key)) => {
+                        return Err(StoreError::InvalidOperation(format!(
+                            "budget '{key}' cost must be at least 1"
                         )));
                     }
                 };
@@ -155,12 +154,13 @@ impl Store {
                 // ---- inside tx ----
                 let mut tx = ks.write_tx();
 
-                // Same pre-pass an enqueue runs: every budget the
-                // mutation introduces must exist or be creatable, and
-                // its cost must fit what the bucket can hold. Resolved
-                // under the write lock so the answer cannot change
-                // between the check and the write it guards.
-                let created = match plan_budgets(&tx, &ks, mutation.introduced().iter(), now)? {
+                // Same pre-pass an enqueue runs: every budget whose
+                // cost this mutation sets must exist or be creatable,
+                // and that cost must fit what the bucket can hold.
+                // Resolved under the write lock so the answer cannot
+                // change between the check and the write it guards.
+                let costed = mutation.costed();
+                let created = match plan_budgets(&tx, &ks, costed.iter(), now)? {
                     BudgetPlan::Proceed(created) => created,
                     BudgetPlan::Reject(e) => return Err(e),
                 };
@@ -487,6 +487,93 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+    }
+
+    /// The reported bug. A cost change introduces no binding, so an
+    /// earlier version handed the pre-pass nothing to check and the
+    /// capacity guard never ran — leaving jobs raised past what the
+    /// bucket can hold, which never dispatch again.
+    #[tokio::test]
+    async fn raising_a_cost_above_the_capacity_is_refused() {
+        let store = test_store();
+        store
+            .create_budget(
+                "per-minute",
+                10,
+                BudgetStrategy::TimeBased {
+                    duration_ms: 60_000,
+                    burst: Some(1),
+                },
+                NOW,
+            )
+            .await
+            .unwrap();
+        let job = enqueue_bound(&store, &[("per-minute", 1)]).await;
+
+        let result = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::SetCost {
+                    key: "per-minute".into(),
+                    cost: 2,
+                },
+                now_millis(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+
+        // And the job still draws what it did, so it still dispatches.
+        let stored = store.get_job(now_millis(), &job.id).await.unwrap().unwrap();
+        assert_eq!(stored.budgets[0].cost, 1);
+    }
+
+    /// The allocation is not the ceiling when a burst is set, so the
+    /// burst is what a cost has to fit inside — a cost well within the
+    /// allocation is still refused.
+    #[tokio::test]
+    async fn a_cost_change_is_measured_against_the_burst() {
+        let store = test_store();
+        store
+            .create_budget(
+                "bursty",
+                1_000,
+                BudgetStrategy::TimeBased {
+                    duration_ms: 60_000,
+                    burst: Some(5),
+                },
+                NOW,
+            )
+            .await
+            .unwrap();
+        let job = enqueue_bound(&store, &[("bursty", 1)]).await;
+
+        let result = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::SetCost {
+                    key: "bursty".into(),
+                    cost: 50,
+                },
+                now_millis(),
+            )
+            .await;
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+
+        // Up to the burst is fine.
+        changed(
+            store
+                .patch_job_budgets(
+                    &job.id,
+                    BudgetMutation::SetCost {
+                        key: "bursty".into(),
+                        cost: 5,
+                    },
+                    now_millis(),
+                )
+                .await
+                .unwrap(),
+        );
     }
 
     /// An in-flight job holds tokens against the bindings it was

--- a/src/store/budget/job_ops.rs
+++ b/src/store/budget/job_ops.rs
@@ -1,0 +1,621 @@
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Applying a [`BudgetMutation`] to a job.
+//!
+//! [`BudgetMutation`] works out *what* a job's bindings should become;
+//! this applies those bindings, which is much more involved than simply
+//! writing the record.
+//!
+//! # Changing a binding moves the job
+//!
+//! A budgeted job does not live in the ready index — it is parked in the
+//! group of every budget it draws on, and that placement is derived from
+//! the bindings themselves. So a re-bind has to unpark from the old
+//! groups and park into the new along with the write.
+//!
+//! It also shifts the cost accounting the delete and shrink guards read,
+//! and may create budgets, if the caller supplied a `create_with` for
+//! one that does not exist yet. All of it belongs to one transaction: a
+//! job whose record says one thing while the registry says another is
+//! either throttled by a budget it no longer draws on, or not throttled
+//! by one it does.
+//!
+//! # Queued jobs only
+//!
+//! A dispatched job holds tokens against its *current* bindings, and by
+//! the release rules its slot returns to whatever binding it holds when
+//! it finishes. Re-binding it mid-flight would either credit the new
+//! budget for a slot it never issued, or strand a token on the old one
+//! forever. Nothing here can make that safe, so it is refused instead.
+//!
+//! The same restriction falls out for terminal jobs, which hold nothing
+//! and will never run again.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use fjall::Slice;
+use tokio::task;
+
+use super::super::dispatch::Placement;
+use super::super::keys::make_job_key;
+use super::super::store::{Store, StoreEvent};
+use super::super::types::{Job, JobStatus, StoreError};
+use super::BudgetPlan;
+use super::mutation::{BudgetMutation, BudgetMutationError, BudgetMutationOutcome};
+use super::ops::{plan_budgets, stage_budgets, unstage_budgets, write_created_budgets};
+
+/// What applying a mutation to one job did.
+///
+/// Every arm is a distinct answer rather than an error, because the two
+/// callers want opposite things from most of them. A route naming one
+/// job turns them into status codes; a bulk route over a filtered set
+/// treats the last three as "skip this one" — a job already bound is not
+/// a failure of "add this budget to everything matching".
+#[allow(
+    dead_code,
+    reason = "consumed by the job-budget routes in the next commit"
+)]
+#[derive(Debug)]
+pub(in crate::store) enum JobBudgetChange {
+    /// The bindings changed. Carries the job as it now stands.
+    Changed(Job),
+
+    /// The job already satisfied the request, so nothing was written.
+    Unchanged(Job),
+
+    /// No job with that id.
+    JobNotFound,
+
+    /// The job is in flight or finished, so its bindings may not move.
+    NotQueued(JobStatus),
+
+    /// [`BudgetMutation::Add`] against a budget the job already draws on.
+    AlreadyBound(String),
+
+    /// [`BudgetMutation::SetCost`] against one it does not.
+    NotBound(String),
+}
+
+impl Store {
+    /// Apply a mutation to one job's budgets.
+    ///
+    /// Only queued jobs may change — see the module docs for why. A
+    /// mutation that leaves the bindings as they were writes nothing at
+    /// all.
+    ///
+    /// Budgets named by a `create_with` are created as part of the same
+    /// transaction, exactly as an enqueue would, so binding a job to a
+    /// budget that does not exist yet is one call rather than two.
+    #[allow(
+        dead_code,
+        reason = "consumed by the job-budget routes in the next commit"
+    )]
+    pub(in crate::store) async fn patch_job_budgets(
+        &self,
+        id: &str,
+        mutation: BudgetMutation,
+        now: u64,
+    ) -> Result<JobBudgetChange, StoreError> {
+        let ks = self.ks.clone();
+        let dispatch = self.dispatch.clone();
+        let live = self.budgets.clone();
+        let id = id.to_string();
+
+        let change = task::spawn_blocking(move || -> Result<JobBudgetChange, StoreError> {
+            let job_key = make_job_key(&id);
+
+            // Retry loop: pre-read and decide outside the tx, then
+            // compare-and-write inside. Retries only when the job
+            // changed under us between the two.
+            loop {
+                // ---- outside tx ----
+                let Some(pre_bytes) = ks.data.get(&job_key)? else {
+                    return Ok(JobBudgetChange::JobNotFound);
+                };
+
+                let job: Job = rmp_serde::from_slice(&pre_bytes)?;
+                let status = JobStatus::try_from(job.status).map_err(|v| {
+                    StoreError::Corruption(format!("job {id} has unrecognized status byte: {v}"))
+                })?;
+
+                if !matches!(status, JobStatus::Ready | JobStatus::Scheduled) {
+                    return Ok(JobBudgetChange::NotQueued(status));
+                }
+
+                let next = match mutation.apply(&job.budgets) {
+                    Ok(BudgetMutationOutcome::Changed(next)) => next,
+                    // Nothing to write, nothing to move, nothing to
+                    // re-account. Returned as the job already is.
+                    Ok(BudgetMutationOutcome::Unchanged) => {
+                        return Ok(JobBudgetChange::Unchanged(job));
+                    }
+                    Err(BudgetMutationError::AlreadyBound(key)) => {
+                        return Ok(JobBudgetChange::AlreadyBound(key));
+                    }
+                    Err(BudgetMutationError::NotBound(key)) => {
+                        return Ok(JobBudgetChange::NotBound(key));
+                    }
+                    // Malformed rather than inapplicable: the request
+                    // names one budget twice whatever job it is aimed
+                    // at, so it is wrong for all of them.
+                    Err(BudgetMutationError::DuplicateKey(key)) => {
+                        return Err(StoreError::InvalidOperation(format!(
+                            "budget '{key}' named more than once"
+                        )));
+                    }
+                };
+
+                let previous = job.budgets.clone();
+                let mut updated = job.clone();
+                updated.budgets = next;
+                let updated_slice: Slice = rmp_serde::to_vec_named(&updated)?.into();
+
+                // ---- inside tx ----
+                let mut tx = ks.write_tx();
+
+                // Same pre-pass an enqueue runs: every budget the
+                // mutation introduces must exist or be creatable, and
+                // its cost must fit what the bucket can hold. Resolved
+                // under the write lock so the answer cannot change
+                // between the check and the write it guards.
+                let created = match plan_budgets(&tx, &ks, mutation.introduced().iter(), now)? {
+                    BudgetPlan::Proceed(created) => created,
+                    BudgetPlan::Reject(e) => return Err(e),
+                };
+                write_created_budgets(&mut tx, &ks, &created)?;
+
+                let prev = tx.fetch_update(&ks.data, &job_key, |_| Some(updated_slice.clone()))?;
+
+                if prev.as_deref() != Some(&*pre_bytes) {
+                    drop(tx);
+                    continue;
+                }
+
+                // Staged before the commit, while the write lock still
+                // excludes every other writer — see `stage_budgets`. The
+                // *new* bindings are counted up here; the old ones are
+                // counted down after, so the accounting reads high for a
+                // moment rather than low.
+                stage_budgets(&live, &created, std::iter::once(&updated), now);
+
+                if let Err(e) = ks.commit(tx, ks.default_commit_mode) {
+                    unstage_budgets(&live, &created, std::iter::once(&updated));
+                    return Err(e);
+                }
+
+                live.untrack(&previous);
+
+                // A scheduled job is not placed for dispatch at all, so
+                // there is nothing to move; it is re-placed from its new
+                // bindings when it is promoted.
+                if status == JobStatus::Ready {
+                    dispatch.remove(Placement {
+                        queue: &updated.queue,
+                        priority: updated.priority,
+                        id: &updated.id,
+                        budgets: &previous,
+                    });
+                    dispatch.insert(Placement::of(&updated));
+                }
+
+                return Ok(JobBudgetChange::Changed(updated));
+            }
+        })
+        .await??;
+
+        // Announced outside the closure, which holds the keyspace and
+        // the registry but not the event channel.
+        //
+        // Worth announcing whichever way the bindings moved. Unbinding a
+        // budget can make a job dispatchable that was throttled a moment
+        // ago, and rebinding it moves it between groups — in both cases
+        // a worker blocked on an empty queue has no other reason to look
+        // again.
+        if let JobBudgetChange::Changed(job) = &change
+            && job.status == JobStatus::Ready as u8
+        {
+            let _ = self.event_tx.send(StoreEvent::JobDispatchable {
+                id: job.id.clone(),
+                queue: job.queue.clone(),
+                token: Arc::new(AtomicBool::new(false)),
+            });
+        }
+
+        Ok(change)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::super::super::options::EnqueueOptions;
+    use super::super::super::test_support::test_store;
+    use super::super::{BudgetBinding, BudgetStrategy};
+    use super::*;
+    use crate::time::now_millis;
+
+    const NOW: u64 = 1_700_000_000_000;
+
+    async fn store_with_budgets(keys: &[&str]) -> Store {
+        let store = test_store();
+        for key in keys {
+            store
+                .create_budget(key, 100, BudgetStrategy::WhileInFlight, NOW)
+                .await
+                .unwrap();
+        }
+        store
+    }
+
+    async fn enqueue_bound(store: &Store, bindings: &[(&str, u32)]) -> Job {
+        let mut opts = EnqueueOptions::new("t", "q", serde_json::json!({}));
+        for (key, cost) in bindings {
+            opts = opts.budget(BudgetBinding::new(*key).cost(*cost));
+        }
+        store.enqueue(now_millis(), opts).await.unwrap().into_job()
+    }
+
+    fn changed(change: JobBudgetChange) -> Job {
+        match change {
+            JobBudgetChange::Changed(job) => job,
+            other => panic!("expected a change, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn adding_a_budget_binds_it_and_counts_its_cost() {
+        let store = store_with_budgets(&["stripe", "mailgun"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        let updated = changed(
+            store
+                .patch_job_budgets(
+                    &job.id,
+                    BudgetMutation::Add(BudgetBinding::new("mailgun").cost(4)),
+                    now_millis(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(updated.budgets.len(), 2);
+        assert_eq!(store.budgets.tracked("mailgun"), 1);
+        assert_eq!(store.budgets.max_cost("mailgun"), Some(4));
+        // The binding it already had is untouched.
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+    }
+
+    /// Unbinding has to release the cost accounting as well as the
+    /// record, or the budget stays undeletable on the strength of a job
+    /// that no longer draws on it.
+    #[tokio::test]
+    async fn removing_a_budget_stops_counting_against_it() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 5)]).await;
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+
+        changed(
+            store
+                .patch_job_budgets(
+                    &job.id,
+                    BudgetMutation::Remove {
+                        key: "stripe".into(),
+                    },
+                    now_millis(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(store.budgets.tracked("stripe"), 0);
+        assert_eq!(store.budgets.max_cost("stripe"), None);
+
+        // And with nothing drawing on it, the budget deletes cleanly.
+        assert!(store.delete_budget("stripe").await.unwrap());
+    }
+
+    /// The part a read of the job record cannot show: a budgeted job is
+    /// parked in its budgets' groups, so a re-bind has to move it. If it
+    /// stayed in the old group it would be dispatched under a throttle
+    /// it no longer draws on — and never under the one it does.
+    #[tokio::test]
+    async fn re_binding_moves_the_job_between_budget_groups() {
+        let store = test_store();
+        store
+            .create_budget("old", 1, BudgetStrategy::WhileInFlight, NOW)
+            .await
+            .unwrap();
+        store
+            .create_budget("new", 1, BudgetStrategy::WhileInFlight, NOW)
+            .await
+            .unwrap();
+
+        let blocker = enqueue_bound(&store, &[("old", 1)]).await;
+        let moved = enqueue_bound(&store, &[("old", 1)]).await;
+
+        // Drain `old` so anything parked on it is stuck.
+        let taken = store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(taken.id, blocker.id);
+        assert!(
+            store
+                .take_next_job(now_millis(), &HashSet::new())
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Move the second job onto a budget with capacity to spare.
+        changed(
+            store
+                .patch_job_budgets(
+                    &moved.id,
+                    BudgetMutation::ReplaceAll(vec![BudgetBinding::new("new")]),
+                    now_millis(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        // It dispatches now, which it could not have from `old`.
+        let dispatched = store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dispatched.id, moved.id);
+    }
+
+    /// Unbinding entirely returns a job to the plain ready index, so it
+    /// dispatches without consulting any budget.
+    #[tokio::test]
+    async fn unbinding_everything_makes_a_job_unthrottled() {
+        let store = store_with_budgets(&["solo"]).await;
+        // Allocation of one, already spent by another job.
+        let holder = enqueue_bound(&store, &[("solo", 1)]).await;
+        let stuck = enqueue_bound(&store, &[("solo", 1)]).await;
+
+        let taken = store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(taken.id, holder.id);
+
+        store
+            .patch_budget(
+                "solo",
+                crate::store::PatchBudgetOptions {
+                    allocation: Some(1),
+                    strategy: Default::default(),
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .take_next_job(now_millis(), &HashSet::new())
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        changed(
+            store
+                .patch_job_budgets(&stuck.id, BudgetMutation::RemoveAll, now_millis())
+                .await
+                .unwrap(),
+        );
+
+        let dispatched = store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dispatched.id, stuck.id);
+    }
+
+    /// Binding to a budget that does not exist yet is one call, as it is
+    /// on enqueue.
+    #[tokio::test]
+    async fn create_with_creates_the_budget_it_names() {
+        let store = test_store();
+        let job = enqueue_bound(&store, &[]).await;
+
+        changed(
+            store
+                .patch_job_budgets(
+                    &job.id,
+                    BudgetMutation::Add(BudgetBinding::new("fresh").cost(2).create_with(
+                        super::super::BudgetPolicy {
+                            allocation: 50,
+                            strategy: BudgetStrategy::WhileInFlight,
+                        },
+                    )),
+                    now_millis(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        let budget = store.get_budget("fresh").await.unwrap().unwrap();
+        assert_eq!(budget.allocation, 50);
+        assert_eq!(store.budgets.tracked("fresh"), 1);
+    }
+
+    #[tokio::test]
+    async fn binding_to_an_unknown_budget_is_refused() {
+        let store = test_store();
+        let job = enqueue_bound(&store, &[]).await;
+
+        let result = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::Add(BudgetBinding::new("ghost")),
+                now_millis(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+    }
+
+    /// A cost the bucket could never hold would never dispatch, so it is
+    /// refused here exactly as it is on enqueue.
+    #[tokio::test]
+    async fn a_cost_above_the_capacity_is_refused() {
+        let store = test_store();
+        store
+            .create_budget("small", 5, BudgetStrategy::WhileInFlight, NOW)
+            .await
+            .unwrap();
+        let job = enqueue_bound(&store, &[]).await;
+
+        let result = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::Add(BudgetBinding::new("small").cost(50)),
+                now_millis(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+    }
+
+    /// An in-flight job holds tokens against the bindings it was
+    /// dispatched under, so moving them would either invent a slot on
+    /// the new budget or strand one on the old.
+    #[tokio::test]
+    async fn an_in_flight_job_is_refused() {
+        let store = store_with_budgets(&["stripe", "mailgun"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let change = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::Add(BudgetBinding::new("mailgun")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            change,
+            JobBudgetChange::NotQueued(JobStatus::InFlight)
+        ));
+        // And nothing moved.
+        assert_eq!(store.budgets.tracked("mailgun"), 0);
+    }
+
+    #[tokio::test]
+    async fn a_missing_job_is_reported_rather_than_erroring() {
+        let store = test_store();
+
+        let change = store
+            .patch_job_budgets(
+                "0000000000000000000000000",
+                BudgetMutation::RemoveAll,
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(change, JobBudgetChange::JobNotFound));
+    }
+
+    #[tokio::test]
+    async fn already_bound_and_not_bound_are_reported_separately() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        let change = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::Add(BudgetBinding::new("stripe")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(change, JobBudgetChange::AlreadyBound(k) if k == "stripe"));
+
+        let change = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::SetCost {
+                    key: "absent".into(),
+                    cost: 2,
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(change, JobBudgetChange::NotBound(k) if k == "absent"));
+    }
+
+    /// A request the job already satisfies writes nothing — no record,
+    /// no placement move, no change to the accounting.
+    #[tokio::test]
+    async fn a_no_op_request_leaves_the_job_alone() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 3)]).await;
+
+        let change = store
+            .patch_job_budgets(
+                &job.id,
+                BudgetMutation::SetCost {
+                    key: "stripe".into(),
+                    cost: 3,
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(change, JobBudgetChange::Unchanged(_)));
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+        assert_eq!(store.budgets.max_cost("stripe"), Some(3));
+    }
+
+    /// Scheduled jobs are not placed for dispatch, but they are counted:
+    /// the guards have to see work that is committed but not yet due.
+    #[tokio::test]
+    async fn a_scheduled_job_can_be_rebound() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let now = now_millis();
+        let job = store
+            .enqueue(
+                now,
+                EnqueueOptions::new("t", "q", serde_json::json!({})).ready_at(now + 600_000),
+            )
+            .await
+            .unwrap()
+            .into_job();
+
+        changed(
+            store
+                .patch_job_budgets(
+                    &job.id,
+                    BudgetMutation::Add(BudgetBinding::new("stripe").cost(6)),
+                    now_millis(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+        assert_eq!(store.budgets.max_cost("stripe"), Some(6));
+    }
+}

--- a/src/store/budget/job_ops.rs
+++ b/src/store/budget/job_ops.rs
@@ -40,8 +40,10 @@ use tokio::task;
 
 use super::super::dispatch::Placement;
 use super::super::keys::make_job_key;
+use super::super::options::JobFilter;
+use super::super::scan::{JobStream, apply_filters, build_id_stream, filter_needs_payload};
 use super::super::store::{Store, StoreEvent};
-use super::super::types::{Job, JobStatus, StoreError};
+use super::super::types::{Job, JobStatus, ScanDirection, StoreError};
 use super::BudgetPlan;
 use super::mutation::{BudgetMutation, BudgetMutationError, BudgetMutationOutcome};
 use super::ops::{plan_budgets, stage_budgets, unstage_budgets, write_created_budgets};
@@ -72,6 +74,63 @@ pub enum JobBudgetChange {
 
     /// [`BudgetMutation::SetCost`] against one it does not.
     NotBound(String),
+}
+
+/// A job the bulk pass is about to rewrite.
+///
+/// Carried out of the scan so the placement move and the untracking of
+/// the *old* bindings can happen after the commit.
+///
+/// The two halves of the accounting are deliberately split around it:
+/// the new bindings are tracked *before* the commit by `stage_budgets`,
+/// the old ones untracked *after*. That brackets the change, so in the
+/// window between them both are counted — a cost raised from one to two
+/// reads a maximum of two, and one lowered from five to two reads five.
+/// High in either direction, which costs at worst a delete or shrink
+/// refused that would have been safe. The opposite order would leave the
+/// aggregate briefly reporting less work than exists, and a guard
+/// reading it then would let a budget be shrunk out from under a job.
+struct Rewritten {
+    previous: Vec<super::BudgetRef>,
+    updated: Job,
+    status: JobStatus,
+}
+
+/// What applying a mutation across a matched set did.
+///
+/// Counts what happened and names what was prevented, which are
+/// different questions. A caller wants to know how much moved, and then
+/// wants to be able to *do something* about whatever did not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BulkBudgetChange {
+    /// Jobs whose bindings moved.
+    pub changed: usize,
+
+    /// Jobs the mutation would have changed, but could not, because they
+    /// were in flight.
+    ///
+    /// Named rather than counted, because this is the one outcome a
+    /// caller can act on — wait for the jobs to leave the in-flight
+    /// state and try those ids again.
+    ///
+    /// **Jobs the mutation simply did not apply to are absent**, not
+    /// counted here or anywhere. A `Remove` against a job that never had
+    /// the binding, an `Add` against one already bound, a cost already
+    /// at the requested value: these are the documented behaviour of the
+    /// bulk verbs rather than a shortfall. Counting them would make the
+    /// number roughly "jobs that exist" — an unfiltered unbind would
+    /// report the whole store as skipped, which is both useless and
+    /// alarming.
+    ///
+    /// **Terminal jobs are absent too**, deliberately. A finished job's
+    /// bindings are inert: it will never dispatch, it is already
+    /// untracked from the cost accounting, and it is parked nowhere.
+    /// Nothing can be done about it and nothing needs to be, so listing
+    /// them would reintroduce the unbounded list this exists to avoid.
+    ///
+    /// That leaves a set bounded by how much work is in flight at once,
+    /// which is small enough to name.
+    pub blocked: Vec<String>,
 }
 
 impl Store {
@@ -225,6 +284,197 @@ impl Store {
 
         Ok(change)
     }
+
+    /// Apply a mutation to every job a filter matches.
+    ///
+    /// Skips rather than fails on anything that is true of one job but
+    /// not of the request: already bound, not bound, in flight, finished,
+    /// or already in the requested state. A per-job `409` has nowhere to
+    /// go in an operation over a matched set, and "add this budget to
+    /// everything matching" is not wrong about the ones that have it.
+    ///
+    /// Malformed requests still fail outright — an unknown budget, a
+    /// cost the bucket could never hold, a repeated key, a cost of zero.
+    /// Those are wrong for every job the filter could match, so failing
+    /// half way through would leave the caller worse off than refusing.
+    ///
+    /// One transaction for the whole set, like the other bulk
+    /// operations. The budgets to resolve are the same for every job,
+    /// since the mutation is, so the pre-pass runs once rather than per
+    /// job.
+    pub async fn patch_jobs_budgets(
+        &self,
+        filter: JobFilter,
+        mutation: BudgetMutation,
+        now: u64,
+    ) -> Result<BulkBudgetChange, StoreError> {
+        let ks = self.ks.clone();
+        let dispatch = self.dispatch.clone();
+        let live = self.budgets.clone();
+
+        let (result, rewritten) = task::spawn_blocking(
+            move || -> Result<(BulkBudgetChange, Vec<Rewritten>), StoreError> {
+                // Write lock first, then the snapshot: nothing can commit
+                // while the scan runs, so the set cannot shift underneath
+                // the decisions made about it.
+                let mut tx = ks.write_tx();
+                let snapshot = ks.db.read_tx();
+
+                // Resolved once. Every job takes the same mutation, so
+                // the budgets it names and the costs it sets are the same
+                // whichever job is being looked at.
+                let costed = mutation.costed();
+                let created = match plan_budgets(&tx, &ks, costed.iter(), now)? {
+                    BudgetPlan::Proceed(created) => created,
+                    BudgetPlan::Reject(e) => return Err(e),
+                };
+                write_created_budgets(&mut tx, &ks, &created)?;
+
+                let needs_payload = filter_needs_payload(&filter);
+                let jobs = match build_id_stream(&snapshot, &ks, &filter, &None, ScanDirection::Asc)
+                {
+                    Some((id_stream, source, _)) => apply_filters(
+                        JobStream::by_id(
+                            id_stream,
+                            &snapshot,
+                            &ks.data,
+                            None,
+                            needs_payload,
+                            source,
+                        ),
+                        &filter,
+                    ),
+                    None => apply_filters(
+                        JobStream::full_scan(
+                            &snapshot,
+                            &ks,
+                            &None,
+                            ScanDirection::Asc,
+                            None,
+                            needs_payload,
+                        ),
+                        &filter,
+                    ),
+                };
+
+                let mut rewritten: Vec<Rewritten> = Vec::new();
+                let mut blocked: Vec<String> = Vec::new();
+
+                for job in jobs {
+                    let job = job?;
+                    let status = JobStatus::try_from(job.status).map_err(|v| {
+                        StoreError::Corruption(format!(
+                            "job {} has unrecognized status byte: {v}",
+                            job.id
+                        ))
+                    })?;
+
+                    // Applied before the state is consulted, so that
+                    // "would have changed but could not" can be told
+                    // apart from "there was nothing to do". Only the
+                    // first is worth reporting.
+                    let next = match mutation.apply(&job.budgets) {
+                        Ok(BudgetMutationOutcome::Changed(next)) => next,
+                        // Nothing to do. Not a shortfall, and not
+                        // reported: these are what the bulk verbs
+                        // promise to pass over.
+                        Ok(BudgetMutationOutcome::Unchanged) => continue,
+                        Err(BudgetMutationError::AlreadyBound(_))
+                        | Err(BudgetMutationError::NotBound(_)) => continue,
+                        // Wrong for every job, not just this one.
+                        Err(BudgetMutationError::DuplicateKey(key)) => {
+                            return Err(StoreError::InvalidOperation(format!(
+                                "budget '{key}' named more than once"
+                            )));
+                        }
+                        Err(BudgetMutationError::ZeroCost(key)) => {
+                            return Err(StoreError::InvalidOperation(format!(
+                                "budget '{key}' cost must be at least 1"
+                            )));
+                        }
+                    };
+
+                    match status {
+                        JobStatus::Ready | JobStatus::Scheduled => {}
+                        // Live work whose bindings cannot move while it
+                        // holds tokens against them. The caller can try
+                        // again once it has left the in-flight state.
+                        JobStatus::InFlight => {
+                            blocked.push(job.id);
+                            continue;
+                        }
+                        // Finished, so its bindings are record-keeping: it
+                        // will never dispatch and is already untracked.
+                        // Nothing to do and nothing to report.
+                        JobStatus::Completed | JobStatus::Dead => continue,
+                    }
+
+                    let previous = job.budgets.clone();
+                    let mut updated = job;
+                    updated.budgets = next;
+
+                    tx.insert(
+                        &ks.data,
+                        make_job_key(&updated.id),
+                        rmp_serde::to_vec_named(&updated)?,
+                    );
+
+                    rewritten.push(Rewritten {
+                        previous,
+                        updated,
+                        status,
+                    });
+                }
+
+                let result = BulkBudgetChange {
+                    changed: rewritten.len(),
+                    blocked,
+                };
+
+                // Nothing written and nothing created: no commit to make.
+                if rewritten.is_empty() && created.is_empty() {
+                    drop(tx);
+                    return Ok((result, Vec::new()));
+                }
+
+                stage_budgets(&live, &created, rewritten.iter().map(|r| &r.updated), now);
+
+                if let Err(e) = ks.commit(tx, ks.default_commit_mode) {
+                    unstage_budgets(&live, &created, rewritten.iter().map(|r| &r.updated));
+                    return Err(e);
+                }
+
+                for entry in &rewritten {
+                    live.untrack(&entry.previous);
+
+                    if entry.status == JobStatus::Ready {
+                        dispatch.remove(Placement {
+                            queue: &entry.updated.queue,
+                            priority: entry.updated.priority,
+                            id: &entry.updated.id,
+                            budgets: &entry.previous,
+                        });
+                        dispatch.insert(Placement::of(&entry.updated));
+                    }
+                }
+
+                Ok((result, rewritten))
+            },
+        )
+        .await??;
+
+        for entry in rewritten {
+            if entry.status == JobStatus::Ready {
+                let _ = self.event_tx.send(StoreEvent::JobDispatchable {
+                    id: entry.updated.id,
+                    queue: entry.updated.queue,
+                    token: Arc::new(AtomicBool::new(false)),
+                });
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
@@ -232,7 +482,7 @@ mod tests {
     use std::collections::HashSet;
 
     use super::super::super::options::EnqueueOptions;
-    use super::super::super::test_support::test_store;
+    use super::super::super::test_support::{test_store, test_store_with_retention};
     use super::super::{BudgetBinding, BudgetStrategy};
     use super::*;
     use crate::time::now_millis;
@@ -576,6 +826,67 @@ mod tests {
         );
     }
 
+    /// The aggregate has to end up describing the *new* cost and not the
+    /// old, in both directions. The old binding is untracked after the
+    /// commit; forgetting it would leave the previous cost counted
+    /// forever, and a budget permanently unshrinkable on the strength of
+    /// a cost no job draws any more.
+    #[tokio::test]
+    async fn a_cost_change_leaves_only_the_new_cost_counted() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 3)]).await;
+
+        let raise = |cost| BudgetMutation::SetCost {
+            key: "stripe".into(),
+            cost,
+        };
+
+        changed(
+            store
+                .patch_job_budgets(&job.id, raise(7), now_millis())
+                .await
+                .unwrap(),
+        );
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+        assert_eq!(store.budgets.max_cost("stripe"), Some(7));
+
+        // Downwards is the direction that exposes a lingering old cost:
+        // the maximum would stay at seven.
+        changed(
+            store
+                .patch_job_budgets(&job.id, raise(2), now_millis())
+                .await
+                .unwrap(),
+        );
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+        assert_eq!(store.budgets.max_cost("stripe"), Some(2));
+    }
+
+    /// The same, through the bulk path, which does its untracking in a
+    /// separate loop after the commit.
+    #[tokio::test]
+    async fn a_bulk_cost_change_leaves_only_the_new_cost_counted() {
+        let store = store_with_budgets(&["stripe"]).await;
+        enqueue_bound(&store, &[("stripe", 9)]).await;
+        enqueue_bound(&store, &[("stripe", 9)]).await;
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::SetCost {
+                    key: "stripe".into(),
+                    cost: 2,
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.changed, 2);
+
+        assert_eq!(store.budgets.tracked("stripe"), 2);
+        assert_eq!(store.budgets.max_cost("stripe"), Some(2));
+    }
+
     /// An in-flight job holds tokens against the bindings it was
     /// dispatched under, so moving them would either invent a slot on
     /// the new budget or strand one on the old.
@@ -674,6 +985,347 @@ mod tests {
         assert!(matches!(change, JobBudgetChange::Unchanged(_)));
         assert_eq!(store.budgets.tracked("stripe"), 1);
         assert_eq!(store.budgets.max_cost("stripe"), Some(3));
+    }
+
+    // --- bulk ---
+
+    /// The operator case this exists for: move every job off one budget
+    /// and onto another, without disturbing bindings it was not asked
+    /// about. Two calls, each scoped to one key.
+    #[tokio::test]
+    async fn a_shared_budget_can_be_split_without_losing_other_bindings() {
+        let store = store_with_budgets(&["old", "new", "other"]).await;
+
+        // One job on `old` alone, one on `old` and `other`.
+        let alone = enqueue_bound(&store, &[("old", 1)]).await;
+        let both = enqueue_bound(&store, &[("old", 1), ("other", 2)]).await;
+
+        let filter = JobFilter::new().budget_keys(HashSet::from(["old".to_string()]));
+
+        let added = store
+            .patch_jobs_budgets(
+                filter.clone(),
+                BudgetMutation::Add(BudgetBinding::new("new")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(added.changed, 2);
+        assert!(added.blocked.is_empty());
+
+        let removed = store
+            .patch_jobs_budgets(
+                filter,
+                BudgetMutation::Remove { key: "old".into() },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(removed.changed, 2);
+
+        let alone = store
+            .get_job(now_millis(), &alone.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let keys: Vec<_> = alone.budgets.iter().map(|b| b.key.as_str()).collect();
+        assert_eq!(keys, vec!["new"]);
+
+        // The binding it was never asked about survived.
+        let both = store
+            .get_job(now_millis(), &both.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut keys: Vec<_> = both.budgets.iter().map(|b| b.key.as_str()).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["new", "other"]);
+    }
+
+    /// A job already bound is what `POST` promises to pass over, so it
+    /// is not reported at all — reporting it would make the response say
+    /// the operation fell short when it did exactly what it says.
+    #[tokio::test]
+    async fn already_bound_jobs_are_passed_over_silently() {
+        let store = store_with_budgets(&["stripe"]).await;
+        enqueue_bound(&store, &[("stripe", 1)]).await;
+        enqueue_bound(&store, &[]).await;
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::Add(BudgetBinding::new("stripe")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 1);
+        assert!(result.blocked.is_empty());
+    }
+
+    /// The number this replaced counted every no-op, so an unfiltered
+    /// unbind reported the whole store as skipped — a figure that grew
+    /// with the database and told the caller nothing.
+    #[tokio::test]
+    async fn jobs_the_mutation_does_not_touch_are_not_reported() {
+        let store = store_with_budgets(&["wanted"]).await;
+        for _ in 0..5 {
+            enqueue_bound(&store, &[]).await;
+        }
+        enqueue_bound(&store, &[("wanted", 1)]).await;
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::Remove {
+                    key: "wanted".into(),
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 1);
+        assert!(
+            result.blocked.is_empty(),
+            "five untouched jobs should not be reported: {:?}",
+            result.blocked
+        );
+    }
+
+    /// In-flight jobs hold tokens against their current bindings, so a
+    /// filter that sweeps one up passes over it — but this is the one
+    /// outcome the caller can act on, so it comes back by id.
+    #[tokio::test]
+    async fn in_flight_jobs_are_reported_by_id() {
+        let store = store_with_budgets(&["stripe", "mailgun"]).await;
+        enqueue_bound(&store, &[("stripe", 1)]).await;
+        enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        let running = store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::Add(BudgetBinding::new("mailgun")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 1);
+        assert_eq!(result.blocked, vec![running.id.clone()]);
+        assert_eq!(store.budgets.tracked("mailgun"), 1);
+
+        // Once it is no longer in flight, the same call lands.
+        store
+            .mark_completed(now_millis(), &running.id)
+            .await
+            .unwrap();
+    }
+
+    /// An in-flight job the mutation would not have changed anyway is
+    /// not blocked by anything — reporting it would send the caller
+    /// retrying something that will never do anything.
+    #[tokio::test]
+    async fn an_in_flight_job_with_nothing_to_change_is_not_reported() {
+        let store = store_with_budgets(&["stripe"]).await;
+        enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // It already draws on `stripe`, so `Add` had nothing to do
+        // regardless of its state.
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::Add(BudgetBinding::new("stripe")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 0);
+        assert!(result.blocked.is_empty());
+    }
+
+    /// The other way a mutation can have nothing to do: the job does not
+    /// draw on the budget being removed at all. Being in flight is
+    /// irrelevant to a job the request was never going to touch, so it
+    /// is not reported — otherwise an unfiltered unbind would name every
+    /// running job on the server.
+    #[tokio::test]
+    async fn an_in_flight_job_without_the_budget_is_not_reported() {
+        let store = store_with_budgets(&["targeted", "unrelated"]).await;
+
+        // In flight, and bound only to a budget the request ignores.
+        enqueue_bound(&store, &[("unrelated", 1)]).await;
+        store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Queued, and actually affected.
+        let affected = enqueue_bound(&store, &[("targeted", 1)]).await;
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::Remove {
+                    key: "targeted".into(),
+                },
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 1);
+        assert!(
+            result.blocked.is_empty(),
+            "an in-flight job the request never touched should not be \
+             reported: {:?}",
+            result.blocked
+        );
+
+        let stored = store
+            .get_job(now_millis(), &affected.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(stored.budgets.is_empty());
+    }
+
+    /// A finished job's bindings are inert — it will never dispatch and
+    /// is already untracked — so it is neither changed nor reported.
+    #[tokio::test]
+    async fn terminal_jobs_are_not_reported() {
+        let store = test_store_with_retention(60_000, 60_000);
+        store
+            .create_budget("stripe", 100, BudgetStrategy::WhileInFlight, NOW)
+            .await
+            .unwrap();
+        let job = enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        store
+            .take_next_job(now_millis(), &HashSet::new())
+            .await
+            .unwrap()
+            .unwrap();
+        store.mark_completed(now_millis(), &job.id).await.unwrap();
+
+        let result = store
+            .patch_jobs_budgets(JobFilter::new(), BudgetMutation::RemoveAll, now_millis())
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 0);
+        assert!(
+            result.blocked.is_empty(),
+            "a finished job cannot be acted on: {:?}",
+            result.blocked
+        );
+    }
+
+    /// Wrong for every job the filter could match, so it refuses rather
+    /// than getting half way through.
+    #[tokio::test]
+    async fn a_malformed_request_fails_the_whole_batch() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let job = enqueue_bound(&store, &[("stripe", 1)]).await;
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new(),
+                BudgetMutation::Add(BudgetBinding::new("ghost")),
+                now_millis(),
+            )
+            .await;
+        assert!(matches!(result, Err(StoreError::InvalidOperation(_))));
+
+        // Nothing moved.
+        let stored = store.get_job(now_millis(), &job.id).await.unwrap().unwrap();
+        assert_eq!(stored.budgets.len(), 1);
+        assert_eq!(store.budgets.tracked("stripe"), 1);
+    }
+
+    /// The filter narrows what is touched, so jobs outside it keep their
+    /// bindings.
+    #[tokio::test]
+    async fn only_matching_jobs_are_changed() {
+        let store = store_with_budgets(&["stripe"]).await;
+        let inside = store
+            .enqueue(
+                now_millis(),
+                EnqueueOptions::new("t", "wanted", serde_json::json!({})),
+            )
+            .await
+            .unwrap()
+            .into_job();
+        let outside = store
+            .enqueue(
+                now_millis(),
+                EnqueueOptions::new("t", "other", serde_json::json!({})),
+            )
+            .await
+            .unwrap()
+            .into_job();
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new().queues(HashSet::from(["wanted".to_string()])),
+                BudgetMutation::Add(BudgetBinding::new("stripe")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 1);
+        assert!(
+            !store
+                .get_job(now_millis(), &inside.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .budgets
+                .is_empty()
+        );
+        assert!(
+            store
+                .get_job(now_millis(), &outside.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .budgets
+                .is_empty()
+        );
+    }
+
+    /// Matching nothing is a success that did nothing, not an error.
+    #[tokio::test]
+    async fn matching_no_jobs_changes_nothing() {
+        let store = store_with_budgets(&["stripe"]).await;
+
+        let result = store
+            .patch_jobs_budgets(
+                JobFilter::new().queues(HashSet::from(["absent".to_string()])),
+                BudgetMutation::Add(BudgetBinding::new("stripe")),
+                now_millis(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.changed, 0);
+        assert!(result.blocked.is_empty());
     }
 
     /// Scheduled jobs are not placed for dispatch, but they are counted:

--- a/src/store/budget/mod.rs
+++ b/src/store/budget/mod.rs
@@ -27,11 +27,8 @@ mod mutation;
 mod ops;
 mod registry;
 
-#[allow(
-    unused_imports,
-    reason = "consumed by the job-budget store operation and its routes"
-)]
-pub(in crate::store) use mutation::{BudgetMutation, BudgetMutationError, BudgetMutationOutcome};
+pub use job_ops::JobBudgetChange;
+pub use mutation::BudgetMutation;
 pub(in crate::store) use registry::Budgets;
 
 pub(in crate::store) use ops::{

--- a/src/store/budget/mod.rs
+++ b/src/store/budget/mod.rs
@@ -22,9 +22,15 @@
 
 mod costs;
 mod limiter;
+mod mutation;
 mod ops;
 mod registry;
 
+#[allow(
+    unused_imports,
+    reason = "consumed by the job-budget store operation and its routes"
+)]
+pub(in crate::store) use mutation::{BudgetMutation, BudgetMutationError, BudgetMutationOutcome};
 pub(in crate::store) use registry::Budgets;
 
 pub(in crate::store) use ops::{

--- a/src/store/budget/mod.rs
+++ b/src/store/budget/mod.rs
@@ -21,6 +21,7 @@
 //! sibling `ops` submodule.
 
 mod costs;
+mod job_ops;
 mod limiter;
 mod mutation;
 mod ops;

--- a/src/store/budget/mutation.rs
+++ b/src/store/budget/mutation.rs
@@ -29,14 +29,6 @@
 //! the cost accounting are all the transaction's problem, and are tested
 //! separately from the question of what the caller asked for.
 
-// Everything here is consumed by the store operation that applies a
-// mutation inside a transaction, and by the routes over it. Staged as
-// one attribute rather than six, since it comes off in one go.
-#![allow(
-    dead_code,
-    reason = "consumed by the job-budget store operation and its routes"
-)]
-
 use super::{BudgetBinding, BudgetRef};
 
 /// A change to the set of budgets a job draws on.
@@ -45,7 +37,7 @@ use super::{BudgetBinding, BudgetRef};
 /// value applies correctly to any job regardless of what it is bound to
 /// already.
 #[derive(Debug, Clone)]
-pub(in crate::store) enum BudgetMutation {
+pub enum BudgetMutation {
     /// Replace every binding with these.
     ///
     /// The one whole-set operation, and the reason it is confined to a
@@ -110,6 +102,18 @@ pub(in crate::store) enum BudgetMutationError {
     /// [`BudgetMutation::SetCost`] against one it does not.
     NotBound(String),
 
+    /// A binding was given a cost of zero.
+    ///
+    /// "Draws on this budget without consuming any of it" is
+    /// indistinguishable from not naming it — and worse than useless:
+    /// a job that dispatches without decreasing a bucket is what the
+    /// budget waker's termination argument rules out, since its loop
+    /// spends a token per turn to make progress.
+    ///
+    /// Enqueue rejects this in `prepare_enqueue`; every other way a
+    /// binding can be created goes through here.
+    ZeroCost(String),
+
     /// The requested set names one budget more than once.
     ///
     /// A job draws on a budget once, at one cost; two entries for the
@@ -134,6 +138,7 @@ impl BudgetMutation {
             Self::ReplaceAll(bindings) => to_refs(bindings)?,
 
             Self::Add(binding) => {
+                check_cost(binding)?;
                 if let Some(existing) = find(current, &binding.key) {
                     return Err(BudgetMutationError::AlreadyBound(existing.key.clone()));
                 }
@@ -143,6 +148,7 @@ impl BudgetMutation {
             }
 
             Self::Set(binding) => {
+                check_cost(binding)?;
                 let mut next = current.to_vec();
                 match next.iter_mut().find(|r| r.key == binding.key) {
                     // Replaced whole rather than field by field. The key
@@ -162,6 +168,9 @@ impl BudgetMutation {
             }
 
             Self::SetCost { key, cost } => {
+                if *cost == 0 {
+                    return Err(BudgetMutationError::ZeroCost(key.clone()));
+                }
                 let mut next = current.to_vec();
                 match next.iter_mut().find(|r| &r.key == key) {
                     Some(existing) => existing.cost = *cost,
@@ -186,17 +195,28 @@ impl BudgetMutation {
         }
     }
 
-    /// The bindings this mutation introduces, if any.
+    /// Every binding whose cost this mutation sets.
     ///
-    /// What the transaction has to validate and possibly create: these
-    /// carry `create_with`, which the stored form drops. Removals and
-    /// cost changes introduce nothing, since a job cannot be bound to a
-    /// budget that was never resolved in the first place.
-    pub(in crate::store) fn introduced(&self) -> &[BudgetBinding] {
+    /// What the transaction has to validate: each named budget must
+    /// exist — or be creatable, for those carrying a `create_with` — and
+    /// each cost must fit what that budget's bucket can hold.
+    ///
+    /// **A cost change belongs here even though it introduces nothing.**
+    /// An earlier version asked which bindings were *introduced*, on the
+    /// grounds that a job cannot already be bound to a budget that was
+    /// never resolved. True of existence, and false of cost: raising a
+    /// cost above the bucket's capacity leaves a job that can never be
+    /// afforded however long it waits, which is exactly the stall the
+    /// capacity check exists to prevent.
+    ///
+    /// Removals are genuinely exempt. Unbinding a budget cannot make a
+    /// job unaffordable, and neither can leaving the others alone.
+    pub(in crate::store) fn costed(&self) -> Vec<BudgetBinding> {
         match self {
-            Self::ReplaceAll(bindings) => bindings,
-            Self::Add(binding) | Self::Set(binding) => std::slice::from_ref(binding),
-            Self::SetCost { .. } | Self::Remove { .. } | Self::RemoveAll => &[],
+            Self::ReplaceAll(bindings) => bindings.clone(),
+            Self::Add(binding) | Self::Set(binding) => vec![binding.clone()],
+            Self::SetCost { key, cost } => vec![BudgetBinding::new(key.clone()).cost(*cost)],
+            Self::Remove { .. } | Self::RemoveAll => Vec::new(),
         }
     }
 }
@@ -206,6 +226,7 @@ fn to_refs(bindings: &[BudgetBinding]) -> Result<Vec<BudgetRef>, BudgetMutationE
     let mut refs: Vec<BudgetRef> = Vec::with_capacity(bindings.len());
 
     for binding in bindings {
+        check_cost(binding)?;
         if refs.iter().any(|r| r.key == binding.key) {
             return Err(BudgetMutationError::DuplicateKey(binding.key.clone()));
         }
@@ -213,6 +234,14 @@ fn to_refs(bindings: &[BudgetBinding]) -> Result<Vec<BudgetRef>, BudgetMutationE
     }
 
     Ok(refs)
+}
+
+/// Reject a binding that would consume nothing.
+fn check_cost(binding: &BudgetBinding) -> Result<(), BudgetMutationError> {
+    if binding.cost == 0 {
+        return Err(BudgetMutationError::ZeroCost(binding.key.clone()));
+    }
+    Ok(())
 }
 
 /// The binding to `key`, if the job has one.
@@ -429,43 +458,79 @@ mod tests {
         );
     }
 
+    /// A job that dispatches without decreasing a bucket is what the
+    /// waker's termination argument rules out, so no route may create
+    /// one — enqueue rejects it separately, and this covers the rest.
+    #[test]
+    fn a_zero_cost_is_refused_however_it_arrives() {
+        let current = [drawn("stripe", 1)];
+
+        assert_eq!(
+            BudgetMutation::Add(binding("mailgun", 0)).apply(&current),
+            Err(BudgetMutationError::ZeroCost("mailgun".into()))
+        );
+        assert_eq!(
+            BudgetMutation::Set(binding("mailgun", 0)).apply(&current),
+            Err(BudgetMutationError::ZeroCost("mailgun".into()))
+        );
+        assert_eq!(
+            BudgetMutation::SetCost {
+                key: "stripe".into(),
+                cost: 0
+            }
+            .apply(&current),
+            Err(BudgetMutationError::ZeroCost("stripe".into()))
+        );
+        assert_eq!(
+            BudgetMutation::ReplaceAll(vec![binding("stripe", 0)]).apply(&current),
+            Err(BudgetMutationError::ZeroCost("stripe".into()))
+        );
+    }
+
     // --- introduced ---
 
-    /// The transaction validates and may create only what a mutation
-    /// brings in. Removals and cost changes bring in nothing, so they
-    /// need no budget resolution at all.
+    /// The transaction checks every cost a mutation sets against what
+    /// the budget can hold.
     #[test]
-    fn only_binding_mutations_introduce_budgets() {
-        assert_eq!(
-            BudgetMutation::Add(binding("stripe", 1)).introduced().len(),
-            1
-        );
-        assert_eq!(
-            BudgetMutation::Set(binding("stripe", 1)).introduced().len(),
-            1
-        );
+    fn every_mutation_that_sets_a_cost_offers_it_for_checking() {
+        assert_eq!(BudgetMutation::Add(binding("stripe", 1)).costed().len(), 1);
+        assert_eq!(BudgetMutation::Set(binding("stripe", 1)).costed().len(), 1);
         assert_eq!(
             BudgetMutation::ReplaceAll(vec![binding("a", 1), binding("b", 2)])
-                .introduced()
+                .costed()
                 .len(),
             2
         );
+    }
 
-        assert!(
-            BudgetMutation::SetCost {
-                key: "stripe".into(),
-                cost: 2
-            }
-            .introduced()
-            .is_empty()
-        );
+    /// The one that is easy to miss, and did go missing: a cost change
+    /// introduces no binding, but the new cost still has to fit the
+    /// bucket. Raising it past capacity leaves a job that can never be
+    /// afforded however long it waits.
+    #[test]
+    fn a_cost_change_offers_the_new_cost_for_checking() {
+        let costed = BudgetMutation::SetCost {
+            key: "stripe".into(),
+            cost: 9,
+        }
+        .costed();
+
+        assert_eq!(costed.len(), 1);
+        assert_eq!(costed[0].key, "stripe");
+        assert_eq!(costed[0].cost, 9);
+    }
+
+    /// Removals are genuinely exempt: unbinding cannot make a job
+    /// unaffordable.
+    #[test]
+    fn removals_need_no_checking() {
         assert!(
             BudgetMutation::Remove {
                 key: "stripe".into()
             }
-            .introduced()
+            .costed()
             .is_empty()
         );
-        assert!(BudgetMutation::RemoveAll.introduced().is_empty());
+        assert!(BudgetMutation::RemoveAll.costed().is_empty());
     }
 }

--- a/src/store/budget/mutation.rs
+++ b/src/store/budget/mutation.rs
@@ -1,0 +1,471 @@
+// Copyright (c) 2026 Chris Corbyn <chris@zizq.io>
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+
+//! Changing which budgets a job draws on.
+//!
+//! Every route for managing a job's bindings maps onto one variant of
+//! [`BudgetMutation`], so the rules about what may replace what live
+//! here once rather than per endpoint.
+//!
+//! # Why a mutation rather than a new set of bindings
+//!
+//! The obvious alternative — have the caller read a job's bindings,
+//! change them, and hand back the whole set — cannot be made atomic
+//! without holding a lock across the read and the write. Describing the
+//! *change* lets the store apply it inside the transaction that reads
+//! the job, so two callers adding different budgets to one job cannot
+//! lose each other's work.
+//!
+//! It is also what makes the bulk routes possible at all. "Add this
+//! budget to everything matching" is one mutation applied to N jobs;
+//! expressed as whole sets it would be N different documents the caller
+//! would have to compute from N reads.
+//!
+//! # Nothing here touches the keyspace
+//!
+//! Deliberately pure: given the bindings a job has, work out the ones it
+//! should have. Whether those budgets exist, whether their costs fit,
+//! where the job then sits in the dispatch groups, and what that does to
+//! the cost accounting are all the transaction's problem, and are tested
+//! separately from the question of what the caller asked for.
+
+// Everything here is consumed by the store operation that applies a
+// mutation inside a transaction, and by the routes over it. Staged as
+// one attribute rather than six, since it comes off in one go.
+#![allow(
+    dead_code,
+    reason = "consumed by the job-budget store operation and its routes"
+)]
+
+use super::{BudgetBinding, BudgetRef};
+
+/// A change to the set of budgets a job draws on.
+///
+/// Names the *operation*, not the resulting state, so that the same
+/// value applies correctly to any job regardless of what it is bound to
+/// already.
+#[derive(Debug, Clone)]
+pub(in crate::store) enum BudgetMutation {
+    /// Replace every binding with these.
+    ///
+    /// The one whole-set operation, and the reason it is confined to a
+    /// single addressed job: replacing a set is only a sound thing to
+    /// ask for when the caller knows what is being replaced, which over
+    /// a filtered selection they do not.
+    ReplaceAll(Vec<BudgetBinding>),
+
+    /// Bind a budget the job does not already draw on.
+    ///
+    /// Refuses rather than overwrites, so a caller adding a binding
+    /// cannot silently change a cost someone else set.
+    Add(BudgetBinding),
+
+    /// Bind a budget, replacing any existing binding to it.
+    Set(BudgetBinding),
+
+    /// Change the cost of a binding the job already has.
+    ///
+    /// Distinct from [`Self::Set`] in refusing to create one. A caller
+    /// adjusting a cost has a job in mind that it believes is already
+    /// throttled, and creating the binding instead would silently
+    /// throttle a job that was not.
+    SetCost { key: String, cost: u32 },
+
+    /// Unbind one budget.
+    Remove { key: String },
+
+    /// Unbind every budget, leaving the job unthrottled.
+    RemoveAll,
+}
+
+/// What applying a mutation did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::store) enum BudgetMutationOutcome {
+    /// The bindings changed, and these are the new ones.
+    Changed(Vec<BudgetRef>),
+
+    /// The job already satisfied the request, so there is nothing to
+    /// write.
+    ///
+    /// Worth distinguishing from `Changed`: a job whose bindings did not
+    /// move does not need its record rewritten, its placement disturbed,
+    /// or its cost accounting touched — and a bulk operation wants to
+    /// report how many jobs it actually changed rather than how many it
+    /// looked at.
+    Unchanged,
+}
+
+/// Why a mutation could not be applied.
+///
+/// Reported rather than absorbed, because the two callers want opposite
+/// things from them. A route addressing one job turns them into `409`
+/// and `404` — the caller specified a job and was wrong about it. A bulk
+/// route skips the job and moves on, since "add this budget to
+/// everything matching" is not wrong about the ones already bound.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::store) enum BudgetMutationError {
+    /// [`BudgetMutation::Add`] against a budget the job already draws on.
+    AlreadyBound(String),
+
+    /// [`BudgetMutation::SetCost`] against one it does not.
+    NotBound(String),
+
+    /// The requested set names one budget more than once.
+    ///
+    /// A job draws on a budget once, at one cost; two entries for the
+    /// same key are a contradiction rather than an addition, and
+    /// silently keeping the last would be a coin toss over which the
+    /// caller meant.
+    DuplicateKey(String),
+}
+
+impl BudgetMutation {
+    /// Work out the bindings a job should have after this change.
+    ///
+    /// `current` is what it has now. Returns [`Unchanged`] when the two
+    /// would be the same, so the caller can skip the write entirely.
+    ///
+    /// [`Unchanged`]: BudgetMutationOutcome::Unchanged
+    pub(in crate::store) fn apply(
+        &self,
+        current: &[BudgetRef],
+    ) -> Result<BudgetMutationOutcome, BudgetMutationError> {
+        let next = match self {
+            Self::ReplaceAll(bindings) => to_refs(bindings)?,
+
+            Self::Add(binding) => {
+                if let Some(existing) = find(current, &binding.key) {
+                    return Err(BudgetMutationError::AlreadyBound(existing.key.clone()));
+                }
+                let mut next = current.to_vec();
+                next.push(binding.to_ref());
+                next
+            }
+
+            Self::Set(binding) => {
+                let mut next = current.to_vec();
+                match next.iter_mut().find(|r| r.key == binding.key) {
+                    // Replaced whole rather than field by field. The key
+                    // is already known equal, so this is the same result
+                    // today — but `Set` means "this binding is now that
+                    // one", and saying it that way keeps it true when
+                    // `BudgetRef` grows a field. Assigning `cost` alone
+                    // would quietly drop the new one.
+                    //
+                    // `SetCost` deliberately does the opposite: it names
+                    // the one field it changes, because that is what it
+                    // means.
+                    Some(existing) => *existing = binding.to_ref(),
+                    None => next.push(binding.to_ref()),
+                }
+                next
+            }
+
+            Self::SetCost { key, cost } => {
+                let mut next = current.to_vec();
+                match next.iter_mut().find(|r| &r.key == key) {
+                    Some(existing) => existing.cost = *cost,
+                    None => return Err(BudgetMutationError::NotBound(key.clone())),
+                }
+                next
+            }
+
+            Self::Remove { key } => current.iter().filter(|r| &r.key != key).cloned().collect(),
+
+            Self::RemoveAll => Vec::new(),
+        };
+
+        // Compared rather than assumed, because several of these reach
+        // the same state by different routes — setting a cost to what it
+        // already is, removing a budget that was never bound, replacing
+        // a set with itself. None of them should cost a write.
+        if next == current {
+            Ok(BudgetMutationOutcome::Unchanged)
+        } else {
+            Ok(BudgetMutationOutcome::Changed(next))
+        }
+    }
+
+    /// The bindings this mutation introduces, if any.
+    ///
+    /// What the transaction has to validate and possibly create: these
+    /// carry `create_with`, which the stored form drops. Removals and
+    /// cost changes introduce nothing, since a job cannot be bound to a
+    /// budget that was never resolved in the first place.
+    pub(in crate::store) fn introduced(&self) -> &[BudgetBinding] {
+        match self {
+            Self::ReplaceAll(bindings) => bindings,
+            Self::Add(binding) | Self::Set(binding) => std::slice::from_ref(binding),
+            Self::SetCost { .. } | Self::Remove { .. } | Self::RemoveAll => &[],
+        }
+    }
+}
+
+/// Narrow a requested set to its stored form, rejecting repeats.
+fn to_refs(bindings: &[BudgetBinding]) -> Result<Vec<BudgetRef>, BudgetMutationError> {
+    let mut refs: Vec<BudgetRef> = Vec::with_capacity(bindings.len());
+
+    for binding in bindings {
+        if refs.iter().any(|r| r.key == binding.key) {
+            return Err(BudgetMutationError::DuplicateKey(binding.key.clone()));
+        }
+        refs.push(binding.to_ref());
+    }
+
+    Ok(refs)
+}
+
+/// The binding to `key`, if the job has one.
+fn find<'a>(current: &'a [BudgetRef], key: &str) -> Option<&'a BudgetRef> {
+    current.iter().find(|r| r.key == key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drawn(key: &str, cost: u32) -> BudgetRef {
+        BudgetRef::new(key).cost(cost)
+    }
+
+    fn binding(key: &str, cost: u32) -> BudgetBinding {
+        BudgetBinding::new(key).cost(cost)
+    }
+
+    fn changed(outcome: BudgetMutationOutcome) -> Vec<BudgetRef> {
+        match outcome {
+            BudgetMutationOutcome::Changed(refs) => refs,
+            BudgetMutationOutcome::Unchanged => panic!("expected a change"),
+        }
+    }
+
+    // --- ReplaceAll ---
+
+    #[test]
+    fn replace_all_takes_the_requested_set_whole() {
+        let current = [drawn("stripe", 1), drawn("mailgun", 2)];
+        let mutation = BudgetMutation::ReplaceAll(vec![binding("ses", 5)]);
+
+        assert_eq!(
+            changed(mutation.apply(&current).unwrap()),
+            vec![drawn("ses", 5)]
+        );
+    }
+
+    #[test]
+    fn replace_all_with_an_empty_set_unbinds_everything() {
+        let current = [drawn("stripe", 1)];
+        let mutation = BudgetMutation::ReplaceAll(Vec::new());
+
+        assert_eq!(changed(mutation.apply(&current).unwrap()), Vec::new());
+    }
+
+    /// Two entries for one key are a contradiction, not an addition —
+    /// keeping the last would be a coin toss over which was meant.
+    #[test]
+    fn replace_all_rejects_a_repeated_key() {
+        let mutation = BudgetMutation::ReplaceAll(vec![binding("stripe", 1), binding("stripe", 9)]);
+
+        assert_eq!(
+            mutation.apply(&[]),
+            Err(BudgetMutationError::DuplicateKey("stripe".into()))
+        );
+    }
+
+    // --- Add ---
+
+    #[test]
+    fn add_binds_a_budget_the_job_lacks() {
+        let current = [drawn("stripe", 1)];
+        let mutation = BudgetMutation::Add(binding("mailgun", 3));
+
+        assert_eq!(
+            changed(mutation.apply(&current).unwrap()),
+            vec![drawn("stripe", 1), drawn("mailgun", 3)]
+        );
+    }
+
+    /// Refusing rather than overwriting: a caller adding a binding must
+    /// not silently change a cost someone else set.
+    #[test]
+    fn add_refuses_a_budget_already_bound() {
+        let current = [drawn("stripe", 1)];
+        let mutation = BudgetMutation::Add(binding("stripe", 9));
+
+        assert_eq!(
+            mutation.apply(&current),
+            Err(BudgetMutationError::AlreadyBound("stripe".into()))
+        );
+    }
+
+    // --- Set ---
+
+    #[test]
+    fn set_binds_when_absent_and_replaces_when_present() {
+        let current = [drawn("stripe", 1)];
+
+        assert_eq!(
+            changed(
+                BudgetMutation::Set(binding("stripe", 9))
+                    .apply(&current)
+                    .unwrap()
+            ),
+            vec![drawn("stripe", 9)]
+        );
+        assert_eq!(
+            changed(
+                BudgetMutation::Set(binding("ses", 4))
+                    .apply(&current)
+                    .unwrap()
+            ),
+            vec![drawn("stripe", 1), drawn("ses", 4)]
+        );
+    }
+
+    /// Replacing a binding leaves it where it was rather than moving it
+    /// to the end. Order is not meaningful to dispatch, but a read-back
+    /// that reshuffles for no reason is a poor answer to a cost change.
+    #[test]
+    fn set_keeps_an_existing_binding_in_place() {
+        let current = [drawn("a", 1), drawn("b", 2), drawn("c", 3)];
+        let mutation = BudgetMutation::Set(binding("b", 9));
+
+        assert_eq!(
+            changed(mutation.apply(&current).unwrap()),
+            vec![drawn("a", 1), drawn("b", 9), drawn("c", 3)]
+        );
+    }
+
+    // --- SetCost ---
+
+    #[test]
+    fn set_cost_changes_an_existing_binding() {
+        let current = [drawn("stripe", 1)];
+        let mutation = BudgetMutation::SetCost {
+            key: "stripe".into(),
+            cost: 7,
+        };
+
+        assert_eq!(
+            changed(mutation.apply(&current).unwrap()),
+            vec![drawn("stripe", 7)]
+        );
+    }
+
+    /// Unlike `Set`, this will not create one: a caller adjusting a cost
+    /// believes the job is already throttled, and quietly throttling one
+    /// that was not is the opposite of what they asked for.
+    #[test]
+    fn set_cost_refuses_a_budget_not_bound() {
+        let mutation = BudgetMutation::SetCost {
+            key: "stripe".into(),
+            cost: 7,
+        };
+
+        assert_eq!(
+            mutation.apply(&[]),
+            Err(BudgetMutationError::NotBound("stripe".into()))
+        );
+    }
+
+    // --- Remove ---
+
+    #[test]
+    fn remove_unbinds_one_and_leaves_the_rest() {
+        let current = [drawn("stripe", 1), drawn("mailgun", 2)];
+        let mutation = BudgetMutation::Remove {
+            key: "stripe".into(),
+        };
+
+        assert_eq!(
+            changed(mutation.apply(&current).unwrap()),
+            vec![drawn("mailgun", 2)]
+        );
+    }
+
+    #[test]
+    fn remove_all_unbinds_everything() {
+        let current = [drawn("stripe", 1), drawn("mailgun", 2)];
+
+        assert_eq!(
+            changed(BudgetMutation::RemoveAll.apply(&current).unwrap()),
+            Vec::new()
+        );
+    }
+
+    // --- Unchanged ---
+
+    /// Several of these reach the state the job is already in, and none
+    /// of them should cost a write, a placement move, or a change to the
+    /// cost accounting.
+    #[test]
+    fn a_request_the_job_already_satisfies_changes_nothing() {
+        let current = [drawn("stripe", 1)];
+
+        for mutation in [
+            BudgetMutation::Set(binding("stripe", 1)),
+            BudgetMutation::SetCost {
+                key: "stripe".into(),
+                cost: 1,
+            },
+            BudgetMutation::Remove {
+                key: "mailgun".into(),
+            },
+            BudgetMutation::ReplaceAll(vec![binding("stripe", 1)]),
+        ] {
+            assert_eq!(
+                mutation.apply(&current).unwrap(),
+                BudgetMutationOutcome::Unchanged,
+                "{mutation:?} should have been a no-op"
+            );
+        }
+    }
+
+    #[test]
+    fn unbinding_an_already_unbound_job_changes_nothing() {
+        assert_eq!(
+            BudgetMutation::RemoveAll.apply(&[]).unwrap(),
+            BudgetMutationOutcome::Unchanged
+        );
+    }
+
+    // --- introduced ---
+
+    /// The transaction validates and may create only what a mutation
+    /// brings in. Removals and cost changes bring in nothing, so they
+    /// need no budget resolution at all.
+    #[test]
+    fn only_binding_mutations_introduce_budgets() {
+        assert_eq!(
+            BudgetMutation::Add(binding("stripe", 1)).introduced().len(),
+            1
+        );
+        assert_eq!(
+            BudgetMutation::Set(binding("stripe", 1)).introduced().len(),
+            1
+        );
+        assert_eq!(
+            BudgetMutation::ReplaceAll(vec![binding("a", 1), binding("b", 2)])
+                .introduced()
+                .len(),
+            2
+        );
+
+        assert!(
+            BudgetMutation::SetCost {
+                key: "stripe".into(),
+                cost: 2
+            }
+            .introduced()
+            .is_empty()
+        );
+        assert!(
+            BudgetMutation::Remove {
+                key: "stripe".into()
+            }
+            .introduced()
+            .is_empty()
+        );
+        assert!(BudgetMutation::RemoveAll.introduced().is_empty());
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -52,8 +52,8 @@ pub use storage_config::{
 pub use store::{Store, StoreEvent};
 
 pub use budget::{
-    Budget, BudgetBinding, BudgetPolicy, BudgetRef, BudgetStrategy, DEFAULT_BUDGET_COST,
-    MAX_BUDGET_ALLOCATION,
+    Budget, BudgetBinding, BudgetMutation, BudgetPolicy, BudgetRef, BudgetStrategy,
+    DEFAULT_BUDGET_COST, JobBudgetChange, MAX_BUDGET_ALLOCATION,
 };
 
 pub use cron::{CronEntry, CronGroup};


### PR DESCRIPTION
Adds single-job and bulk-job endpoints to add, remove, replace or update the budgets bound to each job.

Single jobs:

- `POST /jobs/{id}/budgets/{key}` - create one - 201 or 409
- `PUT /jobs/{id}/budgets/{key}` - replace one - 200
- `PATCH /jobs/{id}/budgets/{key}` - update one - 200 or 404
- `DELETE /jobs/{id}/budgets/{key}` - remove one - 200 or 404
- `PUT /jobs/{id}/budgets` - replace all - 200
- `DELETE /jobs/{id}/budgets` - remove all - 200

Bulk jobs:

- `POST /jobs/budgets/{key}` - add one - 200
- `DELETE /jobs/budgets/{key}` - remove one - 200
- `PUT /jobs/budgets/{key}` - replace one - 200
- `PATCH /jobs/budgets/{key}` - update one - 200
- `DELETE /jobs/budgets` - remove all - 200
