### PR TITLE
Add Docs for Budgets (Rate Limiting and Concurrency Control).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,143 +1,24 @@
 # Changelog
 
-## 0.7.0 (Unreleased)
+## 0.7.0
 
-- Added **budgets**, a server-side throttle on how fast jobs are
-  dispatched. A budget is a named token bucket that jobs draw from; a
-  job whose budgets have no capacity waits until they replenish.
-  Workers are unaware of any of it — a throttled job looks like any
-  other when it finally arrives. Pro tier, alongside unique jobs, cron
-  and batching.
+- Added **budgets**, server-side concurrency control and rate limiting.
+  A budget is a named token bucket that jobs draw from; a job whose
+  budgets have no capacity waits until they replenish. Workers are
+  unaware of any of it — a throttled job looks like any other when it
+  finally arrives.
 
   Two strategies, covering the two things people mean by "rate limit":
 
   - `time_based` refills the whole allocation every `duration_ms`, as a
-    continuous drip rather than in fixed windows. A counter that reset
-    on the minute would allow the allocation at 59.9s and again at
-    60.0s — twice the configured rate across the boundary, every
-    boundary. Accrual is computed lazily from elapsed time, so an idle
-    budget costs nothing.
+    continuous drip rather than in fixed windows. Accrual is computed
+    lazily from elapsed time, so an idle budget costs nothing.
   - `while_in_flight` returns a token when the job leaves the in-flight
     state, by acknowledgement, failure, deletion or worker disconnect.
-    This is a concurrency limit, of which a mutex is the
-    `allocation: 1` case.
+    This is a concurrency limit, of which a mutex is the `allocation: 1`
+    case.
 
-  Budgets are managed at `GET /budgets`, and `GET` / `POST` / `PUT` /
-  `PATCH` / `DELETE` on `/budgets/{key}`. `POST` creates and returns
-  `409` if the key is taken, so an application can declare the budgets
-  it expects on every boot without clobbering an allocation an operator
-  tightened during an incident; `PUT` replaces a policy whole and
-  `PATCH` merges named fields. A budget's `created_at` survives both.
-
-  Jobs bind to budgets with a `budgets` array on enqueue, each entry
-  naming a `key` and an optional `cost` (default 1). A job may draw on
-  several, and acquires from all of them or none. An entry may carry a
-  `create_with` policy, which creates the budget if it does not exist
-  and is ignored if it does — the server stays authoritative, so an
-  enqueue can never quietly restate a throttle. Referencing a budget
-  that does not exist without a `create_with` is rejected with `422`
-  rather than dispatching unthrottled. Bindings are returned on every
-  read of a job for visibility.
-
-  `time_based` also takes an optional `burst` alongside `duration_ms`,
-  capping how many tokens may be banked without changing how fast they
-  arrive. A bucket starts full, so the first work after an idle period
-  draws a whole allocation at once and only then settles to the drip —
-  meaning `10 per minute` permits twenty in the first minute. That
-  overshoot is a one-off and the long-run rate is unaffected, but it is
-  visible, and `burst: 1` removes it entirely by pacing dispatches
-  evenly. A burst above the allocation is allowed, and banks several
-  idle periods. Note that where a burst is set it is the burst, not the
-  allocation, that a job's `cost` must fit inside.
-
-  Cron entries may reference budgets in their job template. Budgets a
-  template needs are created when the entry is installed rather than
-  when it first fires, so an entry cannot be accepted into a schedule
-  and then turn out to be unfireable because the server has since
-  reached its budget cap.
-
-  A budget cannot be deleted, or have its allocation shrunk below a
-  cost already committed to it, while anything still draws on it —
-  unfinished jobs or a cron entry's template. Both are reported
-  separately, because the remedies differ: a job will drain on its own,
-  where a cron entry is a standing claim that has to be edited. A
-  budget referenced only by finished jobs deletes cleanly.
-
-  The number of budgets a server will hold is capped by
-  `--max-budgets` / `ZIZQ_MAX_BUDGETS`, defaulting to 8192. The limit
-  exists because budget keys can be generated from application data,
-  and remain peristed indefinitely. Future releases will enable more
-  dynamic sub-buckets within budgets.
-
-  A job's budgets can be changed after it is enqueued, through routes on
-  `/jobs/{id}/budgets`: `POST` a key to bind one (409 if already bound,
-  and `create_with` works here as it does on an enqueue), `PUT` to bind
-  or replace, `PATCH` to change what it draws, `DELETE` to unbind.
-  `PUT /jobs/{id}/budgets` replaces the whole set and
-  `DELETE /jobs/{id}/budgets` clears it. Only queued jobs may change —
-  an in-flight job holds tokens against the bindings it was dispatched
-  under, so moving them would either invent a slot on the new budget or
-  strand one on the old, and the request is refused with 422.
-
-  The same operations work across a filtered set, taking the same
-  filters as the other bulk job routes: `POST` / `PUT` / `PATCH` /
-  `DELETE /jobs/budgets/{key}` and `DELETE /jobs/budgets`. These skip
-  rather than fail on anything true of one job but not the request,
-  since a per-job 409 has nowhere to go in an operation over a matched
-  set. A malformed request still refuses outright, being wrong for every
-  job it could match.
-
-  The response is `{"changed": N, "blocked": [ids]}`. `blocked` names
-  the jobs the mutation *would* have changed but could not, because they
-  were in flight — the one outcome a caller can act on, by retrying
-  those ids once the jobs finish. Jobs the mutation simply did not apply
-  to are absent: an `Add` against a job already bound, or a `Remove`
-  against one that never had the binding, is the documented behaviour of
-  the verb rather than a shortfall. Terminal jobs are absent too, their
-  bindings being inert.
-
-  There is deliberately no `PUT /jobs/budgets` to replace whole sets
-  across a filter. A filter naming one budget still matches jobs drawing
-  on others, so replacing would silently discard bindings the caller
-  never mentioned. Splitting a shared budget is two scoped calls
-  instead — `POST /jobs/budgets/new?budgets.key=old` then
-  `DELETE /jobs/budgets/old?budgets.key=old` — each of which leaves
-  bindings it was not asked about alone.
-
-  Jobs can be filtered by budget with `?budgets.key=`, comma-delimited
-  like `queue` and `type`, on `GET /jobs`, `GET /jobs/count`,
-  `PATCH /jobs` and `DELETE /jobs`. It matches a job drawing on any of
-  the named budgets. This is what makes the refusal above actionable:
-  `DELETE /jobs?budgets.key=stripe` clears the jobs holding a budget
-  open so it can then be deleted. There is no index from budget to job,
-  so combined with a `status`, `queue`, `type` or `id` filter it narrows
-  within that scan, and on its own it is a full scan — the same cost
-  profile the existing payload filter carries.
-
-  Policy changes take effect immediately, including on work already
-  running. Narrowing a `while_in_flight` budget below what is currently
-  in flight leaves it over-committed, and those slots are surrendered as
-  jobs finish rather than handed straight to replacements — so cutting
-  an allocation from six to one while six are running settles back to
-  one, instead of staying at six for as long as work keeps arriving.
-
-  Policy changes also take effect immediately on jobs already waiting.
-  Speeding a rate limit up re-arms the dispatcher rather than
-  leaving parked jobs to wait out the old period, and progress already
-  accrued toward the next token is kept across a change of rate — half a
-  minute spent waiting on a one-a-minute budget still counts when it
-  becomes two a second. Changing the *period* discards that progress,
-  since it is measured against the period it was accrued under.
-
-  `POST /reset` now clears budgets along with jobs and cron groups.
-
-  Token state is deliberately not persisted, so a server restart brings
-  every bucket back full. For a concurrency budget that is simply
-  accurate — recovery returns in-flight jobs to the queue, so nothing
-  holds a slot. For a rate limit it means a restart forgives whatever
-  the previous process had spent, which is the trade-off between an
-  efficient lazily computed in-memory solution vs a slower one that
-  constantly writes to disk to record state.
+  See https://zizq.io/docs/api/rate-limiting.html for full details.
 
 - Added a **group-level cron timezone**. `PUT /crons/{group}` and
   `PATCH /crons/{group}` now accept a `timezone` field alongside

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ planned soon).
 
 ## Features
 
-Zizq supports a growing number of features.
+Zizq supports a number of powerful features.
 
 * Single self-contained executable— no separate data store required
 * Durable and atomic job queues
-* Easy to use `HTTP/1.1` and `HTTP/2` API with JSON or MsgPack
+* Easy to use `HTTP/1.1` and `HTTP/2` API with JSON or MessagePack
 * Cross-language job enqueueing and execution
 * Unlimited named queues
 * FIFO ordered and granular priority jobs
@@ -24,6 +24,8 @@ Zizq supports a growing number of features.
 * Configurable backoff/retry policies
 * Configurable job retention policies
 * Unique job support (deduplicated enqueues)
+* Job concurrency control (max N jobs running at once)
+* Job rate limiting (max N jobs dispatched over time)
 * Cron (recurring jobs) scheduling
 * Batched job support (folded/merged enqueues)
 * APIs to manage the queue contents, including `jq` expression filters
@@ -174,7 +176,10 @@ each ships a worker that runs jobs with a configurable level of concurrency.
 
 Jobs can be enqueued from one language and processed by a worker in another.
 
