### PR TITLE
Update Croner Integration Code for Croner v4.

### DIFF
--- a/src/commands/serve/cron_scheduler.rs
+++ b/src/commands/serve/cron_scheduler.rs
@@ -129,13 +129,17 @@ async fn process_due_entries(
                 // Entry was paused, not due, or deleted — skip silently.
             }
             Err(e) => {
+                // Skip, don't abort. A failure here is specific to one
+                // entry — an expression an older version accepted, a
+                // timezone that no longer resolves — and returning
+                // would drop every remaining due entry in this pass,
+                // every tick, for as long as the bad entry is due.
                 tracing::error!(
                     group = %group,
                     entry = %entry_name,
                     %e,
-                    "failed to enqueue cron job"
+                    "failed to enqueue cron job, skipping entry"
                 );
-                return Err(e);
             }
         }
     }
@@ -238,6 +242,77 @@ mod tests {
             std::thread::sleep(Duration::from_millis(2));
             tokio::task::yield_now().await;
         }
+    }
+
+    /// An entry that cannot be promoted must not take the rest of the
+    /// pass down with it. The realistic cause is a stored expression an
+    /// older version accepted and this one does not; because that entry
+    /// stays due, aborting the pass would starve every other entry on
+    /// every tick rather than just the broken one.
+    #[tokio::test(start_paused = true)]
+    async fn failing_entry_does_not_block_the_rest_of_the_pass() {
+        let store = test_store();
+        let (clock, _) = test_clock();
+        let t = clock.load(Ordering::Relaxed);
+
+        store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![cron_entry("e1", "* * * * *"), cron_entry("e2", "* * * * *")],
+                },
+                t,
+            )
+            .await
+            .unwrap();
+
+        // Break whichever entry the scheduler will reach first, so the
+        // test fails if the error aborts the pass.
+        let due = store.next_due_cron_entries(u64::MAX);
+        assert_eq!(due.len(), 2);
+        let (_, group, first) = due[0].clone();
+        let (_, _, second) = due[1].clone();
+
+        store
+            .set_cron_expression_unvalidated(&group, &first, "not a cron expression")
+            .await
+            .unwrap();
+
+        let due_at = store
+            .get_cron_entry(&group, &second)
+            .await
+            .unwrap()
+            .unwrap()
+            .next_enqueue_at
+            .unwrap();
+        clock.store(due_at + 1, Ordering::Relaxed);
+
+        // The pass itself succeeds — the broken entry is logged and skipped.
+        process_due_entries(&store, &clock_fn(&clock))
+            .await
+            .unwrap();
+
+        let jobs = store
+            .list_jobs(ListJobsOptions::new().queues(["cron-q".to_string()].into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            jobs.jobs.len(),
+            1,
+            "the healthy entry should still have fired"
+        );
+
+        // The broken entry did not advance; the healthy one did.
+        let broken = store.get_cron_entry(&group, &first).await.unwrap().unwrap();
+        assert_eq!(broken.last_enqueue_at, None);
+        let healthy = store
+            .get_cron_entry(&group, &second)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(healthy.last_enqueue_at, Some(due_at + 1));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/store/cron/ops.rs
+++ b/src/store/cron/ops.rs
@@ -503,6 +503,47 @@ impl Store {
         .await?
     }
 
+    /// Rewrite a stored entry's expression, bypassing validation.
+    ///
+    /// Reproduces an entry written by an earlier version whose
+    /// expression this version no longer parses. That is the only way a
+    /// stored entry can fail on promotion, so it is the only way to
+    /// exercise the scheduler's skip-and-continue path.
+    #[cfg(test)]
+    pub(crate) async fn set_cron_expression_unvalidated(
+        &self,
+        group: &str,
+        entry_name: &str,
+        expression: &str,
+    ) -> Result<(), StoreError> {
+        let ks = self.ks.clone();
+        let group = group.to_string();
+        let entry_name = entry_name.to_string();
+        let expression = expression.to_string();
+
+        task::spawn_blocking(move || -> Result<(), StoreError> {
+            let entry_key = make_cron_entry_key(&group, &entry_name);
+
+            let mut entry: CronEntry = match ks.data.get(&entry_key)? {
+                Some(bytes) => rmp_serde::from_slice(&bytes)?,
+                None => {
+                    return Err(StoreError::InvalidOperation(format!(
+                        "no such cron entry: {group}/{entry_name}"
+                    )));
+                }
+            };
+
+            entry.expression = expression;
+
+            let mut tx = ks.write_tx();
+            tx.insert(&ks.data, &entry_key, &rmp_serde::to_vec_named(&entry)?);
+            ks.commit(tx, ks.default_commit_mode)?;
+
+            Ok(())
+        })
+        .await?
+    }
+
     /// Update a single cron entry's pause state.
     ///
     /// Returns the updated entry, or `None` if the group or entry does
@@ -1318,8 +1359,13 @@ fn cron_next_after(
     now_ms: u64,
     timezone: Option<&str>,
 ) -> Result<Option<u64>, StoreError> {
+    // `sloppy_ranges` keeps single-number step syntax (`0/15`, meaning
+    // "every 15 starting at 0") parsing. It is not OCPS-compliant, but
+    // it is what Quartz and its many descendants emit, and schedules
+    // written that way are already installed in the wild.
     let cron = croner::parser::CronParser::builder()
         .seconds(croner::parser::Seconds::Optional)
+        .sloppy_ranges(true)
         .build()
         .parse(expression)
         .map_err(|e| StoreError::InvalidOperation(format!("invalid cron expression: {e}")))?;
@@ -2440,6 +2486,43 @@ mod tests {
         let next = entries[0].next_enqueue_at.unwrap();
         assert!(next > now);
         assert!(next <= now + 30_000);
+    }
+
+    /// Single-number step syntax (`0/15`, "every 15 starting at 0") is
+    /// what Quartz and its descendants emit, and croner rejects it by
+    /// default from 4.0 onward. Schedules written that way are already
+    /// installed in the wild, so the parser opts into `sloppy_ranges`
+    /// and this pins that decision.
+    #[tokio::test]
+    async fn accepts_single_number_step_expressions() {
+        let store = test_store();
+        let now = CRON_NOW;
+
+        let (_, entries) = store
+            .replace_cron_group(
+                "default",
+                ReplaceCronGroupOptions {
+                    paused: None,
+                    timezone: None,
+                    entries: vec![
+                        cron_entry_opts("quarter-hourly", "0/15 * * * *", "q", "test"),
+                        cron_entry_opts("from-five", "5/5 * * * *", "q", "test"),
+                        cron_entry_opts("with-seconds", "10/30 * * * * *", "q", "test"),
+                    ],
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 3);
+        for entry in &entries {
+            assert!(
+                entry.next_enqueue_at.is_some_and(|next| next > now),
+                "{} did not schedule a future occurrence",
+                entry.name
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Croner v4 tightens the expression parsing so Quartz style expressions no longer work by default and become opt-in. In order to retain backwards compatibility, this opts in via `sloppy_ranges(true)`.