### PR TITLE
Bump Tokio and Cut Release 0.7.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.7.1
+
+- Fixed a cron scheduling pass aborting on its first failing entry
+  instead of skipping it. An entry that cannot be promoted stays due,
+  so a single broken entry starved every other due entry on every
+  subsequent tick, rather than just itself. Failures are now logged
+  per entry and the pass continues.
+
+- Updated **tokio** from 1.50 to 1.53.1. This is a candidate fix for a
+  crash observed in production on 0.6.1, where a long-lived
+  `/jobs/take` connection reconnected every ~262 seconds for days
+  before the server aborted inside tokio's intrusive linked list.
+  262.144s is exactly the wrap interval of level 2 of tokio's timer
+  wheel — the level a client's 30-second stream idle timeout occupies,
+  and the only point at which such a timer is physically moved between
+  wheel lists. 1.53 rewrote the timer entry's lazy-registration state and
+  fixed several timer cancellation and insertion races.
+
+  The link between the reconnect cadence and the abort is
+  circumstantial rather than proven, and neither symptom has been
+  reproduced outside production. If you have seen either, please give
+  this release a try.
+
+- Updated **croner** to 4.0, which corrects occurrence ordering across
+  daylight-saving transitions and backward searches through a DST gap.
+  Also updated **fjall** to 3.1.10, **rcgen** to 0.14.10 and
+  **tokio-rustls** to 0.26.5.
+
 ## 0.7.0
 
 - Added **budgets**, server-side concurrency control and rate limiting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "zizq"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zizq"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 license = "BUSL-1.1"
 

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ License text copyright (c) 2024 MariaDB plc, All Rights Reserved.
 Parameters
 
 Licensor:             Chris Corbyn <chris@zizq.io>
-Licensed Work:        Zizq 0.7.0
+Licensed Work:        Zizq 0.7.1
                       The Licensed Work is (c) 2026 Chris Corbyn
 Additional Use Grant: You may use the Licensed Work for non-commercial and
                       personal purposes. You may freely use short portions
@@ -12,7 +12,7 @@ Additional Use Grant: You may use the Licensed Work for non-commercial and
                       you give credit to the Licensor alongside such usages
                       within your project
 
-Change Date:          2030-08-18
+Change Date:          2030-09-09
 
 Change License:       Apache License, Version 2.0
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ with your system and extract it. You should put the executable somewhere on
 your PATH but you can also just run it from the current directory.
 
 ```shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.0/zizq-0.7.0-linux-x86_64.tar.gz
-tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.1/zizq-0.7.1-linux-x86_64.tar.gz
+tar -xvzf zizq-0.7.1-linux-x86_64.tar.gz
 ```
 
 ### Starting the server
@@ -61,7 +61,7 @@ starts the server. This is the default when no other subcommand is specified.
 
 ```shell
 $ ./zizq serve
-Zizq 0.7.0
+Zizq 0.7.1
 Listening on 127.0.0.1:8901 (admin)
 Listening on 127.0.0.1:7890 (primary)
 ```

--- a/docs/cli/src/installation.md
+++ b/docs/cli/src/installation.md
@@ -12,7 +12,7 @@ All Zizq releases and release notes are available on the
 to choose a release for your operating system and architecture.
 
 ``` shell
-curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.0/zizq-0.7.0-linux-x86_64.tar.gz
+curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.1/zizq-0.7.1-linux-x86_64.tar.gz
 ```
 
 Once you have downloaded a release it will need to be extracted.
@@ -23,7 +23,7 @@ Release binaries are gzipped and contain the version number. Extract the file
 from the archive and it should be executable.
 
 ```shell
-tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.7.1-linux-x86_64.tar.gz
 ./zizq --help
 ```
 
@@ -31,7 +31,7 @@ You may prefer to move the `zizq` executable to a standard system path, such as
 `/usr/bin/zizq` or `/usr/local/bin/zizq`.
 
 ``` shell
-tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
+tar -xvzf zizq-0.7.1-linux-x86_64.tar.gz
 sudo chown root: ./zizq && sudo mv ./zizq /usr/bin/zizq
 zizq --help
 ```

--- a/docs/getting-started/src/quick-start.md
+++ b/docs/getting-started/src/quick-start.md
@@ -17,7 +17,7 @@ does almost all of the work.
 > Download:
 >
 > ```bash
-> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.0/zizq-0.7.0-linux-x86_64.tar.gz
+> curl -sLO https://github.com/zizq-labs/zizq/releases/download/v0.7.1/zizq-0.7.1-linux-x86_64.tar.gz
 > ```
 
 ### 2. Extract it.
@@ -25,7 +25,7 @@ does almost all of the work.
 > Extract:
 >
 > ```bash
-> tar -xvzf zizq-0.7.0-linux-x86_64.tar.gz
+> tar -xvzf zizq-0.7.1-linux-x86_64.tar.gz
 > ```
 
 ### 3. Run it to start the server.
@@ -35,7 +35,7 @@ does almost all of the work.
 > ```bash
 > ./zizq serve
 > 
-> Zizq 0.7.0
+> Zizq 0.7.1
 > 2026-04-05T05:41:26.893318Z  INFO zizq::commands::serve: no license key provided, running in free tier
 > 2026-04-05T05:41:27.081150Z  INFO zizq::commands::serve: store opened root_dir=./zizq-root
 > 2026-04-05T05:41:27.081547Z  INFO zizq::commands::serve: admin API listening addr=127.0.0.1:8901 scheme=http


### PR DESCRIPTION
Bumping tokio as it looks like it potentially resolves a crash seen _once_ in production.