-#### Node.js — [repo](https://github.com/zizq-labs/zizq-node) · [docs](https://zizq.io/docs/clients/node/)
+#### Node.js
+
+* [Source](https://github.com/zizq-labs/zizq-node)
+* [Docs](https://zizq.io/docs/clients/node/)
 
 ```ts
 import { Client } from "@zizq-labs/zizq";
@@ -188,7 +193,10 @@ await client.enqueue({
 });
 ```
 
-#### Ruby — [repo](https://github.com/zizq-labs/zizq-ruby) · [docs](https://zizq.io/docs/clients/ruby/)
+#### Ruby
+
+* [Source](https://github.com/zizq-labs/zizq-ruby)
+* [Docs](https://zizq.io/docs/clients/ruby/)
 
 ```ruby
 class SendEmailJob
@@ -204,7 +212,10 @@ end
 Zizq.enqueue(SendEmailJob, 42, template: 'welcome')
 ```
 
-#### Elixir — [repo](https://github.com/zizq-labs/zizq-elixir) · [docs](https://zizq.io/docs/clients/elixir/)
+#### Elixir
+
+* [Source](https://github.com/zizq-labs/zizq-elixir)
+* [Docs](https://zizq.io/docs/clients/elixir/)
 
 ```elixir
 defmodule MyApp.SendEmail do
@@ -218,7 +229,10 @@ MyApp.SendEmail.new(%{"user_id" => 42})
 |> Zizq.enqueue(MyApp.Zizq)
 ```
 
-#### Rust — [repo](https://github.com/zizq-labs/zizq-rust) · [docs](https://zizq.io/docs/clients/rust/)
+#### Rust
+
+* [Source](https://github.com/zizq-labs/zizq-rust)
+* [Docs](https://zizq.io/docs/clients/rust/)
 
 ```rust
 #[derive(Serialize, Deserialize, JobKind)]
@@ -230,8 +244,8 @@ struct SendEmail {
 client.enqueue(SendEmail { user_id: 42 }).await?;
 ```
 
-Want a client for Zizq in a language not currently supported?
-[leave a feature request](https://github.com/zizq-labs/zizq/issues) or
+Looking for a client for Zizq in a language not currently supported?
+[Leave a feature request](https://github.com/zizq-labs/zizq/issues) or
 [build your own](https://zizq.io/docs/api/) easily.
 
 ### Viewing live queue activity

--- a/docs/api/src/SUMMARY.md
+++ b/docs/api/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Enqueuing Jobs](./enqueue.md)
 - [Taking & Processing Jobs](./processing.md)
 - [Cron Scheduling](./cron.md)
+- [Concurrency Control & Rate Limiting](./rate-limiting.md)
 - [Querying Job Data](./querying.md)
 - [Modifying Job Data](./modifying.md)
 - [Resetting](./resetting.md)

--- a/docs/api/src/bind-budget-parameters.md
+++ b/docs/api/src/bind-budget-parameters.md
@@ -1,0 +1,117 @@
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>cost</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens the job takes from the budget. Defaults
+                to 1.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>create_with</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Specification from which to create this budget atomically
+                with the binding if it does not already exist. Without this, the
+                budget must exist or a 422 response will be returned. Does not
+                overwrite any existing budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>create_with.allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>create_with.strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>create_with.strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        5 jobs bound to this budget can be in-flight at any
+                        given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>create_with.strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>create_with.strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/api/src/budget-parameters.md
+++ b/docs/api/src/budget-parameters.md
@@ -1,0 +1,108 @@
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be
+                valid UTF-8 and must not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        5 jobs bound to this budget can be in-flight at any
+                        given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/api/src/budget-response.md
+++ b/docs/api/src/budget-response.md
@@ -1,0 +1,125 @@
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for this budget, used to bind jobs to it, and
+                when calling other endpoints that operate on the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        no more than 5 jobs bound to this budget can be
+                        in-flight at any given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>created_at</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                When this budget was created on the server. Unix timestamp in
+                milliseconds.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>updated_at</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                When this budget was last updated. Unix timestamp in
+                milliseconds.
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/api/src/cron-group-entry-response.md
+++ b/docs/api/src/cron-group-entry-response.md
@@ -158,7 +158,6 @@
                 <code>duplicate</code> field set to <code>true</code>. This key
                 is intentionally global across all queues and job types.
                 Clients should prefix it as necessary.
-                <strong>Requires a <em>pro</em> license</strong>.
             </td>
         </tr>
         <tr>
@@ -192,6 +191,92 @@
                     </dd>
                 </dl>
                 The default scope is <code>queued</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.batch</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Optional batched-job configuration. When present, subsequent
+                enqueues sharing the same <code>batch.key</code> are
+                <em>folded</em> into this job's pending payload via the
+                <code>when</code> and <code>fold</code> jq expressions,
+                rather than creating separate pending jobs. All three inner
+                fields are required when this field is set. Mutually exclusive
+                with <code>unique_key</code> — supplying both returns
+                <code>400 Bad Request</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.batch.key</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Identifies the batch. Only one unsealed batched job exists
+                per key at a time. Enqueues sharing this key fold into the
+                existing pending job (or start a new one if none exists or
+                the existing batch was already sealed).
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.batch.when</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> predicate that
+                decides whether an incoming enqueue folds into the existing
+                pending job. Evaluated with <code>$existing</code> bound to
+                the current pending payload and <code>$new</code> bound to
+                the incoming payload. Truthy means fold; falsy seals the
+                existing batch and starts a fresh one from the incoming
+                enqueue. Invalid jq syntax, or an expression that returns
+                multiple outputs, returns <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.batch.fold</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> expression that
+                produces the merged payload when a fold occurs. Runs with the
+                same <code>$existing</code> and <code>$new</code> bindings as
+                <code>when</code>. Must produce exactly one output; multiple
+                outputs return <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>job.budgets[*].cost</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget.
             </td>
         </tr>
         <tr>

--- a/docs/api/src/cron-group-response.md
+++ b/docs/api/src/cron-group-response.md
@@ -224,7 +224,6 @@
                 <code>duplicate</code> field set to <code>true</code>. This key
                 is intentionally global across all queues and job types.
                 Clients should prefix it as necessary.
-                <strong>Requires a <em>pro</em> license</strong>.
             </td>
         </tr>
         <tr>
@@ -258,6 +257,92 @@
                     </dd>
                 </dl>
                 The default scope is <code>queued</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Optional batched-job configuration. When present, subsequent
+                enqueues sharing the same <code>batch.key</code> are
+                <em>folded</em> into this job's pending payload via the
+                <code>when</code> and <code>fold</code> jq expressions,
+                rather than creating separate pending jobs. All three inner
+                fields are required when this field is set. Mutually exclusive
+                with <code>unique_key</code> — supplying both returns
+                <code>400 Bad Request</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch.key</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Identifies the batch. Only one unsealed batched job exists
+                per key at a time. Enqueues sharing this key fold into the
+                existing pending job (or start a new one if none exists or
+                the existing batch was already sealed).
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch.when</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> predicate that
+                decides whether an incoming enqueue folds into the existing
+                pending job. Evaluated with <code>$existing</code> bound to
+                the current pending payload and <code>$new</code> bound to
+                the incoming payload. Truthy means fold; falsy seals the
+                existing batch and starts a fresh one from the incoming
+                enqueue. Invalid jq syntax, or an expression that returns
+                multiple outputs, returns <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch.fold</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> expression that
+                produces the merged payload when a fold occurs. Runs with the
+                same <code>$existing</code> and <code>$new</code> bindings as
+                <code>when</code>. Must produce exactly one output; multiple
+                outputs return <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].cost</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget.
             </td>
         </tr>
         <tr>

--- a/docs/api/src/cron.md
+++ b/docs/api/src/cron.md
@@ -15,6 +15,11 @@ allocate a dedicated worker for the purpose of processing recurring jobs.
 Collections of _cron entries_ are grouped together into one or more
 _cron groups_. Entire groups, and individual entries can be paused and resumed.
 
+The jobs that a cron schedule can enqueue are just like any other job, with the
+sole exception that they cannot specify `ready_at` — which would be
+nonsensical. They can use unique keys, batched jobs,
+[budgets](./rate-limiting.md) and any future features without restriction.
+
 The API is designed to facilitate clients performing a single `PUT` operation
 to define (or redefine) one or more schedules at application startup time. Many
 clients can all perform this same operation safely. The result is idempotent.
@@ -293,7 +298,6 @@ schedule data unconditionally and Zizq is smart enough to handle it safely.
                 <code>duplicate</code> field set to <code>true</code>. This key
                 is intentionally global across all queues and job types.
                 Clients should prefix it as necessary.
-                <strong>Requires a <em>pro</em> license</strong>.
             </td>
         </tr>
         <tr>
@@ -327,6 +331,194 @@ schedule data unconditionally and Zizq is smart enough to handle it safely.
                     </dd>
                 </dl>
                 The default scope is <code>queued</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Optional batched-job configuration. When present, subsequent
+                enqueues sharing the same <code>batch.key</code> are
+                <em>folded</em> into this job's pending payload via the
+                <code>when</code> and <code>fold</code> jq expressions,
+                rather than creating separate pending jobs. All three inner
+                fields are required when this field is set. Mutually exclusive
+                with <code>unique_key</code> — supplying both returns
+                <code>400 Bad Request</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch.key</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Identifies the batch. Only one unsealed batched job exists
+                per key at a time. Enqueues sharing this key fold into the
+                existing pending job (or start a new one if none exists or
+                the existing batch was already sealed).
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch.when</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> predicate that
+                decides whether an incoming enqueue folds into the existing
+                pending job. Evaluated with <code>$existing</code> bound to
+                the current pending payload and <code>$new</code> bound to
+                the incoming payload. Truthy means fold; falsy seals the
+                existing batch and starts a fresh one from the incoming
+                enqueue. Invalid jq syntax, or an expression that returns
+                multiple outputs, returns <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.batch.fold</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> expression that
+                produces the merged payload when a fold occurs. Runs with the
+                same <code>$existing</code> and <code>$new</code> bindings as
+                <code>when</code>. Must produce exactly one output; multiple
+                outputs return <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be valid UTF-8 and must
+                not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].cost</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget. Defaults
+                to 1.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].create_with</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Specification from which to create this budget atomically
+                with the cron entry if it does not already exist. Without this,
+                the budget must exist or a 422 response will be returned. Does
+                not overwrite any existing budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].create_with.allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].create_with.strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].create_with.strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        5 jobs bound to this budget can be in-flight at any
+                        given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].create_with.strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>entries[*].job.budgets[*].create_with.strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
             </td>
         </tr>
         <tr>

--- a/docs/api/src/enqueue.md
+++ b/docs/api/src/enqueue.md
@@ -289,6 +289,138 @@ endpoint wraps an array of `{"jobs": [...]}`.
                 outputs return <code>422 Unprocessable Entity</code>.
             </td>
         </tr>
+        <tr>
+            <td>
+                <div><code>budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+                <strong>Requires a <em>pro</em> license</strong>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be valid UTF-8 and must
+                not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].cost</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget. Defaults
+                to 1.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Specification from which to create this budget atomically
+                with the job if it does not already exist. Without this, the
+                budget must exist or a 422 response will be returned. Does not
+                overwrite any existing budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        5 jobs bound to this budget can be in-flight at any
+                        given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
     </tbody>
 </table>
 
@@ -557,6 +689,111 @@ Unique jobs require a [pro license](https://zizq.io/pricing).
 >     "type": "hello_world",
 >     "unique_key": "hello_world:world",
 >     "unique_while": "queued"
+> }
+> ```
+
+### Enqueue a job against multiple budgets
+
+Budgets are used for rate limiting and concurrency control. In this example
+budgets have already been created and the newly enqueued job is bound to those
+budgets.
+
+> Request:
+> ```sh
+> http POST http://127.0.0.1:7890/jobs --raw '{
+>     "type": "example",
+>     "queue": "example",
+>     "payload": {},
+>     "budgets": [
+>         {
+>             "key": "schema-bot",
+>             "cost": 2
+>         },
+>         {"key": "image-service"}
+>     ]
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 201 Created
+> content-length: 249
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:49:49 GMT
+> ```
+> ```json
+> {
+>     "attempts": 0,
+>     "budgets": [
+>         {
+>             "cost": 2,
+>             "key": "schema-bot"
+>         },
+>         {
+>             "cost": 1,
+>             "key": "image-service"
+>         }
+>     ],
+>     "duplicate": false,
+>     "folded": false,
+>     "id": "03gsa8rjaoxgqgnrsnlt7niqb",
+>     "priority": 32768,
+>     "queue": "example",
+>     "ready_at": 1788216589726,
+>     "status": "ready",
+>     "type": "example"
+> }
+> ```
+
+### Enqueue a job against budgets using `create_with`
+
+In this example, the budget for a job need not be created ahead of time. If it
+does not exist, Zizq will create it atomically with the job.
+
+> Request:
+> ```sh
+> http POST http://127.0.0.1:7890/jobs --raw '{
+>     "type": "example",
+>     "queue": "example",
+>     "payload": {},
+>     "budgets": [
+>         {
+>             "key": "cpu-intensive",
+>             "create_with": {
+>                 "allocation": 100,
+>                 "strategy": {
+>                     "type": "while_in_flight"
+>                 }
+>             }
+>         }
+>     ]
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 201 Created
+> content-length: 219
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:53:01 GMT
+> ```
+> ```json
+> {
+>     "attempts": 0,
+>     "budgets": [
+>         {
+>             "cost": 1,
+>             "key": "cpu-intensive"
+>         }
+>     ],
+>     "duplicate": false,
+>     "folded": false,
+>     "id": "03gsa9e0vd59nf3zgysm1yxd0",
+>     "priority": 32768,
+>     "queue": "example",
+>     "ready_at": 1788216781592,
+>     "status": "ready",
+>     "type": "example"
 > }
 > ```
 

--- a/docs/api/src/job-response-with-payload.md
+++ b/docs/api/src/job-response-with-payload.md
@@ -118,14 +118,84 @@
                 <div><pre>object</pre></div>
             </td>
             <td>
-                The batched-job configuration attached at enqueue time, if
-                any. Only the first enqueue's config applies for the life
-                of the batch; this field is echoed back on every
-                job-fetch response so callers can observe the exact
-                <code>when</code> / <code>fold</code> expressions the
-                server is evaluating on subsequent folds. See the
-                <a href="./enqueue.html#batched-jobs">Batched jobs</a>
-                section for the field shape.
+                Optional batched-job configuration. When present, subsequent
+                enqueues sharing the same <code>batch.key</code> are
+                <em>folded</em> into this job's pending payload via the
+                <code>when</code> and <code>fold</code> jq expressions,
+                rather than creating separate pending jobs. All three inner
+                fields are required when this field is set. Mutually exclusive
+                with <code>unique_key</code> — supplying both returns
+                <code>400 Bad Request</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>batch.key</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Identifies the batch. Only one unsealed batched job exists
+                per key at a time. Enqueues sharing this key fold into the
+                existing pending job (or start a new one if none exists or
+                the existing batch was already sealed).
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>batch.when</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> predicate that
+                decides whether an incoming enqueue folds into the existing
+                pending job. Evaluated with <code>$existing</code> bound to
+                the current pending payload and <code>$new</code> bound to
+                the incoming payload. Truthy means fold; falsy seals the
+                existing batch and starts a fresh one from the incoming
+                enqueue. Invalid jq syntax, or an expression that returns
+                multiple outputs, returns <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>batch.fold</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                <a href="https://jqlang.org/manual/">jq</a> expression that
+                produces the merged payload when a fold occurs. Runs with the
+                same <code>$existing</code> and <code>$new</code> bindings as
+                <code>when</code>. Must produce exactly one output; multiple
+                outputs return <code>422 Unprocessable Entity</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].cost</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget.
             </td>
         </tr>
         <tr>
@@ -240,6 +310,35 @@
                 <code>completed</code> jobs after successful processing. When
                 not set, the server's default value (zero) applies. When set to
                 zero, jobs are purged immediately upon completion.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].cost</code></div>
+                <div><pre>int32</pre> <em>required</em></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget.
             </td>
         </tr>
     </tbody>

--- a/docs/api/src/job-response-without-payload.md
+++ b/docs/api/src/job-response-without-payload.md
@@ -258,6 +258,35 @@
                 zero, jobs are purged immediately upon completion.
             </td>
         </tr>
+        <tr>
+            <td>
+                <div><code>budgets</code></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].cost</code></div>
+                <div><pre>int32</pre> <em>required</em></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget.
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/docs/api/src/modifying.md
+++ b/docs/api/src/modifying.md
@@ -8,7 +8,9 @@ Zizq is designed with _visibility_ and _control_ front of mind. A number of
 endpoints exist that allow updating and deleting job data from the server.
 
 Jobs in the `"completed"` and `"dead"` statuses are immutable and cannot be
-modified, though they can be deleted.
+modified, though they can be deleted. Additionally, when modifying
+[budget bindings](./rate-limiting.md) jobs in the `"in_flight"` status cannot
+be updated (the operation can be retried once the job is no longer in-flight).
 
 The following fields are mutable:
 
@@ -18,6 +20,7 @@ The following fields are mutable:
 * `retry_limit`
 * `backoff`
 * `retention`
+* `budgets`
 
 ## `DELETE /jobs/{id}` { #delete-job }
 
@@ -80,53 +83,7 @@ All options are additive.
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td>
-                <div><code>id</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job IDs to delete.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>queue</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of queue names to filter by.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>type</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job types to filter by.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>status</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job statuses to filter by.
-            </td>
-        </tr>
-        {{#include ./range-params.md}}
-        <tr>
-            <td>
-                <div><code>filter</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional <code>jq</code> expression to filter jobs by
-                <code>payload</code>.
-            </td>
-        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
     </tbody>
 </table>
 
@@ -330,54 +287,7 @@ All filter options are additive.
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td>
-                <div><code>id</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job IDs to update.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>queue</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of queue names to filter by.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>type</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job types to filter by.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>status</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job statuses to filter by.
-                Must not include <code>completed</code> or <code>dead</code>.
-            </td>
-        </tr>
-        {{#include ./range-params.md}}
-        <tr>
-            <td>
-                <div><code>filter</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional <code>jq</code> expression to filter jobs by
-                <code>payload</code>.
-            </td>
-        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
     </tbody>
 </table>
 
@@ -419,6 +329,988 @@ When given invalid input parameters.
 
 When the status filter includes terminal statuses, or invalid field values are
 provided.
+
+{{#include ./error-response.md}}
+
+## `POST /jobs/{id}/budgets/{key}` { #post-jobs-id-budgets-key }
+
+Bind a single job to the named budget.
+
+### Parameters { #post-jobs-id-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>id</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                ID of the job to which the budget will be bound.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be
+                valid UTF-8 and must not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Request Body { #post-jobs-id-budgets-key-body }
+
+{{#include ./bind-budget-parameters.md}}
+
+### Responses { #post-jobs-id-budgets-key-response }
+
+#### `200` OK
+
+Returns the updated job without the payload.
+
+{{#include ./job-response-without-payload.md}}
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+{{#include ./error-response.md}}
+
+#### `409` Conflict
+
+When a budget with the named `key` is already bound to this job.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When the job is in a terminal state, is in-flight or invalid values are
+provided.
+
+{{#include ./error-response.md}}
+
+## `PUT /jobs/{id}/budgets/{key}` { #put-jobs-id-budgets-key }
+
+Replace the named budget binding on a single job. Creates it if does not
+already exist.
+
+### Parameters { #put-jobs-id-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>id</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                ID of the job to which the budget will be bound.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be
+                valid UTF-8 and must not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Request Body { #put-jobs-id-budgets-key-body }
+
+{{#include ./bind-budget-parameters.md}}
+
+### Responses { #put-jobs-id-budgets-key-response }
+
+#### `200` OK
+
+Returns the updated job without the payload.
+
+{{#include ./job-response-without-payload.md}}
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+{{#include ./error-response.md}}
+
+#### `409` Conflict
+
+When a budget with the named `key` is already bound to this job.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When the job is in a terminal state, is in-flight or invalid values are
+provided.
+
+{{#include ./error-response.md}}
+
+## `PATCH /jobs/{id}/budgets/{key}` { #patch-jobs-id-budgets-key }
+
+Update the named budget binding on a single job. Currently the only patchable
+field is `cost`.
+
+### Parameters { #patch-jobs-id-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>id</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                ID of the job for which the budget is to be patched.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Request Body { #patch-jobs-id-budgets-key-body }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>cost</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens the job takes from the budget.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #patch-jobs-id-budgets-key-response }
+
+#### `200` OK
+
+Returns the updated job without the payload.
+
+{{#include ./job-response-without-payload.md}}
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When the job is in a terminal state, is in-flight or invalid values are
+provided.
+
+{{#include ./error-response.md}}
+
+## `DELETE /jobs/{id}/budgets/{key}` { #delete-jobs-id-budgets-key }
+
+Remove the named budget binding from a single job.
+
+### Parameters { #delete-jobs-id-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>id</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                ID of the job for which the budget is to be removed.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #delete-jobs-id-budgets-key-response }
+
+#### `200` OK
+
+Returns the updated job without the payload.
+
+{{#include ./job-response-without-payload.md}}
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When the job is in a terminal state or is in-flight.
+
+{{#include ./error-response.md}}
+
+## `PUT /jobs/{id}/budgets` { #put-jobs-id-budgets-bulk }
+
+Replace all budgets on the specified job.
+
+### Parameters { #put-jobs-id-budgets-bulk }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>id</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                ID of the job for which to replace budgets.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Request Body { #put-jobs-id-budgets-bulk-body }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>budgets</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of <a href="./rate-limiting.md">budget bindings</a>
+                used to control concurrency and/or rate limiting of dispatched
+                jobs.
+                <strong>Requires a <em>pro</em> license</strong>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be valid UTF-8 and must
+                not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].cost</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens this job takes from the budget. Defaults
+                to 1.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Specification from which to create this budget atomically
+                with the job if it does not already exist. Without this, the
+                budget must exist or a 422 response will be returned. Does not
+                overwrite any existing budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        5 jobs bound to this budget can be in-flight at any
+                        given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].create_with.strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #put-jobs-id-budgets-bulk-response }
+
+#### `200` OK
+
+Returns the updated job without the payload.
+
+{{#include ./job-response-without-payload.md}}
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When the job is in a terminal state, is in-flight or invalid values are
+provided.
+
+{{#include ./error-response.md}}
+
+## `DELETE /jobs/{id}/budgets` { #delete-jobs-id-budgets-bulk }
+
+Remove all budgets from the specified job.
+
+### Parameters { #delete-jobs-id-budgets-bulk }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>id</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                ID of the job for which to remove budgets.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #delete-jobs-id-budgets-bulk-response }
+
+#### `200` OK
+
+Returns the updated job without the payload.
+
+{{#include ./job-response-without-payload.md}}
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When the job is in a terminal state, is in-flight or invalid values are
+provided.
+
+{{#include ./error-response.md}}
+
+## `POST /jobs/budgets/{key}` { #post-jobs-budgets-key }
+
+Bind a budget to all matching jobs specified by the filter. Jobs that already
+have the binding are gracefully skipped. Jobs in a terminal status are
+gracefully skipped. Jobs in the `in_flight` status are _blocked_ and reported
+for retry.
+
+### Parameters { #post-jobs-budgets-key-parameters }
+
+All options are additive.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be
+                valid UTF-8 and must not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
+    </tbody>
+</table>
+
+### Request Body { #post-jobs-budgets-key-body }
+
+{{#include ./bind-budget-parameters.md}}
+
+### Responses { #post-jobs-budgets-key-response }
+
+#### `200` OK
+
+Returns the number of updated jobs, and the list of any job IDs that could not
+be updated because those jobs were `in_flight` — in which case those specific
+IDs may be retried.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>changed</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                The number of jobs that were modified in the operation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>blocked</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of Job IDs that were not modified because they were
+                <code>in_flight</code>. The operation may be retried, including
+                just those IDs in the <code>id</code> query parameter.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When invalid values are provided.
+
+{{#include ./error-response.md}}
+
+## `PUT /jobs/budgets/{key}` { #put-jobs-budgets-key }
+
+Replace budget to all matching jobs specified by the filter. Jobs that already
+have the binding are updated. Jobs that do not have the binding are given it.
+Jobs in a terminal status are gracefully skipped. Jobs in the `in_flight`
+status are _blocked_ and reported for retry.
+
+### Parameters { #put-jobs-budgets-key-parameters }
+
+All options are additive.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget. Must be
+                valid UTF-8 and must not contain any of the follow reserved
+                characters: <code>,</code>, <code>*</code>, <code>?</code>,
+                <code>[</code>, <code>]</code>, <code>{</code>, <code>}</code>,
+                <code>\</code>.
+            </td>
+        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
+    </tbody>
+</table>
+
+### Request Body { #post-jobs-budgets-key-body }
+
+{{#include ./bind-budget-parameters.md}}
+
+### Responses { #post-jobs-budgets-key-response }
+
+#### `200` OK
+
+Returns the number of updated jobs, and the list of any job IDs that could not
+be updated because those jobs were `in_flight` — in which case those specific
+IDs may be retried.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>changed</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                The number of jobs that were modified in the operation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>blocked</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of Job IDs that were not modified because they were
+                <code>in_flight</code>. The operation may be retried, including
+                just those IDs in the <code>id</code> query parameter.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When invalid values are provided.
+
+{{#include ./error-response.md}}
+
+## `PATCH /jobs/budgets/{key}` { #patch-jobs-budgets-key }
+
+Update the details of the named budget on all matching jobs specified by the
+filter. Currently only the `cost` can be patched. Jobs that do not have the
+binding are gracefull skipped. Jobs that have the binding are updated. Jobs in
+a terminal status are gracefully skipped. Jobs in the `in_flight` status are
+_blocked_ and reported for retry.
+
+### Parameters { #patch-jobs-budgets-key-parameters }
+
+All options are additive.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
+    </tbody>
+</table>
+
+### Request Body { #patch-jobs-budgets-key-body }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>cost</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The number of tokens jobs take from the budget.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #patch-jobs-budgets-key-response }
+
+#### `200` OK
+
+Returns the number of updated jobs, and the list of any job IDs that could not
+be updated because those jobs were `in_flight` — in which case those specific
+IDs may be retried.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>changed</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                The number of jobs that were modified in the operation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>blocked</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of Job IDs that were not modified because they were
+                <code>in_flight</code>. The operation may be retried, including
+                just those IDs in the <code>id</code> query parameter.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When invalid values are provided.
+
+{{#include ./error-response.md}}
+
+## `DELETE /jobs/budgets/{key}` { #delete-jobs-budgets-key }
+
+Remove the named budget from all matching jobs specified by the filter. Jobs
+that do not have the binding are gracefull skipped. Jobs that have the binding
+are updated. Jobs in a terminal status are gracefully skipped. Jobs in the
+`in_flight` status are _blocked_ and reported for retry.
+
+### Parameters { #delete-jobs-budgets-key-parameters }
+
+All options are additive.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
+    </tbody>
+</table>
+
+### Responses { #delete-jobs-budgets-key-response }
+
+#### `200` OK
+
+Returns the number of updated jobs, and the list of any job IDs that could not
+be updated because those jobs were `in_flight` — in which case those specific
+IDs may be retried.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>changed</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                The number of jobs that were modified in the operation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>blocked</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of Job IDs that were not modified because they were
+                <code>in_flight</code>. The operation may be retried, including
+                just those IDs in the <code>id</code> query parameter.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When invalid values are provided.
+
+{{#include ./error-response.md}}
+
+## `DELETE /jobs/budgets` { #delete-jobs-budgets-bulk }
+
+Remove _all_ budgets from all matching jobs specified by the filter. Jobs in a
+terminal status are gracefully skipped. Jobs in the `in_flight` status are
+_blocked_ and reported for retry.
+
+### Parameters { #delete-jobs-budgets-bulk-parameters }
+
+All options are additive.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{#include ./query-filter-parameter-rows.md}}
+    </tbody>
+</table>
+
+### Responses { #delete-jobs-budgets-bulk-response }
+
+#### `200` OK
+
+Returns the number of updated jobs, and the list of any job IDs that could not
+be updated because those jobs were `in_flight` — in which case those specific
+IDs may be retried.
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>changed</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                The number of jobs that were modified in the operation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>blocked</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                Array of Job IDs that were not modified because they were
+                <code>in_flight</code>. The operation may be retried, including
+                just those IDs in the <code>id</code> query parameter.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### `403` Forbidden
+
+When the server is not confiured with a Pro license.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessable Entity
+
+When invalid values are provided.
 
 {{#include ./error-response.md}}
 

--- a/docs/api/src/query-filter-parameter-rows.md
+++ b/docs/api/src/query-filter-parameter-rows.md
@@ -1,0 +1,65 @@
+<tr>
+    <td>
+        <div><code>id</code> <em>query</em></div>
+        <div><pre>string</pre></div>
+    </td>
+    <td>
+        Optional comma-separated list of job IDs to include.
+    </td>
+</tr>
+<tr>
+    <td>
+        <div><code>queue</code> <em>query</em></div>
+        <div><pre>string</pre></div>
+    </td>
+    <td>
+        Optional comma-separated list of queue names to include. Defaults
+        to <em>all queues</em>.
+    </td>
+</tr>
+<tr>
+    <td>
+        <div><code>type</code> <em>query</em></div>
+        <div><pre>string</pre></div>
+    </td>
+    <td>
+        Optional comma-separated list of job types to include. Defaults
+        to <em>all types</em>.
+    </td>
+</tr>
+<tr>
+    <td>
+        <div><code>status</code> <em>query</em></div>
+        <div><pre>string</pre></div>
+    </td>
+    <td>
+        Optional comma-separated list of job statuses to include. Defaults
+        to <em>all statuses</em>.
+    </td>
+</tr>
+{{#include ./range-params.md}}
+<tr>
+    <td>
+        <div><code>budgets.key</code> <em>query</em></div>
+        <div><pre>string</pre></div>
+    </td>
+    <td>
+        Optional comma-separated list of
+        <a href="./rate-limiting.md">budget keys</a> to which jobs are
+        bound. Jobs matching <em>any</em> of the keys are included.
+    </td>
+</tr>
+<tr>
+    <td>
+        <div><code>filter</code> <em>query</em></div>
+        <div><pre>string</pre></div>
+    </td>
+    <td>
+        Optional <code>jq</code> expression by which to filter jobs by
+        <code>payload</code>. This enables matching on the entire
+        payload, or arbitrarily on a subset of the payload. Filtering
+        is done via
+        <a href="https://gedenkt.at/jaq/manual/#corelang">jaq</a> which
+        is compatible with <code>jq</code>.
+    </td>
+</tr>

--- a/docs/api/src/querying.md
+++ b/docs/api/src/querying.md
@@ -75,60 +75,7 @@ All options are additive.
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td>
-                <div><code>id</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job IDs to retrieve.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>queue</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of queue names for which to list
-                jobs. Defaults to <em>all queues</em>.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>type</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job types for which to list
-                jobs. Defaults to <em>all types</em>.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>status</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job statuses for which to list
-                jobs. Defaults to <em>all statuses</em>.
-            </td>
-        </tr>
-        {{#include ./range-params.md}}
-        <tr>
-            <td>
-                <div><code>filter</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional <code>jq</code> expression by which to filter jobs by
-                <code>payload</code>. This enables matching on the entire
-                payload, or arbitrarily on a subset of the payload. Filtering
-                is done via
-                <a href="https://gedenkt.at/jaq/manual/#corelang">jaq</a> which
-                is compatible with <code>jq</code>.
-            </td>
-        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
         <tr>
             <td>
                 <div><code>order</code> <em>query</em></div>
@@ -282,53 +229,7 @@ All options are additive.
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td>
-                <div><code>id</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job IDs to include.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>queue</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of queue names to filter by.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>type</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job types to filter by.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <div><code>status</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional comma-separated list of job statuses to filter by.
-            </td>
-        </tr>
-        {{#include ./range-params.md}}
-        <tr>
-            <td>
-                <div><code>filter</code> <em>query</em></div>
-                <div><pre>string</pre></div>
-            </td>
-            <td>
-                Optional <code>jq</code> expression to filter jobs by
-                <code>payload</code>.
-            </td>
-        </tr>
+        {{#include ./query-filter-parameter-rows.md}}
     </tbody>
 </table>
 

--- a/docs/api/src/rate-limiting.md
+++ b/docs/api/src/rate-limiting.md
@@ -1,0 +1,1119 @@
+# Concurrency Control &amp; Rate Limiting
+
+> [!NOTE]
+> These endpoints are available in both `application/json` and
+> `application/msgpack` formats.
+
+> [!NOTE]
+> This feature requires a [Pro license](https://zizq.io/pricing).
+
+Applications typically enqueue jobs to offload expensive work to a background
+worker. Some jobs can put pressure on upstream systems if running with high
+throughput. For example, you may have jobs that resize images through an image
+service, and that service may have a maximum throughput of 10,000 requests per
+hour. Or you may send push notifications through your queue worker, but at
+times bursts of notifications dominate your queue, starving other jobs of
+processing time. Both of these problems can be solved with a feature Zizq calls
+_budgets_.
+
+Budgets are Zizq's approach to limiting throughput, both from a pure concurrency
+control perspective (no more than N jobs in-flight at any given time), and also
+from a rate limiting perspective (no more than N jobs dispatched over a period
+of time). The server stores named budgets, which are pools of available _tokens_
+managed under a specified _strategy_. Currently two strategies exist:
+`while_in_flight`, and `time_based`. Jobs are enqueued referencing one or more
+of these budgets, along with optional costs to run those jobs, where that cost
+defaults to `1` token. Before a job can be dispatched to a worker, it needs to
+successfully debit its cost from each of its budgets' shared token pools.
+
+Unlike with some other job queues, throughput is controlled entirely by the
+server, so workers do not need to receive a job and then wait or retry because
+it exceeded some rate limit. Instead, workers remain naive to the dispatching
+logic and just process every job they receive in the same way. If the budget
+does not have enough tokens available for a job to run, Zizq does not dispatch
+that job to a worker in the first place. It _parks_ that job and dispatches it
+the moment its budget allows. Other jobs — those without budget restrictions
+and those on other budgets that have tokens available — continue to be
+dispatched to workers without stalling.
+
+> [!NOTE]
+> Budgets are a shared resource. The Zizq server currently enforces an upper
+> limit on the number of distinct budgets that can be created. The default is
+> `8192` different budgets, which should be far in excess of what typical
+> applications would require, but this limit can be configured on the server
+> via `--max-budgets` (`$ZIZQ_MAX_BUDGETS`). A future release will introduce a
+> sub-bucket concept for dynamically allocated budget scenarios.
+
+## Budget Strategies
+
+There are currently two available strategies for budgeting: `while_in_flight`
+implements pure concurrency control, and `time_based` implements a dispatch
+rate limit over time. Both take a total `allocation` value, which is the number
+of tokens made available in the budget's pool. Jobs can be bound to more than
+one budget, mixing and matching across different strategies. In this case,
+_all_ budgets must be satisified before the job can run.
+
+Budgets must have an allocation greater than or equal to the `cost` of each
+job that references that budget. That is, the Zizq server will reject any
+attempt to enqueue a job that costs more than its budget will ever allow, and
+it will reject any attempt to update a budget to allocate less tokens than some
+job referencing that budget would cost.
+
+### `while_in_flight`
+
+For pure concurrency control, where you need to ensure at most `N` workers are
+processing a given job at once, use the `while_in_flight` strategy. In this
+strategy, the budget has a given token allocation of say `20` and no other
+configuration. We'll see how to allocate budgets below, but this is the shape
+of a `while_in_flight` budget.
+
+> `while_in_flight` budget:
+> ```json
+> {
+>     "allocation": 20,
+>     "strategy": {
+>         "type": "while_in_flight"
+>     }
+> }
+> ```
+
+The above budget would allow at most 20 concurrent jobs with the default cost
+of `1`, or 10 concurrent jobs with a cost of `2`, or any valid combination of
+costs that is less than or equal to 20.
+
+- `20 x cost=1`
+- `10 x cost=2`
+- `(5 x cost=2) + (10 x cost=1)`
+- `(3 x cost=5) + (2 x cost=2)`
+
+When a job is dispatched that uses a `while_in_flight` strategy, it must debit
+its cost in full from the budget's token pool. If the pool is too depleted to
+do that, the job remains parked until more tokens are available in the pool.
+Once dispatched, tokens remain debited from the pool for as long as that job is
+`in_flight`. As soon as the worker acknowledges the job with a successful
+completion, or reports a failure, the job is no longer `in_flight` and its
+tokens are released back to the pool, allowing other jobs to run within that
+same budget.
+
+To illustrate how this works, take this example job that takes a consistent 2
+seconds to run, bound to a `while_in_flight` budget with an allocation of 5.
+
+> 2 second jobs with `while_in_flight` 5:
+> ```sh
+> 2026-08-31T19:16:28+10:00: Job 03gs5tvn78uny555dm88vjsoj running in process 3098324
+> 2026-08-31T19:16:28+10:00: Job 03gs5tvn78uny555dmbvk61n3 running in process 3098338
+> 2026-08-31T19:16:28+10:00: Job 03gs5tvn78uny555dmdlmcrhh running in process 3098358
+> 2026-08-31T19:16:28+10:00: Job 03gs5tvn78uny555dmew56mwy running in process 3098370
+> 2026-08-31T19:16:28+10:00: Job 03gs5tvn78uny555dmgjcsuw2 running in process 3098385
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dm88vjsoj exited with status 0
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmbvk61n3 exited with status 0
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmdlmcrhh exited with status 0
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmew56mwy exited with status 0
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmim3oaw5 running in process 3098448
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmgjcsuw2 exited with status 0
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmkz0iee0 running in process 3098485
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmmee2rjg running in process 3098504
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmppqcuqe running in process 3098518
+> 2026-08-31T19:16:30+10:00: Job 03gs5tvn78uny555dmrdrgvdm running in process 3098533
+> 2026-08-31T19:16:32+10:00: Job 03gs5tvn78uny555dmim3oaw5 exited with status 0
+> 2026-08-31T19:16:32+10:00: Job 03gs5tvn78uny555dmkz0iee0 exited with status 0
+> 2026-08-31T19:16:32+10:00: Job 03gs5tvn78uny555dms8wyffo running in process 3098578
+> 2026-08-31T19:16:32+10:00: Job 03gs5tvn78uny555dmmee2rjg exited with status 0
+> 2026-08-31T19:16:32+10:00: Job 03gs5tvn78uny555dmppqcuqe exited with status 0
+> 2026-08-31T19:16:32+10:00: Job 03gs5tvn78uny555dmrdrgvdm exited with status 0
+> ```
+
+Jobs are running 5 at once, taking 2 seconds to complete and then another 5
+jobs run at once. Note that what _looks like_ overlap here is just an artifact
+of the concurrent processing locally. These logs are genuinely copied &amp;
+pasted from a live example. The overlap is just the way the logs were output,
+with the acknowledgment reaching the server before the success log was printed.
+
+### `time_based`
+
+Where concurrency is not the concern, but overall throughput is, the
+`time_based` strategy can be used to enforce a rate limit. Just like a
+`while_in_flight` budget, a `time_based` one has a token allocation, which
+represents the number of tokens that can be _spent_ over some period of time.
+Unlike the `while_in_flight` strategy, a `time_based` strategy is specified
+along with a `duration_ms`, specifying the number of milliseconds over which
+its allocation can be spent.
+
+> `time_based` budget:
+> ```json
+> {
+>     "allocation": 10000,
+>     "strategy": {
+>         "type": "time_based",
+>         "duration_ms": 3600000
+>     }
+> }
+> ```
+
+The above budget states that at most 10,000 tokens can be spent over a
+3,600,000 millisecond period, hence it is a rate limit of `10000/hour`.
+
+When a job is dispatched that uses a `time_based` budget, it must debit its
+cost in full, otherwise it remains parked until enough tokens become available.
+Unlike `while_in_flight`, tokens are not released back to the pool when the job
+completes, but rather are released back to the pool on the cadence specified by
+the duration. This means a `time_based` budget controls how many jobs are
+_dispatched_ over time, but it cares not how many of those jobs finish up
+running at once (i.e. jobs that take longer than `duration_ms` to run may
+overlap). The server implements this _lazily_. There is no constant scanning of
+the database to look for jobs that can now be dispatched. The server is smart
+enough to know when tokens will next become available and sleeps until that
+time, or until some other event wakes it.
+
+The `time_based` strategy implements a _continuous_ (drip) rate limiter. Also
+known as a [leaky bucket](https://en.wikipedia.org/wiki/Leaky_bucket) rate
+limit. Unlike some rate limiters which bucket tokens into fixed time intervals
+— e.g. for a 5 minute limit, `00:00 - 00:05`, `00:05 - 00:10`, ... — a
+continuous drip rate limiter sets a pace. For example if 100 tokens are
+available over 5 minutes, and the pool is empty, after 1 minute the pool has 20
+tokens available, after 4 minutes it has 80 tokens available, and after the
+full 5 minutes it has all 100 tokens available. This naturally spreads work
+over time, rather than sending sharp bursts of jobs across fixed bucket
+boundaries, then stalling until the next bucket etc. When the pool is _full_
+however, it has 100 tokens available and therefore a sudden burst of 100 jobs
+with a cost of 1 could all go at once, followed by a steady pace of around 1
+job every 3 seconds. This is generally desirable in order to accommodate
+short-lived spikes, but not always, and the behaviour is configurable through
+the `burst` parameter on on the strategy.
+
+To illustrate how this works, take this example which runs a job that takes a
+consistent 2 seconds per execution, using a budget configured at 6/minute.
+
+> `time_based` at 6/minute:
+> ```sh
+> 2026-08-31T19:21:55+10:00: Job 03gs5uwrfxd4pt761yklejqko running in process 3099369
+> 2026-08-31T19:21:57+10:00: Job 03gs5uwrfxd4pt761yklejqko exited with status 0
+> 2026-08-31T19:22:05+10:00: Job 03gs5uwrfxd4pt761ymwt6p98 running in process 3099409
+> 2026-08-31T19:22:07+10:00: Job 03gs5uwrfxd4pt761ymwt6p98 exited with status 0
+> 2026-08-31T19:22:15+10:00: Job 03gs5uwrfxd4pt761yp3o5g8j running in process 3099443
+> 2026-08-31T19:22:17+10:00: Job 03gs5uwrfxd4pt761yp3o5g8j exited with status 0
+> 2026-08-31T19:22:25+10:00: Job 03gs5uwrg2tzskvxfx78r00j5 running in process 3099479
+> 2026-08-31T19:22:27+10:00: Job 03gs5uwrg2tzskvxfx78r00j5 exited with status 0
+> ```
+
+As you can see, each job takes its 2 seconds to complete, but the worker
+continues receiving and processing these jobs at a rate of 6 per second.
+
+The `burst` is how full the token pool can be at any single point in time. When
+not specified, the `allocation` is used, so for our 100 jobs/5 minute example
+the default burst is 100, as descibed above. Budgets specifying a different
+`burst` look like so:
+
+> `time_based` budget with burst:
+> ```json
+> {
+>     "allocation": 10000,
+>     "strategy": {
+>         "type": "time_based",
+>         "duration_ms": 3600000,
+>         "burst": 500
+>     }
+> }
+> ```
+
+In this example, no more than 500 jobs can be dispatched at any moment, then
+10,000/hour at a steady pace thereafter. Setting a `burst` of just `1` is
+equivalent to enforcing the 10,000/hour always. It is also possible to set the
+`burst` _higher_ than the total allocation — say 20,000 tokens — which allows
+for brief spikes of high throughput that exceed the rate limit by design, if
+and only if the budget was otherwise unused for an equivalent period of time.
+
+Again, to illustrate how this works, here's that 6/minute job with its upfront
+default burst of 6 jobs in one go.
+
+> `time_based` at 6/minute, with its burst:
+> ```sh
+> 2026-08-31T19:21:45+10:00: Job 03gs5uwrfxd4pt761y86gg2qs running in process 3099195
+> 2026-08-31T19:21:45+10:00: Job 03gs5uwrfxd4pt761y9pfrlq1 running in process 3099214
+> 2026-08-31T19:21:45+10:00: Job 03gs5uwrfxd4pt761yck5ma8c running in process 3099228
+> 2026-08-31T19:21:45+10:00: Job 03gs5uwrfxd4pt761yegaxtjt running in process 3099245
+> 2026-08-31T19:21:45+10:00: Job 03gs5uwrfxd4pt761yh9m250z running in process 3099263
+> 2026-08-31T19:21:45+10:00: Job 03gs5uwrfxd4pt761yhxue08x running in process 3099278
+> 2026-08-31T19:21:47+10:00: Job 03gs5uwrfxd4pt761y86gg2qs exited with status 0
+> 2026-08-31T19:21:47+10:00: Job 03gs5uwrfxd4pt761y9pfrlq1 exited with status 0
+> 2026-08-31T19:21:47+10:00: Job 03gs5uwrfxd4pt761yck5ma8c exited with status 0
+> 2026-08-31T19:21:47+10:00: Job 03gs5uwrfxd4pt761yegaxtjt exited with status 0
+> 2026-08-31T19:21:47+10:00: Job 03gs5uwrfxd4pt761yh9m250z exited with status 0
+> 2026-08-31T19:21:47+10:00: Job 03gs5uwrfxd4pt761yhxue08x exited with status 0
+> 2026-08-31T19:21:55+10:00: Job 03gs5uwrfxd4pt761yklejqko running in process 3099369
+> 2026-08-31T19:21:57+10:00: Job 03gs5uwrfxd4pt761yklejqko exited with status 0
+> 2026-08-31T19:22:05+10:00: Job 03gs5uwrfxd4pt761ymwt6p98 running in process 3099409
+> 2026-08-31T19:22:07+10:00: Job 03gs5uwrfxd4pt761ymwt6p98 exited with status 0
+> 2026-08-31T19:22:15+10:00: Job 03gs5uwrfxd4pt761yp3o5g8j running in process 3099443
+> 2026-08-31T19:22:17+10:00: Job 03gs5uwrfxd4pt761yp3o5g8j exited with status 0
+> 2026-08-31T19:22:25+10:00: Job 03gs5uwrg2tzskvxfx78r00j5 running in process 3099479
+> 2026-08-31T19:22:27+10:00: Job 03gs5uwrg2tzskvxfx78r00j5 exited with status 0
+> ```
+
+Here it is visible that before the worker settles into receiving these jobs at
+a rate of 6 per second, it receives an upfront burst of 6 jobs in one go. This
+only happens:
+
+1. If no jobs have been dispatched for the configured duration (i.e. the token
+   pool is full); or
+2. The budget is freshly allocated (newly created, or the Zizq server was
+   restarted).
+
+When using `burst`, all jobs that reference the budget must have a cost less
+than or equal to the configured burst, and any attempts to update the budget
+such that this condition is violated are rejected.
+
+## Budget Bindings
+
+> [!NOTE]
+> See [Enqueueing Jobs](./enqueue.md) for full details on the fields available
+> to jobs.
+
+Budgets are a shared resource, referenced under a known _key_. Jobs _bind_ to
+those budgets by specifying them when enqueued. Jobs can be bound to zero or
+more budgets, which they specify through the options `budgets` array.
+
+> Budget bindings on a job:
+> ```json
+> {
+>     "budgets": [
+>         {"key": "image-service"},
+>         {"key": "notifications", "cost": 5}
+>     ]
+> }
+> ```
+
+When no budgets are specified, that job is unbudgeted and is dispatched the
+moment it reaches the front of the queue. When one budget is specified, even if
+the job has reached the front of the queue, it must debit its `cost` from the
+budget's token pool before it can be dispatched, otherwise it is parked and
+other jobs continue to be dispatched without interruption. When multiple
+budgets are specified, it must debit its cost from _all_ of those budgets
+before it can be dispatched.
+
+For example, a job could be configured against a `while_in_flight` limit of 10,
+and a `time_based` limit of 1000/hour. Both controls are equally authoritative:
+no more than 10 jobs will ever run concurrently, and no more than 1000 jobs
+will ever be dispatched per hour.
+
+While budgets are shared resources that can be created ahead of time, it is
+also possible for jobs to provide a `create_with` specification when they are
+enqueued against a budget. If the budget already exists, the `create_with` is
+ignored and the existing budget is authoritative. If the budget does not exist
+however, it is atomically created along with the job that is bound to it, and
+subsequent enqueues will see that budget.
+
+> Using `create_with`:
+> ```json
+> {
+>     "budgets": [
+>         {"key": "image-service"},
+>         {
+>             "key": "notifications",
+>             "cost": 5,
+>             "create_with": {
+>                 "allocaton": 50000,
+>                 "strategy": {
+>                     "type": "while_in_flight"
+>                 }
+>             }
+>         }
+>     ]
+> }
+> ```
+
+## `GET /budgets` { #get-budgets }
+
+Returns a list of all configured budgets.
+
+### Responses { #get-budgets-response }
+
+#### `200` OK
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>budgets</code> <em>required</em></div>
+                <div><pre>array</pre></div>
+            </td>
+            <td>
+                List of budgets configured on the server.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].key</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for this budget, used to bind jobs to it, and
+                when calling other endpoints that operate on the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].allocation</code> <em>required</em></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].strategy</code> <em>required</em></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].strategy.type</code> <em>required</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        no more than 5 jobs bound to this budget can be
+                        in-flight at any given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Required for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].strategy.burst</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].created_at</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                When this budget was created on the server. Unix timestamp in
+                milliseconds.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>budgets[*].updated_at</code> <em>required</em></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                When this budget was last updated. Unix timestamp in
+                milliseconds.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### `403` Forbidden
+
+When the server is not configured with a [Pro license](https://zizq.io/pricing).
+
+{{#include ./error-response.md}}
+
+## `GET /budgets/{key}` { #get-budgets-key }
+
+Fetch the named budget.
+
+### Parameters { #get-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #get-budgets-key-response }
+
+#### `200` OK
+
+{{#include ./budget-response.md}}
+
+#### `403` Forbidden
+
+When the server is not configured with a [Pro license](https://zizq.io/pricing).
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+When the specified budget does not exist.
+
+{{#include ./error-response.md}}
+
+## `POST /budgets/{key}` { #post-budgets-key }
+
+Create the named budget, or reject if the budget already exists.
+
+### Parameters { #post-budgets-key-parameters }
+
+{{#include ./budget-parameters.md}}
+
+### Responses { #post-budgets-key-response }
+
+#### `201` Created
+
+{{#include ./budget-response.md}}
+
+#### `403` Forbidden
+
+When the server is not configured with a [Pro license](https://zizq.io/pricing).
+
+{{#include ./error-response.md}}
+
+#### `409` Conflict
+
+When the specified budget already exists.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessible Entity
+
+When the specified budget is not semantically valid (e.g. invalid key).
+
+{{#include ./error-response.md}}
+
+## `PUT /budgets/{key}` { #put-budgets-key }
+
+Create the named budget or overwrite it if it already exists.
+
+### Parameters { #put-budgets-key-parameters }
+
+{{#include ./budget-parameters.md}}
+
+### Responses { #put-budgets-key-response }
+
+#### `200` OK
+
+{{#include ./budget-response.md}}
+
+#### `403` Forbidden
+
+When the server is not configured with a [Pro license](https://zizq.io/pricing).
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessible Entity
+
+When the specified budget is not semantically valid (e.g. invalid key
+or allocation below existing jobs bound to the budget).
+
+{{#include ./error-response.md}}
+
+## `PATCH /budgets/{key}` { #patch-budgets-key }
+
+Update specified fields within the given budget. This operation is a
+JSON merge patch. Omitted fields are left unchanged, fields with values
+are updated, and fields set to `null` are cleared or reset to the default.
+
+### Parameters { #patch-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>allocation</code></div>
+                <div><pre>int32</pre></div>
+            </td>
+            <td>
+                The total number of tokens available in this budget's pool for
+                use by its configured strategy. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the allocation.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy</code></div>
+                <div><pre>object</pre></div>
+            </td>
+            <td>
+                Details of the specific strategy that is used to manage the
+                tokens available under this budget.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.type</code></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                Names the strategy used to manage the tokens within the budget.
+                One of:
+                <dl>
+                    <dt><code>while_in_flight</code></dt>
+                    <dd>
+                        Concurrency control — tokens are spent from the budget
+                        when jobs are dispatched to workers, and returned when
+                        the job completes or fails, or the worker disconnects
+                        uncleanly. For example, for an allocation of 5, at most
+                        5 jobs bound to this budget can be in-flight at any
+                        given time.
+                    </dd>
+                    <dt><code>time_based</code></dt>
+                    <dd>
+                        Rate limit — tokens are spent from the budget when jobs
+                        are dispatched to workers and are only returned after a
+                        configured period of time, regardless of the outcome of
+                        the job.
+                    </dd>
+                </dl>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.duration_ms</code></div>
+                <div><pre>int64</pre></div>
+            </td>
+            <td>
+                Only for <code>time_based</code> strategies. Invalid for
+                <code>while_in_flight</code>. Specifies the period of time in
+                milliseconds over which a <code>time_based</code> rate limit is
+                measured. For example, for an allocation of 1000 and a
+                <code>duration_ms</code> of 60000, the rate limit is
+                <code>1000/minute</code>.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div><code>strategy.burst</code></div>
+                <div><pre>int32 | null</pre></div>
+            </td>
+            <td>
+                The maximum number of tokens that may be accumulated at once
+                for a <code>time_based</code> budget. Defaults to whatever the
+                configured <code>allocation</code> is. So for a
+                <code>1000/hour</code> rate limit, the budget would technically
+                permit a short burst of 1000 jobs if no other jobs have used
+                tokens from the budget for a whole hour. Setting a burst of 1
+                means tokens cannot accumulate and jobs are always paced
+                according to the configured rate limit. It is also possible to
+                intentionally set a burst higher than the configured
+                allocation, such as a burst of 2000 for a
+                <code>1000/hour</code> allocation. In this case if the budget
+                has been idle for 2 hours, it would permit a sudden burst of
+                2000 jobs at any moment. No jobs can exist bound to this
+                budget with a <code>cost</code> that exceeds the burst.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #put-budgets-key-response }
+
+#### `200` OK
+
+{{#include ./budget-response.md}}
+
+#### `403` Forbidden
+
+When the server is not configured with a [Pro license](https://zizq.io/pricing).
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+When the specified job does not exist.
+
+{{#include ./error-response.md}}
+
+#### `422` Unprocessible Entity
+
+When the specified budget is not semantically valid (e.g. invalid key
+or allocation below existing jobs bound to the budget).
+
+{{#include ./error-response.md}}
+
+## `DELETE /budgets/{key}` { #delete-budgets-key }
+
+Delete the named budget.
+
+### Parameters { #delete-budgets-key-parameters }
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div><code>key</code> <em>path</em></div>
+                <div><pre>string</pre></div>
+            </td>
+            <td>
+                The identifier for the budget.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Responses { #delete-budgets-key-response }
+
+#### `204` No Content
+
+No content is returned on successful deletion.
+
+#### `403` Forbidden
+
+When the server is not configured with a [Pro license](https://zizq.io/pricing).
+
+{{#include ./error-response.md}}
+
+#### `404` Not Found
+
+When the specified budget does not exist.
+
+{{#include ./error-response.md}}
+
+#### `409` Conflict
+
+When deleting the specified budget is not valid because one or more jobs
+are still bound to it.
+
+{{#include ./error-response.md}}
+
+## Examples
+
+### Create a `time_based` budget
+
+> Request:
+> ```sh
+> http POST http://127.0.0.1:7890/budgets/image-service --raw '{
+>     "allocation": 10000,
+>     "strategy": {
+>         "type": "time_based",
+>         "duration_ms": 3600000
+>     }
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 201 Created
+> content-length: 151
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:35:27 GMT
+> ```
+> ```json
+> {
+>     "allocation": 10000,
+>     "created_at": 1788215727072,
+>     "key": "image-service",
+>     "strategy": {
+>         "duration_ms": 3600000,
+>         "type": "time_based"
+>     },
+>     "updated_at": 1788215727072
+> }
+> ```
+
+### Duplicate create rejected
+
+> Request:
+> ```sh
+> http POST http://127.0.0.1:7890/budgets/image-service --raw '{
+>     "allocation": 10000,
+>     "strategy": {
+>         "type": "time_based",
+>         "duration_ms": 7200000
+>     }
+> }
+> '
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 409 Conflict
+> content-length: 49
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:37:37 GMT
+> ```
+> ```json
+> {
+>     "error": "budget 'image-service' already exists"
+> }
+> ```
+
+### Replace an existing budget
+
+Also creates it if it doesn't exist.
+
+> Request:
+> ```sh
+> http PUT http://127.0.0.1:7890/budgets/image-service --raw '{
+>     "allocation": 10000,
+>     "strategy": {
+>         "type": "time_based",
+>         "duration_ms": 3600000
+>     }
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 200 OK
+> content-length: 151
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:40:00 GMT
+> ```
+> ```json
+> {
+>     "allocation": 10000,
+>     "created_at": 1788215727072,
+>     "key": "image-service",
+>     "strategy": {
+>         "duration_ms": 3600000,
+>         "type": "time_based"
+>     },
+>     "updated_at": 1788216000273
+> }
+> ```
+
+### Create a `while_in_flight` budget
+
+> Request:
+> ```sh
+> http PUT http://127.0.0.1:7890/budgets/schema-bot --raw '{
+>     "allocation": 10,
+>     "strategy": {
+>         "type": "while_in_flight"
+>     }
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 200 OK
+> content-length: 128
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:42:17 GMT
+> ```
+> ```json
+> {
+>     "allocation": 10,
+>     "created_at": 1788216137108,
+>     "key": "schema-bot",
+>     "strategy": {
+>         "type": "while_in_flight"
+>     },
+>     "updated_at": 1788216137108
+> }
+> ```
+
+### Enqueue a job against multiple budgets
+
+> Request:
+> ```sh
+> http POST http://127.0.0.1:7890/jobs --raw '{
+>     "type": "example",
+>     "queue": "example",
+>     "payload": {},
+>     "budgets": [
+>         {
+>             "key": "schema-bot",
+>             "cost": 2
+>         },
+>         {"key": "image-service"}
+>     ]
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 201 Created
+> content-length: 249
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:49:49 GMT
+> ```
+> ```json
+> {
+>     "attempts": 0,
+>     "budgets": [
+>         {
+>             "cost": 2,
+>             "key": "schema-bot"
+>         },
+>         {
+>             "cost": 1,
+>             "key": "image-service"
+>         }
+>     ],
+>     "duplicate": false,
+>     "folded": false,
+>     "id": "03gsa8rjaoxgqgnrsnlt7niqb",
+>     "priority": 32768,
+>     "queue": "example",
+>     "ready_at": 1788216589726,
+>     "status": "ready",
+>     "type": "example"
+> }
+> ```
+
+### Enqueue a job using `create_with`
+
+> Request:
+> ```sh
+> http POST http://127.0.0.1:7890/jobs --raw '{
+>     "type": "example",
+>     "queue": "example",
+>     "payload": {},
+>     "budgets": [
+>         {
+>             "key": "cpu-intensive",
+>             "create_with": {
+>                 "allocation": 100,
+>                 "strategy": {
+>                     "type": "while_in_flight"
+>                 }
+>             }
+>         }
+>     ]
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 201 Created
+> content-length: 219
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:53:01 GMT
+> ```
+> ```json
+> {
+>     "attempts": 0,
+>     "budgets": [
+>         {
+>             "cost": 1,
+>             "key": "cpu-intensive"
+>         }
+>     ],
+>     "duplicate": false,
+>     "folded": false,
+>     "id": "03gsa9e0vd59nf3zgysm1yxd0",
+>     "priority": 32768,
+>     "queue": "example",
+>     "ready_at": 1788216781592,
+>     "status": "ready",
+>     "type": "example"
+> }
+> ```
+
+### Patch an existing budget
+
+> Request:
+> ```sh
+> http PATCH http://127.0.0.1:7890/budgets/image-service --raw '{
+>     "strategy": {
+>         "burst": 50000
+>     }
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 200 OK
+> content-length: 165
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:44:08 GMT
+> ```
+> ```json
+> {
+>     "allocation": 10000,
+>     "created_at": 1788215727072,
+>     "key": "image-service",
+>     "strategy": {
+>         "burst": 50000,
+>         "duration_ms": 3600000,
+>         "type": "time_based"
+>     },
+>     "updated_at": 1788216248745
+> }
+> ```
+
+### List budgets
+
+> Request:
+> ```sh
+> http GET http://127.0.0.1:7890/budgets
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 200 OK
+> content-length: 308
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:45:42 GMT
+> ```
+> ```json
+> {
+>     "budgets": [
+>         {
+>             "allocation": 10000,
+>             "created_at": 1788215727072,
+>             "key": "image-service",
+>             "strategy": {
+>                 "burst": 50000,
+>                 "duration_ms": 3600000,
+>                 "type": "time_based"
+>             },
+>             "updated_at": 1788216248745
+>         },
+>         {
+>             "allocation": 10,
+>             "created_at": 1788216137108,
+>             "key": "schema-bot",
+>             "strategy": {
+>                 "type": "while_in_flight"
+>             },
+>             "updated_at": 1788216137108
+>         }
+>     ]
+> }
+> ```
+
+### Delete a budget
+
+> Request:
+> ```sh
+> http DELETE http://127.0.0.1:7890/budgets/schema-bot
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 204 No Content
+> date: Mon, 31 Aug 2026 22:46:57 GMT
+> ```
+
+### Delete a referenced budget rejected
+
+> Request:
+> ```sh
+> http DELETE http://127.0.0.1:7890/budgets/image-service
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 409 Conflict
+> content-length: 128
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:54:27 GMT
+> ```
+> ```json
+> {
+>     "error": "budget 'image-service' is referenced by 1 unfinished job. Delete them or wait for them to finish before deleting it."
+> }
+> ```
+
+### Reduce a budget below a job's cost rejected
+
+
+> Request:
+> ```sh
+> http PATCH http://127.0.0.1:7890/budgets/schema-bot --raw '{
+>     "allocation": 1
+> }'
+> ```
+
+> Response:
+> ```http
+> HTTP/1.1 422 Unprocessable Entity
+> content-length: 151
+> content-type: application/json
+> date: Mon, 31 Aug 2026 22:56:44 GMT
+> ```
+> ```json
+> {
+>     "error": "budget 'schema-bot' cannot allocate 1: 1 unfinished job draw up to 2 from it. Raise the allocation, delete them, or wait for them to drain."
+> }
+> ```


### PR DESCRIPTION
There's quite a bit to document here. This adds the mdBook documentation for budgets, covering how it works, the budget CRUD endpoints, cron endpoints, enqueueing and query and modifying budget bindings on jobs.

We'll release the server ahead of any new clients.